### PR TITLE
balance query fix and max button

### DIFF
--- a/src/lib/cards/Balance/Balance.svelte
+++ b/src/lib/cards/Balance/Balance.svelte
@@ -6,7 +6,7 @@
 	import Diff from './Diff.svelte';
 	import Date from './Date.svelte';
 	import { getAuth } from '$lib/auth/store';
-	import { accountBalanceStore, fetchAndStoreAccountBalances } from '$lib/balanceGraphData';
+	import { accountBalanceHistory, fetchAndStoreAccountBalances } from '$lib/balances';
 	let auth = $derived(getAuth()());
 	let did = $derived(auth.value?.did);
 	let loadingBalances = $state(true);
@@ -28,8 +28,8 @@
 	let hoveredIndex: number | undefined = $state();
 	const active = $derived(
 		hoveredPoint ??
-			($accountBalanceStore?.length > 0
-				? $accountBalanceStore[$accountBalanceStore.length - 1]
+			($accountBalanceHistory?.length > 0
+				? $accountBalanceHistory[$accountBalanceHistory.length - 1]
 				: null)
 	);
 	const balance = $derived(active?.value ?? 0);
@@ -70,11 +70,8 @@
 	let hourly = $derived(moment(selectedDateRange.end).diff(selectedDateRange.start, 'day') < 14);
 	let interval = $derived(hourly ? moment.duration(1, 'hour') : moment.duration(1, 'day'));
 	let filteredData = $derived(
-		$accountBalanceStore.filter((v) => {
-			return (
-				v.date.getTime() > selectedDateRange.start.getTime() &&
-				v.date.getTime() < selectedDateRange.end.getTime()
-			);
+		$accountBalanceHistory.filter((v) => {
+			return v.date.getTime() > selectedDateRange.start.getTime();
 		})
 	);
 	const date = $derived(hoveredPoint && active?.date);
@@ -100,6 +97,9 @@
 					loadingBalances = false;
 				});
 		}
+	});
+	$effect(() => {
+		console.log('last element', filteredData[filteredData.length - 1]);
 	});
 </script>
 

--- a/src/lib/cards/Balance/Date.svelte
+++ b/src/lib/cards/Balance/Date.svelte
@@ -13,8 +13,10 @@
 </script>
 
 {#if currDate}
-	{#if hourly}
-		{moment(currDate).format('MMMM D, YYYY, h A')}
+	{#if moment(currDate).minutes() !== 0}
+		Now
+	{:else if hourly}
+		{moment(currDate).format('MMMM D, YYYY, HH:mm')}
 	{:else}
 		{moment(currDate).format('MMMM D, YYYY')}
 	{/if}

--- a/src/lib/send/Amounts.svelte
+++ b/src/lib/send/Amounts.svelte
@@ -3,6 +3,7 @@
 	import { untrack } from 'svelte';
 	import { Coin, Network } from './sendOptions';
 	import { CoinAmount } from '$lib/currency/CoinAmount';
+	import { isValidBalanceField } from '$lib/balances';
 	let {
 		fromAmount = $bindable(''),
 		fromCoin: newFromCoin,
@@ -92,6 +93,9 @@
 		coin={fromCoin}
 		network={fromNetwork ?? Network.unknown}
 		label="From Amount:"
+		maxField={fromNetwork === Network.vsc && isValidBalanceField(fromCoin.value)
+			? fromCoin.value
+			: undefined}
 	/>
 
 	<Amount

--- a/src/lib/vscTransactions/hive/vscOperations/StakeHBDModal.svelte
+++ b/src/lib/vscTransactions/hive/vscOperations/StakeHBDModal.svelte
@@ -116,6 +116,7 @@
 				network={shouldDeposit ? Network.hiveMainnet : Network.vsc}
 				bind:originalAmount={amount}
 				required
+				maxField={type === 'stake' ? (shouldDeposit ? undefined : 'hbd') : 'hbd_savings'}
 			/>
 		</div>
 		{#if type === 'stake'}
@@ -126,7 +127,7 @@
 		{/if}
 		<PillButton disabled={!!status} styleType="invert" theme="primary" onclick={() => {}}
 			>{#if shouldDeposit}Deposit and{/if}
-			{#if type === 'stake'}Stake{:else}Unstake{/if}</PillButton
+			{#if type === 'stake'}Stake{:else}Initialize Unstake{/if}</PillButton
 		>
 		<span class="status">{status}</span>
 	</form>

--- a/src/routes/(authed)/witness-assistant/DepositModal.svelte
+++ b/src/routes/(authed)/witness-assistant/DepositModal.svelte
@@ -112,6 +112,7 @@
 				network={shouldDeposit ? Network.hiveMainnet : Network.vsc}
 				bind:originalAmount={amount}
 				required
+				maxField={shouldDeposit ? undefined : 'hive'}
 			/>
 		</div>
 		<label for="deposit-checkbox">

--- a/src/routes/(authed)/witness-assistant/WithdrawModal.svelte
+++ b/src/routes/(authed)/witness-assistant/WithdrawModal.svelte
@@ -18,14 +18,14 @@
 		nodeRunnerAccount = username;
 	});
 	const sendTransaction = async (amount: string, nodeRunnerAccount: string) => {
-		if (!username || !auth.value?.aioha) 
+		if (!username || !auth.value?.aioha)
 			return {
 				success: false,
 				error: 'Error: not authenticated.',
 				errorCode: 1
 			};
 		status = 'Awaiting transaction approval…';
-		if (Number(amount) == 0) 
+		if (Number(amount) == 0)
 			return {
 				success: false,
 				error: 'Error: cannot stake 0 HIVE.',
@@ -37,7 +37,7 @@
 				ops: [
 					{
 						data: {
-							amount: (new CoinAmount(amount, Coin.hive)).toAmountString(),
+							amount: new CoinAmount(amount, Coin.hive).toAmountString(),
 							asset: Coin.hive.unit.toLowerCase(),
 							from: username,
 							to: nodeRunnerAccount,
@@ -90,6 +90,7 @@
 				network={Network.vsc}
 				bind:originalAmount={amount}
 				required
+				maxField={'hive_consensus'}
 			/>
 		</div>
 		<PillButton disabled={!!status} styleType="invert" theme="primary" onclick={() => {}}


### PR DESCRIPTION
- Balance graph queries on the hour or at the start of the day
- displays most recent value as "now"

- max button
- balance display when relevant, also clickable and has the same function as max button
- displays balance for interactions where the "from Network" is vsc
    - shows for withdrawal and stake/unstake by themselves
    - doesn't show for deposit or stake/deposit combo
- removed dropdown for currency if there is only one option 