### PR TITLE
feat(swap): inject Altera referral fee on outbound mainnet swaps

### DIFF
--- a/src/lib/cards/QuickSwap.svelte
+++ b/src/lib/cards/QuickSwap.svelte
@@ -46,7 +46,10 @@
 	import {
 		getHiveSwapOp,
 		getBtcApproveOp,
-		SWAP_CONTRACT_ID
+		SWAP_CONTRACT_ID,
+		qualifiesForAlteraFee,
+		ALTERA_FEE_BENEFICIARY,
+		ALTERA_FEE_BPS
 	} from '$lib/magiTransactions/hive/vscOperations/swap';
 	import { getHiveDepositOp } from '$lib/magiTransactions/hive/vscOperations/deposit';
 	import { executeTx } from '$lib/magiTransactions/hive';
@@ -848,7 +851,7 @@
 					? Number($SendTxDetails.minAmountOut)
 					: undefined;
 				ops.push(
-					getHiveSwapOp(
+					await getHiveSwapOp(
 						username,
 						amount,
 						fromCoinDef as typeof Coin.hive | typeof Coin.hbd | typeof Coin.btc,
@@ -866,13 +869,25 @@
 			} else {
 				// EVM reown wallet path (no BTC reown since BTC is
 				// handled above).
-				const swapInstruction: Record<string, string> = {
+				const feeQualifies = await qualifiesForAlteraFee(
+					amount as CoinAmount<typeof Coin.hive | typeof Coin.hbd | typeof Coin.btc>,
+					toCoinDef as typeof Coin.hive | typeof Coin.hbd | typeof Coin.btc,
+					destinationChain || undefined
+				);
+				const storeMin = $SendTxDetails.minAmountOut;
+				// Contract validates min_amount_out AFTER altera deduction,
+				// so scale the store's pre-fee min down by the same bps.
+				const finalMin =
+					feeQualifies && storeMin
+						? String(Math.floor((Number(storeMin) * (10000 - ALTERA_FEE_BPS)) / 10000))
+						: (storeMin ?? '0');
+				const swapInstruction: Record<string, string | number> = {
 					type: 'swap',
 					version: '1.0.0',
 					asset_in: fromCoinDef.value.toUpperCase(),
 					asset_out: toCoinDef.value.toUpperCase(),
 					amount_in: String(amount.amount),
-					min_amount_out: $SendTxDetails.minAmountOut ?? '0',
+					min_amount_out: finalMin,
 					// Recipient is the user-entered target-chain address
 					// (already normalised into routerRecipient above). Only
 					// falls back to the Magi caller when the swap stays on
@@ -881,6 +896,10 @@
 				};
 				if (destinationChain) {
 					swapInstruction.destination_chain = destinationChain;
+				}
+				if (feeQualifies) {
+					swapInstruction.beneficiary = ALTERA_FEE_BENEFICIARY;
+					swapInstruction.ref_bps = ALTERA_FEE_BPS;
 				}
 				const swapPayload: CallContractTransaction = {
 					op: 'call',

--- a/src/lib/magiTransactions/hive/vscOperations/swap.ts
+++ b/src/lib/magiTransactions/hive/vscOperations/swap.ts
@@ -3,6 +3,44 @@ import { Coin } from '$lib/sendswap/utils/sendOptions';
 import { CoinAmount } from '$lib/currency/CoinAmount';
 import { vscNetworkId, DEX_ROUTER_CONTRACT_ID } from '../../../../client';
 import { BTC_MAPPING_CONTRACT_ID } from '$lib/constants';
+import { getCryptoPrices } from '$lib/sendswap/v4v/api-types/cryptoprices';
+
+export const ALTERA_FEE_BENEFICIARY = 'hive:altera.app';
+export const ALTERA_FEE_BPS = 25;
+export const ALTERA_FEE_USD_THRESHOLD = 0;
+
+/**
+ * Altera charges a UI usage fee on swaps that leave the Hive/Magi ecosystem
+ * to a non-HIVE, non-HBD mainnet target when the input value is at least
+ * $100 USD. Prices come from the same v4v feed the UI already uses.
+ */
+export async function qualifiesForAlteraFee(
+	amountIn: CoinAmount<typeof Coin.hive | typeof Coin.hbd | typeof Coin.btc>,
+	assetOut: typeof Coin.hive | typeof Coin.hbd | typeof Coin.btc,
+	destinationChain?: string
+): Promise<boolean> {
+	if (!destinationChain || destinationChain === 'MAGI') return false;
+	if (assetOut.value === Coin.hive.value || assetOut.value === Coin.hbd.value) return false;
+
+	const prices = await getCryptoPrices();
+	let usdPerUnit: number;
+	switch (amountIn.coin.value) {
+		case Coin.hive.value:
+			usdPerUnit = prices.hive.usd;
+			break;
+		case Coin.hbd.value:
+			usdPerUnit = prices.hive_dollar.usd;
+			break;
+		case Coin.btc.value:
+			usdPerUnit = prices.bitcoin.usd;
+			break;
+		default:
+			return false;
+	}
+	if (!Number.isFinite(usdPerUnit) || usdPerUnit <= 0) return false;
+	const usdValue = amountIn.toNumber() * usdPerUnit;
+	return usdValue >= ALTERA_FEE_USD_THRESHOLD;
+}
 
 /**
  * DEX Router — handles all swap types (HIVE/HBD, BTC/HBD, BTC/HIVE multi-hop).
@@ -50,7 +88,7 @@ export function getBtcApproveOp(
 	];
 }
 
-export function getHiveSwapOp(
+export async function getHiveSwapOp(
 	username: string,
 	amount: CoinAmount<SwapCoin>,
 	assetIn: SwapCoin,
@@ -58,21 +96,34 @@ export function getHiveSwapOp(
 	minAmountOut?: number,
 	destinationChain?: string,
 	destinationRecipient?: string
-): CustomJsonOperation {
+): Promise<CustomJsonOperation> {
 	const caller = `hive:${username}`;
 	const isNative = assetIn.value === Coin.hive.value || assetIn.value === Coin.hbd.value;
 
-	const payload: Record<string, string> = {
+	const feeQualifies = await qualifiesForAlteraFee(amount, assetOut, destinationChain);
+	// Contract validates min_amount_out AFTER the referral/altera deduction.
+	// Scale the caller's pre-fee min down by the same bps so slippage
+	// tolerance is measured against what the user actually receives.
+	const finalMinAmountOut =
+		feeQualifies && minAmountOut !== undefined
+			? Math.floor((minAmountOut * (10000 - ALTERA_FEE_BPS)) / 10000)
+			: minAmountOut;
+
+	const payload: Record<string, string | number> = {
 		type: 'swap',
 		version: '1.0.0',
 		asset_in: assetIn.value.toUpperCase(),
 		asset_out: assetOut.value.toUpperCase(),
 		amount_in: String(amount.amount),
-		min_amount_out: minAmountOut ? String(minAmountOut) : '0',
+		min_amount_out: finalMinAmountOut ? String(finalMinAmountOut) : '0',
 		recipient: destinationRecipient ?? caller
 	};
 	if (destinationChain) {
 		payload.destination_chain = destinationChain;
+	}
+	if (feeQualifies) {
+		payload.beneficiary = ALTERA_FEE_BENEFICIARY;
+		payload.ref_bps = ALTERA_FEE_BPS;
 	}
 	const payloadStr = JSON.stringify(payload);
 

--- a/src/lib/sendswap/stages/Complete.svelte
+++ b/src/lib/sendswap/stages/Complete.svelte
@@ -14,6 +14,10 @@
 	import { getUsernameFromAuth } from '$lib/getAccountName';
 	import { getHiveAssetName, getHbdAssetName } from '$lib/../client';
 	import { numberFormatLanguage } from '$lib/constants';
+	import {
+		ALTERA_FEE_BPS,
+		ALTERA_FEE_USD_THRESHOLD
+	} from '$lib/magiTransactions/hive/vscOperations/swap';
 
 	let timer = $state<PieTimer>();
 
@@ -81,12 +85,28 @@
 		return `${isNegative ? '-' : ''}${formatter.format(n)} ${unit}`;
 	}
 	let inUsd = $state('');
+	let grossInUsdNum = $state(0);
 	$effect(() => {
 		new CoinAmount($SendTxDetails.fromAmount, fromCoin)
 			.convertTo(Coin.usd, Network.lightning)
 			.then((amount) => {
 				inUsd = amount.toMinFigs();
+				grossInUsdNum = amount.toNumber();
 			});
+	});
+	const alteraFeeApplies = $derived(
+		!!$SendTxDetails.toNetwork &&
+			$SendTxDetails.toNetwork.value !== Network.magi.value &&
+			toCoin.value !== Coin.hive.value &&
+			toCoin.value !== Coin.hbd.value &&
+			grossInUsdNum >= ALTERA_FEE_USD_THRESHOLD
+	);
+	const alteraFeeAmount = $derived.by(() => {
+		if (!alteraFeeApplies) return undefined;
+		const out = new CoinAmount($SendTxDetails.toAmount, toCoin);
+		const feeSmallest = Math.floor((out.amount * ALTERA_FEE_BPS) / 10000);
+		if (feeSmallest <= 0) return undefined;
+		return new CoinAmount(feeSmallest, toCoin, true);
 	});
 	let today = moment().format('MMM D, YYYY');
 
@@ -161,6 +181,12 @@
 				</div>
 			{/if}
 		</div>
+		{#if alteraFeeAmount}
+			<div class="altera-fee">
+				<span class="sm-caption">Altera Fee ({(ALTERA_FEE_BPS / 100).toFixed(2)}%)</span>
+				<span class="content">{prettyWithDisplayUnit(alteraFeeAmount)}</span>
+			</div>
+		{/if}
 		<div class="date">
 			<span>Paid on {today}</span>
 		</div>
@@ -200,6 +226,13 @@
 		// font-weight: 400;
 		// color: var(--neutral-fg);
 		margin: 0;
+	}
+	.altera-fee {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 0.5rem 0 1rem;
+		color: var(--mid);
 	}
 	.date {
 		padding: 1.5rem 0 1rem;

--- a/src/lib/sendswap/stages/ReviewSwap.svelte
+++ b/src/lib/sendswap/stages/ReviewSwap.svelte
@@ -18,6 +18,10 @@
 		estimateBtcUnmapFee,
 		type BtcFeeEstimate
 	} from '$lib/magiTransactions/bitcoin/btcFeeEstimate';
+	import {
+		ALTERA_FEE_BPS,
+		ALTERA_FEE_USD_THRESHOLD
+	} from '$lib/magiTransactions/hive/vscOperations/swap';
 
 	const auth = $derived(getAuth()());
 	let {
@@ -272,6 +276,40 @@
 			feeInUsd = amount;
 		});
 	});
+
+	let grossInUsd = $state<CoinAmount<Coin>>();
+	$effect(() => {
+		new CoinAmount(effectiveFromAmount, fromCoin)
+			.convertTo(Coin.usd, Network.lightning)
+			.then((amt) => {
+				grossInUsd = amt;
+			});
+	});
+	const alteraFeeApplies = $derived(
+		!!$SendTxDetails.toNetwork &&
+			$SendTxDetails.toNetwork.value !== Network.magi.value &&
+			toCoin.value !== Coin.hive.value &&
+			toCoin.value !== Coin.hbd.value &&
+			!!grossInUsd &&
+			grossInUsd.toNumber() >= ALTERA_FEE_USD_THRESHOLD
+	);
+	const alteraFeeAmount = $derived.by(() => {
+		if (!alteraFeeApplies) return undefined;
+		const out = convertedToAmount ?? new CoinAmount(effectiveToAmount, toCoin);
+		const feeSmallest = Math.floor((out.amount * ALTERA_FEE_BPS) / 10000);
+		if (feeSmallest <= 0) return undefined;
+		return new CoinAmount(feeSmallest, toCoin, true);
+	});
+	let alteraFeeInUsd = $state<CoinAmount<Coin>>();
+	$effect(() => {
+		if (!alteraFeeAmount) {
+			alteraFeeInUsd = undefined;
+			return;
+		}
+		alteraFeeAmount.convertTo(Coin.usd, Network.lightning).then((amt) => {
+			alteraFeeInUsd = amt;
+		});
+	});
 	let today = moment().format('MMM D, YYYY');
 
 	const senderAddress = $derived(
@@ -399,8 +437,14 @@
 								>
 								<td class="content">
 									{#if $SendTxDetails.minAmountOut && $SendTxDetails.toCoin}
+										{@const minRaw = alteraFeeApplies
+											? Math.floor(
+													(Number($SendTxDetails.minAmountOut) *
+														(10000 - ALTERA_FEE_BPS)) /
+														10000
+												)
+											: Number($SendTxDetails.minAmountOut)}
 										{#if btcFeeEstimate}
-											{@const minRaw = Number($SendTxDetails.minAmountOut)}
 											Min. ~{prettyRangeWithDisplayUnit(
 												new CoinAmount(
 													Math.max(0, minRaw - btcFeeEstimate.maxSats),
@@ -414,12 +458,25 @@
 												)
 											)}
 										{:else}
-											Min. {prettyWithDisplayUnit(
-												new CoinAmount(Number($SendTxDetails.minAmountOut), toCoin, true)
-											)}
+											Min. {prettyWithDisplayUnit(new CoinAmount(minRaw, toCoin, true))}
 										{/if}
 									{:else}
 										—
+									{/if}
+								</td>
+							</tr>
+						{/if}
+						{#if alteraFeeAmount}
+							<tr>
+								<td class="icon"><Dot size="32" /></td>
+								<td class="sm-caption label"
+									>Altera Fee ({(ALTERA_FEE_BPS / 100).toFixed(2)}%)</td
+								>
+								<td class="content">
+									{prettyWithDisplayUnit(alteraFeeAmount)}
+									{#if alteraFeeInUsd}
+										<EqualApproximately size={16} />
+										{alteraFeeInUsd.toPrettyString()}
 									{/if}
 								</td>
 							</tr>

--- a/src/lib/sendswap/stages/ReviewSwap.svelte
+++ b/src/lib/sendswap/stages/ReviewSwap.svelte
@@ -134,21 +134,27 @@
 			return;
 		}
 		// Different coins: convert fromCoin → toCoin
-		new CoinAmount(entered, fromCoin)
-			.convertTo(toCoin, Network.lightning)
-			.then((converted) => {
-				// Only use if toAmount still not set
-				const current = $SendTxDetails.toAmount;
-				if (!current || current === '0') {
-					convertedToAmount = converted;
-				}
-			});
+		new CoinAmount(entered, fromCoin).convertTo(toCoin, Network.lightning).then((converted) => {
+			// Only use if toAmount still not set
+			const current = $SendTxDetails.toAmount;
+			if (!current || current === '0') {
+				convertedToAmount = converted;
+			}
+		});
 	});
 	const fromCoinDisplayLabel = $derived(
-		fromCoin.value === Coin.hive.value ? getHiveAssetName() : fromCoin.value === Coin.hbd.value ? getHbdAssetName() : fromCoin.label
+		fromCoin.value === Coin.hive.value
+			? getHiveAssetName()
+			: fromCoin.value === Coin.hbd.value
+				? getHbdAssetName()
+				: fromCoin.label
 	);
 	const toCoinDisplayLabel = $derived(
-		toCoin.value === Coin.hive.value ? getHiveAssetName() : toCoin.value === Coin.hbd.value ? getHbdAssetName() : toCoin.label
+		toCoin.value === Coin.hive.value
+			? getHiveAssetName()
+			: toCoin.value === Coin.hbd.value
+				? getHbdAssetName()
+				: toCoin.label
 	);
 	/** Format amount with display unit (TESTS/TBD) for hive/hbd, else use coin.unit */
 	function prettyWithDisplayUnit(amt: CoinAmount<Coin>): string {
@@ -167,11 +173,16 @@
 		return `${isNegative ? '-' : ''}${formatter.format(n)} ${unit}`;
 	}
 	/** Like toPrettyMinFigs but with display unit for hive/hbd */
-	function prettyMinFigsWithDisplayUnit(amt: CoinAmount<Coin>, figures?: number, decimals?: number): string {
+	function prettyMinFigsWithDisplayUnit(
+		amt: CoinAmount<Coin>,
+		figures?: number,
+		decimals?: number
+	): string {
 		const isNegative = amt.amount < 0;
 		const n = Math.abs(amt.amount) / 10 ** amt.coin.decimalPlaces;
 		const dec = decimals ?? amt.coin.decimalPlaces;
-		const minFigs = n < 1 ? Math.min(amt.coin.decimalPlaces, figures ?? dec + 1) : (figures ?? dec + 1);
+		const minFigs =
+			n < 1 ? Math.min(amt.coin.decimalPlaces, figures ?? dec + 1) : (figures ?? dec + 1);
 		const formatter = new Intl.NumberFormat(numberFormatLanguage, {
 			useGrouping: true,
 			minimumSignificantDigits: minFigs,
@@ -215,10 +226,7 @@
 		);
 	}
 	/** Render `low – high UNIT` using `prettyWithDisplayUnit`, unit shown once. */
-	function prettyRangeWithDisplayUnit(
-		low: CoinAmount<Coin>,
-		high: CoinAmount<Coin>
-	): string {
+	function prettyRangeWithDisplayUnit(low: CoinAmount<Coin>, high: CoinAmount<Coin>): string {
 		const highStr = prettyWithDisplayUnit(high);
 		const lowStr = prettyWithDisplayUnit(low);
 		const sp = lowStr.lastIndexOf(' ');
@@ -249,8 +257,7 @@
 			const feeIn = swapFee ? Number(swapFee) : 0;
 			const netIn = Math.max(0, grossIn - feeIn);
 			if (netIn > 0 && Number.isFinite(expected)) {
-				const ratePerUnitSmallestOut =
-					(expected * 10 ** fromCoin.decimalPlaces) / netIn;
+				const ratePerUnitSmallestOut = (expected * 10 ** fromCoin.decimalPlaces) / netIn;
 				fromInTo = new CoinAmount(Math.round(ratePerUnitSmallestOut), toCoin, true);
 				return;
 			}
@@ -319,221 +326,219 @@
 </script>
 
 {#snippet reviewContent()}
-<div class="stacked-cards">
-	<div class="line-positioner">
-		<Card>
-			<svg class="dashed-line">
-				<line
-					x1="1px"
-					x2="1px"
-					y1="15%"
-					y2="85%"
-					stroke="var(--dash-card-border)"
-					stroke-width="2"
-					stroke-dasharray="5,5"
-				/>
-			</svg>
-			<table>
-				<tbody>
-					{#if $SendTxDetails.fromCoin && $SendTxDetails.fromNetwork}
-						<tr>
-							<td class="icon">
-								<CoinNetworkIcon coin={fromCoin} network={$SendTxDetails.fromNetwork} size={32} />
-							</td>
-							<td class="sm-caption label"
-								>From {fromCoinDisplayLabel} on {$SendTxDetails.fromNetwork
-									?.label}{senderAddress ? ` (${senderAddress})` : ''}</td
-							>
-							<td class="content">{prettyWithDisplayUnit(total)}</td>
-						</tr>
-					{/if}
-					<tr>
-						<td class="icon"><Dot size="32" /></td>
-						<td class="sm-caption label">Fee</td>
-						<td class="content">
-							{#if $SendTxDetails.swapTotalFee && $SendTxDetails.fromCoin}
-								{prettyWithDisplayUnit(new CoinAmount(Number($SendTxDetails.swapTotalFee), fromCoin, true))}
-							{:else if $SendTxDetails.method?.value === TransferMethod.magiTransfer.value}
-								No fee
-							{:else if !$SendTxDetails.fee || !feeInUsd}
-								<div class="fee-loading"><WaveLoading /></div>
-							{:else}
-									{prettyWithDisplayUnit($SendTxDetails.fee)}
-								<EqualApproximately size={16} />
-								{feeInUsd.toPrettyString()}
-							{/if}
-						</td>
-					</tr>
-					<tr>
-						<td class="icon"><Dot size="32" /></td>
-						<td class="sm-caption label">Amount</td>
-						<td class="content">
-							{prettyWithDisplayUnit(netSwapFromAmountCa)}
-							<EqualApproximately size={16} />
-							{inUsd?.toPrettyString()}
-						</td>
-					</tr>
-					{#if $SendTxDetails.fromCoin?.coin !== $SendTxDetails.toCoin?.coin}
-						<tr>
-							<td class="icon"><Dot size="32" /></td>
-							<td class="sm-caption label">Market Rate</td>
-							<td class="content">
-								{prettyMinFigsWithDisplayUnit(new CoinAmount(1, fromCoin))}
-								<EqualApproximately size="16" />
-								{fromInTo ? prettyWithDisplayUnit(fromInTo) : ''}
-							</td>
-						</tr>
-					{/if}
-					{#if $SendTxDetails.toCoin && $SendTxDetails.toNetwork}
-						{#if isToBtcMainnet && btcFeeEstimate}
+	<div class="stacked-cards">
+		<div class="line-positioner">
+			<Card>
+				<svg class="dashed-line">
+					<line
+						x1="1px"
+						x2="1px"
+						y1="15%"
+						y2="85%"
+						stroke="var(--dash-card-border)"
+						stroke-width="2"
+						stroke-dasharray="5,5"
+					/>
+				</svg>
+				<table>
+					<tbody>
+						{#if $SendTxDetails.fromCoin && $SendTxDetails.fromNetwork}
 							<tr>
-								<td class="icon"><Dot size="32" /></td>
-								<td class="sm-caption label">BTC Network Fee</td>
-								<td class="content">
-									~{formatSats(btcFeeEstimate.minSats)} – {formatSats(
-										btcFeeEstimate.maxSats
-									)} sats
+								<td class="icon">
+									<CoinNetworkIcon coin={fromCoin} network={$SendTxDetails.fromNetwork} size={32} />
 								</td>
+								<td class="sm-caption label"
+									>From {fromCoinDisplayLabel} on {$SendTxDetails.fromNetwork?.label}{senderAddress
+										? ` (${senderAddress})`
+										: ''}</td
+								>
+								<td class="content">{prettyWithDisplayUnit(total)}</td>
 							</tr>
 						{/if}
 						<tr>
-							<td class="icon">
-								<CoinNetworkIcon coin={toCoin} network={$SendTxDetails.toNetwork} size={32} />
-							</td>
-							<td class="sm-caption label"
-								>To {toCoinDisplayLabel} on {$SendTxDetails.toNetwork
-									?.label}{receiverAddress ? ` (${receiverAddress})` : ''}</td
-							>
+							<td class="icon"><Dot size="32" /></td>
+							<td class="sm-caption label">Fee</td>
 							<td class="content">
-								{#if btcFeeEstimate}
-									{@const baseTo =
-										convertedToAmount ?? new CoinAmount(effectiveToAmount, toCoin)}
-									~{prettyRangeWithDisplayUnit(
-										new CoinAmount(
-											Math.max(0, baseTo.amount - btcFeeEstimate.maxSats),
-											toCoin,
-											true
-										),
-										new CoinAmount(
-											Math.max(0, baseTo.amount - btcFeeEstimate.minSats),
-											toCoin,
-											true
-										)
-									)}
-								{:else}
+								{#if $SendTxDetails.swapTotalFee && $SendTxDetails.fromCoin}
 									{prettyWithDisplayUnit(
-										convertedToAmount ?? new CoinAmount(effectiveToAmount, toCoin)
+										new CoinAmount(Number($SendTxDetails.swapTotalFee), fromCoin, true)
 									)}
+								{:else if $SendTxDetails.method?.value === TransferMethod.magiTransfer.value}
+									No fee
+								{:else if !$SendTxDetails.fee || !feeInUsd}
+									<div class="fee-loading"><WaveLoading /></div>
+								{:else}
+									{prettyWithDisplayUnit($SendTxDetails.fee)}
+									<EqualApproximately size={16} />
+									{feeInUsd.toPrettyString()}
 								{/if}
 							</td>
 						</tr>
-						{#if $SendTxDetails.slippageBps != null}
+						<tr>
+							<td class="icon"><Dot size="32" /></td>
+							<td class="sm-caption label">Amount</td>
+							<td class="content">
+								{prettyWithDisplayUnit(netSwapFromAmountCa)}
+								<EqualApproximately size={16} />
+								{inUsd?.toPrettyString()}
+							</td>
+						</tr>
+						{#if $SendTxDetails.fromCoin?.coin !== $SendTxDetails.toCoin?.coin}
 							<tr>
 								<td class="icon"><Dot size="32" /></td>
-								<td class="sm-caption label"
-									>Slippage ({($SendTxDetails.slippageBps / 100).toFixed(
-										$SendTxDetails.slippageBps % 100 === 0 ? 0 : 1
-									)}%)</td
-								>
+								<td class="sm-caption label">Market Rate</td>
 								<td class="content">
-									{#if $SendTxDetails.minAmountOut && $SendTxDetails.toCoin}
-										{@const minRaw = alteraFeeApplies
-											? Math.floor(
-													(Number($SendTxDetails.minAmountOut) *
-														(10000 - ALTERA_FEE_BPS)) /
-														10000
-												)
-											: Number($SendTxDetails.minAmountOut)}
-										{#if btcFeeEstimate}
-											Min. ~{prettyRangeWithDisplayUnit(
-												new CoinAmount(
-													Math.max(0, minRaw - btcFeeEstimate.maxSats),
-													toCoin,
-													true
-												),
-												new CoinAmount(
-													Math.max(0, minRaw - btcFeeEstimate.minSats),
-													toCoin,
-													true
-												)
-											)}
-										{:else}
-											Min. {prettyWithDisplayUnit(new CoinAmount(minRaw, toCoin, true))}
+									{prettyMinFigsWithDisplayUnit(new CoinAmount(1, fromCoin))}
+									<EqualApproximately size="16" />
+									{fromInTo ? prettyWithDisplayUnit(fromInTo) : ''}
+								</td>
+							</tr>
+						{/if}
+						{#if $SendTxDetails.toCoin && $SendTxDetails.toNetwork}
+							{@const rawTo = convertedToAmount ?? new CoinAmount(effectiveToAmount, toCoin)}
+							{@const netToAmount = Math.max(0, rawTo.amount - (alteraFeeAmount?.amount ?? 0))}
+							{#if isToBtcMainnet && btcFeeEstimate}
+								<tr>
+									<td class="icon"><Dot size="32" /></td>
+									<td class="sm-caption label">BTC Network Fee</td>
+									<td class="content">
+										~{formatSats(btcFeeEstimate.minSats)} – {formatSats(btcFeeEstimate.maxSats)} sats
+									</td>
+								</tr>
+							{/if}
+							{#if alteraFeeAmount}
+								<tr>
+									<td class="icon"><Dot size="32" /></td>
+									<td class="sm-caption label">Altera Fee ({(ALTERA_FEE_BPS / 100).toFixed(2)}%)</td
+									>
+									<td class="content">
+										{prettyWithDisplayUnit(alteraFeeAmount)}
+										{#if alteraFeeInUsd}
+											<EqualApproximately size={16} />
+											{alteraFeeInUsd.toPrettyString()}
 										{/if}
-									{:else}
-										—
-									{/if}
-								</td>
-							</tr>
-						{/if}
-						{#if alteraFeeAmount}
+									</td>
+								</tr>
+							{/if}
 							<tr>
-								<td class="icon"><Dot size="32" /></td>
+								<td class="icon">
+									<CoinNetworkIcon coin={toCoin} network={$SendTxDetails.toNetwork} size={32} />
+								</td>
 								<td class="sm-caption label"
-									>Altera Fee ({(ALTERA_FEE_BPS / 100).toFixed(2)}%)</td
+									>To {toCoinDisplayLabel} on {$SendTxDetails.toNetwork?.label}{receiverAddress
+										? ` (${receiverAddress})`
+										: ''}</td
 								>
 								<td class="content">
-									{prettyWithDisplayUnit(alteraFeeAmount)}
-									{#if alteraFeeInUsd}
-										<EqualApproximately size={16} />
-										{alteraFeeInUsd.toPrettyString()}
+									{#if btcFeeEstimate}
+										~{prettyRangeWithDisplayUnit(
+											new CoinAmount(
+												Math.max(0, netToAmount - btcFeeEstimate.maxSats),
+												toCoin,
+												true
+											),
+											new CoinAmount(
+												Math.max(0, netToAmount - btcFeeEstimate.minSats),
+												toCoin,
+												true
+											)
+										)}
+									{:else}
+										{prettyWithDisplayUnit(new CoinAmount(netToAmount, toCoin, true))}
 									{/if}
 								</td>
 							</tr>
+							{#if $SendTxDetails.slippageBps != null}
+								<tr>
+									<td class="icon"><Dot size="32" /></td>
+									<td class="sm-caption label"
+										>Slippage ({($SendTxDetails.slippageBps / 100).toFixed(
+											$SendTxDetails.slippageBps % 100 === 0 ? 0 : 1
+										)}%)</td
+									>
+									<td class="content">
+										{#if $SendTxDetails.minAmountOut && $SendTxDetails.toCoin}
+											{@const minRaw = alteraFeeApplies
+												? Math.floor(
+														(Number($SendTxDetails.minAmountOut) * (10000 - ALTERA_FEE_BPS)) / 10000
+													)
+												: Number($SendTxDetails.minAmountOut)}
+											{#if btcFeeEstimate}
+												Min. ~{prettyRangeWithDisplayUnit(
+													new CoinAmount(
+														Math.max(0, minRaw - btcFeeEstimate.maxSats),
+														toCoin,
+														true
+													),
+													new CoinAmount(Math.max(0, minRaw - btcFeeEstimate.minSats), toCoin, true)
+												)}
+											{:else}
+												Min. {prettyWithDisplayUnit(new CoinAmount(minRaw, toCoin, true))}
+											{/if}
+										{:else}
+											—
+										{/if}
+									</td>
+								</tr>
+							{/if}
 						{/if}
-					{/if}
-				</tbody>
-			</table>
+					</tbody>
+				</table>
+			</Card>
+		</div>
+		<Card>
+			<ul>
+				<li class="side-by-side time">
+					<span class="sm-caption label">Settlement Time</span>
+					<span class="content">{$SendTxDetails.method?.length}</span>
+				</li>
+				<li class="side-by-side date">
+					<span class="sm-caption label">Initiated On</span>
+					<span class="content">{today}</span>
+				</li>
+				{#if $SendTxDetails.memo}
+					<li class="side-by-side memo">
+						<span class="sm-caption label">Memo</span>
+						<span class="content">{$SendTxDetails.memo}</span>
+					</li>
+				{/if}
+			</ul>
 		</Card>
 	</div>
-	<Card>
-		<ul>
-			<li class="side-by-side time">
-				<span class="sm-caption label">Settlement Time</span>
-				<span class="content">{$SendTxDetails.method?.length}</span>
-			</li>
-			<li class="side-by-side date">
-				<span class="sm-caption label">Initiated On</span>
-				<span class="content">{today}</span>
-			</li>
-			{#if $SendTxDetails.memo}
-				<li class="side-by-side memo">
-					<span class="sm-caption label">Memo</span>
-					<span class="content">{$SendTxDetails.memo}</span>
-				</li>
-			{/if}
-		</ul>
-	</Card>
-</div>
 
-<TxStatus
-	{status}
-	{waiting}
-	abort={() => abort?.()}
-	showHiveWarning={auth.value?.provider === 'aioha'}
-/>
+	<TxStatus
+		{status}
+		{waiting}
+		abort={() => abort?.()}
+		showHiveWarning={auth.value?.provider === 'aioha'}
+	/>
 
-{#if popup}
-<div class="popup-buttons">
-	<PillButton onclick={() => previous?.()} theme="secondary" styleType="outline" disabled={waiting}>
-		Back
-	</PillButton>
-	<PillButton onclick={() => next?.()} theme="accent" styleType="invert" disabled={waiting}>
-		{waiting ? 'Waiting…' : 'Swap'}
-	</PillButton>
-</div>
-{/if}
+	{#if popup}
+		<div class="popup-buttons">
+			<PillButton
+				onclick={() => previous?.()}
+				theme="secondary"
+				styleType="outline"
+				disabled={waiting}
+			>
+				Back
+			</PillButton>
+			<PillButton onclick={() => next?.()} theme="accent" styleType="invert" disabled={waiting}>
+				{waiting ? 'Waiting…' : 'Swap'}
+			</PillButton>
+		</div>
+	{/if}
 {/snippet}
 
 {#if popup}
-<Dialog bind:open={dialogOpen} bind:toggle={dialogToggle}>
-	{#snippet title()}
-		Review Swap
-	{/snippet}
-	{#snippet content()}
-		{@render reviewContent()}
-	{/snippet}
-</Dialog>
+	<Dialog bind:open={dialogOpen} bind:toggle={dialogToggle}>
+		{#snippet title()}
+			Review Swap
+		{/snippet}
+		{#snippet content()}
+			{@render reviewContent()}
+		{/snippet}
+	</Dialog>
 {:else}
 	{@render reviewContent()}
 {/if}

--- a/src/lib/sendswap/utils/sendUtils.ts
+++ b/src/lib/sendswap/utils/sendUtils.ts
@@ -780,7 +780,7 @@ export async function send(
 					throw new Error('Missing recipient address for mainnet settlement');
 				}
 			}
-			sendOp = getHiveSwapOp(
+			sendOp = await getHiveSwapOp(
 				auth.value.username!,
 				fromCa,
 				fromCoin.coin as typeof Coin.hive | typeof Coin.hbd | typeof Coin.btc,


### PR DESCRIPTION
- Add 0.25% referral fee (25 bps) targeting hive:altera.app via the DEX router's existing ref_bps/beneficiary mechanism, applied in both the aioha and reown swap payload builders
- Only fires when target destination is a non-Magi mainnet AND the output asset is neither HIVE nor HBD (today this means BTC→Bitcoin mainnet; auto-extends to DASH/LTC/etc. once wired)
- USD threshold gate implemented via getCryptoPrices (currently 0 so the fee applies at any size; bump ALTERA_FEE_USD_THRESHOLD to re-enable the minimum)
- Scale min_amount_out down by the fee bps at payload build time — the DEX validates slippage AFTER referral deduction, so pre-fee mins would spuriously revert tight-slippage swaps
- Surface the deducted amount and the adjusted Min. in ReviewSwap, and add a compact Altera Fee line to the Complete receipt so users can see exactly what was taken