### PR TITLE
feat: dashboard polish, transaction table fixes, 404 page, live sHBD APR

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -15,5 +15,10 @@ export const handle: Handle = async ({ event, resolve }) => {
 		});
 	}
 
+	// Chrome DevTools probes this on every local dev server — ignore it silently.
+	if (event.url.pathname === '/.well-known/appspecific/com.chrome.devtools.json') {
+		return new Response(null, { status: 204 });
+	}
+
 	return resolve(event);
 };

--- a/src/lib/AccBalance.svelte
+++ b/src/lib/AccBalance.svelte
@@ -49,108 +49,88 @@
 <div class="balances-list">
 	<div class="balances-header">
 		<span class="balances-title">Balances</span>
-		<!-- <a href="/" class="see-all">See all</a> -->
 	</div>
 
 	<div class="balance-row">
 		<div class="row-icon hbd"><img src={Coin.hbd.icon} alt="" /></div>
 		<div class="row-info">
-			<span class="coin-name">{hbdAssetName}</span>
+			<div class="name-row">
+				<span class="coin-name">{hbdAssetName}</span>
+				<span class="row-amount">{formatWithUnit(new CoinAmount($accountBalance.bal.hbd, Coin.hbd, true), hbdAssetName)}</span>
+			</div>
 			<span class="coin-sub">Hive Backed Dollar</span>
 		</div>
-		<span class="row-amount"
-			>{formatWithUnit(new CoinAmount($accountBalance.bal.hbd, Coin.hbd, true), hbdAssetName)}</span
-		>
 	</div>
 
 	<div class="balance-row">
 		<div class="row-icon shbd"><img src={Coin.hbd.icon} alt="" /></div>
 		<div class="row-info">
-			<span class="coin-name">
-				s{hbdAssetName}
-				<span class="tooltip-inline"
-					><InfoToolip
-						>s{hbdAssetName} is {hbdAssetName} that remains transferable while earning 15% APR</InfoToolip
-					></span
-				>
-			</span>
+			<div class="name-row">
+				<span class="coin-name">
+					s{hbdAssetName}
+					<span class="tooltip-inline"><InfoToolip>s{hbdAssetName} is {hbdAssetName} that remains transferable while earning 15% APR</InfoToolip></span>
+				</span>
+				<span class="row-amount">{formatWithUnit(new CoinAmount($accountBalance.bal.hbd_savings, Coin.hbd, true), hbdAssetName)}</span>
+			</div>
 			<span class="coin-sub">Liquid Hive Dollar Savings</span>
 		</div>
-		<span class="row-amount"
-			>{formatWithUnit(
-				new CoinAmount($accountBalance.bal.hbd_savings, Coin.hbd, true),
-				hbdAssetName
-			)}</span
-		>
 	</div>
 
 	{#if $accountBalance.bal.pending_hbd_unstaking && $accountBalance.bal.pending_hbd_unstaking !== 0}
 		<div class="balance-row">
 			<div class="row-icon hbd"><img src={Coin.hbd.icon} alt="" /></div>
 			<div class="row-info">
-				<span class="coin-name">{hbdAssetName} Unstaking</span>
+				<div class="name-row">
+					<span class="coin-name">{hbdAssetName} Unstaking</span>
+					<span class="row-amount">{formatWithUnit(new CoinAmount($accountBalance.bal.pending_hbd_unstaking, Coin.hbd, true), hbdAssetName)}</span>
+				</div>
 			</div>
-			<span class="row-amount"
-				>{formatWithUnit(
-					new CoinAmount($accountBalance.bal.pending_hbd_unstaking, Coin.hbd, true),
-					hbdAssetName
-				)}</span
-			>
 		</div>
 	{/if}
 
 	<div class="balance-row">
 		<div class="row-icon hive"><img src={Coin.hive.icon} alt="" /></div>
 		<div class="row-info">
-			<span class="coin-name">{hiveAssetName}</span>
+			<div class="name-row">
+				<span class="coin-name">{hiveAssetName}</span>
+				<span class="row-amount">{formatWithUnit(new CoinAmount($accountBalance.bal.hive, Coin.hive, true), hiveAssetName)}</span>
+			</div>
 			<span class="coin-sub">Native Hive Token</span>
 		</div>
-		<span class="row-amount"
-			>{formatWithUnit(
-				new CoinAmount($accountBalance.bal.hive, Coin.hive, true),
-				hiveAssetName
-			)}</span
-		>
 	</div>
 
 	<div class="balance-row">
 		<div class="row-icon consensus"><img src={Coin.hive.icon} alt="" /></div>
 		<div class="row-info">
-			<span class="coin-name">{hiveAssetName} Consensus</span>
+			<div class="name-row">
+				<span class="coin-name">{hiveAssetName} Consensus</span>
+				<span class="row-amount">{formatWithUnit(new CoinAmount($accountBalance.bal.hive_consensus, Coin.hive, true), hiveAssetName)}</span>
+			</div>
 			<span class="coin-sub">Hive Consensus</span>
 		</div>
-		<span class="row-amount"
-			>{formatWithUnit(
-				new CoinAmount($accountBalance.bal.hive_consensus, Coin.hive, true),
-				hiveAssetName
-			)}</span
-		>
 	</div>
 
 	{#if $accountBalance.bal.consensus_unstaking !== 0}
 		<div class="balance-row">
 			<div class="row-icon hive"><img src={Coin.hive.icon} alt="" /></div>
 			<div class="row-info">
-				<span class="coin-name">{hiveAssetName} Unstaking</span>
+				<div class="name-row">
+					<span class="coin-name">{hiveAssetName} Unstaking</span>
+					<span class="row-amount">{formatWithUnit(new CoinAmount($accountBalance.bal.consensus_unstaking, Coin.hive, true), hiveAssetName)}</span>
+				</div>
 			</div>
-			<span class="row-amount"
-				>{formatWithUnit(
-					new CoinAmount($accountBalance.bal.consensus_unstaking, Coin.hive, true),
-					hiveAssetName
-				)}</span
-			>
 		</div>
 	{/if}
 
 	<div class="balance-row">
 		<div class="row-icon btc"><img src={Coin.btc.icon} alt="Bitcoin" /></div>
 		<div class="row-info">
-			<span class="coin-name">Bitcoin</span>
+			<div class="name-row">
+				<span class="coin-name">Bitcoin</span>
+				<span class="row-amount">{new CoinAmount($accountBalance.bal.btc, Coin.btc, true).toPrettyString()}</span>
+			</div>
 			<span class="coin-sub">Bitcoin Native Asset Mapping</span>
 		</div>
-		<span class="row-amount"
-			>{new CoinAmount($accountBalance.bal.btc, Coin.btc, true).toPrettyString()}</span
-		>
 	</div>
 </div>
 
@@ -170,15 +150,6 @@
 		font-size: 0.85rem;
 		font-weight: 600;
 		color: var(--dash-text-primary);
-	}
-	.see-all {
-		color: var(--dash-accent-purple);
-		font-size: 0.8rem;
-		font-weight: 500;
-		text-decoration: none;
-	}
-	.see-all:hover {
-		text-decoration: underline;
 	}
 
 	.balance-row {
@@ -214,6 +185,16 @@
 		flex: 1;
 		min-width: 0;
 	}
+
+	.name-row {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		flex-wrap: wrap;
+		gap: 0.125rem 0.5rem;
+		min-width: 0;
+	}
+
 	.coin-name {
 		font-size: 0.875rem;
 		font-weight: 600;
@@ -221,6 +202,7 @@
 		display: flex;
 		align-items: center;
 		gap: 0.25rem;
+		min-width: 0;
 	}
 	.coin-sub {
 		font-size: 0.75rem;
@@ -237,7 +219,6 @@
 		font-weight: 600;
 		color: var(--dash-text-primary);
 		white-space: nowrap;
-		margin-left: auto;
 		flex-shrink: 0;
 	}
 </style>

--- a/src/lib/AccBalance.svelte
+++ b/src/lib/AccBalance.svelte
@@ -8,6 +8,7 @@
 	import moment from 'moment';
 	import InfoToolip from './components/InfoTooltip.svelte';
 	import { numberFormatLanguage } from '$lib/constants';
+	import { sHbdAprStore } from '$lib/stores/aprStore';
 
 	type Props = {
 		did: string;
@@ -68,7 +69,7 @@
 			<div class="name-row">
 				<span class="coin-name">
 					s{hbdAssetName}
-					<span class="tooltip-inline"><InfoToolip>s{hbdAssetName} is {hbdAssetName} that remains transferable while earning 15% APR</InfoToolip></span>
+					<span class="tooltip-inline"><InfoToolip>s{hbdAssetName} is {hbdAssetName} that remains transferable while earning {$sHbdAprStore !== null ? `${$sHbdAprStore}%` : '~12%'} APR</InfoToolip></span>
 				</span>
 				<span class="row-amount">{formatWithUnit(new CoinAmount($accountBalance.bal.hbd_savings, Coin.hbd, true), hbdAssetName)}</span>
 			</div>

--- a/src/lib/cards/Balance/Balance.svelte
+++ b/src/lib/cards/Balance/Balance.svelte
@@ -117,7 +117,7 @@
 		display: block;
 		font-size: 0.85rem;
 		font-weight: 600;
-		color: var(--dash-text-muted);
+		color: var(--dash-text-primary);
 		margin-bottom: 0.5rem;
 	}
 
@@ -210,5 +210,17 @@
 		min-height: 0;
 		overflow: auto;
 		margin-top: 0.25rem;
+	}
+
+	@media (max-width: 480px) {
+		.dollars {
+			font-size: 1.75rem;
+		}
+		.balance-row {
+			margin-bottom: 1rem;
+		}
+		.action-buttons {
+			margin-bottom: 1.25rem;
+		}
 	}
 </style>

--- a/src/lib/cards/Balance/PortfolioValue.svelte
+++ b/src/lib/cards/Balance/PortfolioValue.svelte
@@ -187,4 +187,16 @@
 		--bg-accent: var(--dash-chart-line);
 		--bg: transparent;
 	}
+
+	@media (max-width: 600px) {
+		.header-row {
+			flex-wrap: wrap;
+			flex-direction: column;
+			align-items: flex-start;
+			gap: 0.5rem;
+		}
+		.date-select {
+			width: 100%;
+		}
+	}
 </style>

--- a/src/lib/cards/StakingEarnings.svelte
+++ b/src/lib/cards/StakingEarnings.svelte
@@ -1,11 +1,37 @@
 <script lang="ts">
+	import { CoinAmount } from '$lib/currency/CoinAmount';
 	import PillBtn from '$lib/PillButton.svelte';
+	import { sHbdAprStore } from '$lib/stores/aprStore';
+	import { accountBalance } from '$lib/stores/currentBalance';
+	import { Coin } from '$lib/sendswap/utils/sendOptions';
 
 	type Props = {
 		onStake: () => void;
 	};
 
 	let { onStake }: Props = $props();
+
+	// HBD savings balance in whole HBD (1 HBD ≈ $1 USD)
+	const hbdSavings = $derived(
+		$accountBalance.bal.hbd_savings / 10 ** Coin.hbd.decimalPlaces
+	);
+
+	const aprLabel = $derived($sHbdAprStore !== null ? `${$sHbdAprStore}%` : '—');
+
+	// Estimated earnings based on current balance × APR. HBD ≈ $1 so these
+	// double as approximate USD values. Shown as '—' while APR is loading or
+	// if the user has no sHBD balance.
+	const todayLabel = $derived.by(() => {
+		if ($sHbdAprStore === null || hbdSavings === 0) return '—';
+		const daily = (hbdSavings * ($sHbdAprStore / 100)) / 365;
+		return `$${daily.toFixed(3)}`;
+	});
+
+	const monthLabel = $derived.by(() => {
+		if ($sHbdAprStore === null || hbdSavings === 0) return '—';
+		const monthly = (hbdSavings * ($sHbdAprStore / 100)) / 12;
+		return `$${monthly.toFixed(2)}`;
+	});
 </script>
 
 <div class="staking-card dashboard-card">
@@ -28,19 +54,23 @@
 	<div class="staking-details">
 		<div class="staking-stat">
 			<span class="label">Today:</span>
-			<span class="value down">$0.18 <span class="arrow">&#9660;</span></span>
+			<span class="value">{todayLabel}</span>
 		</div>
 		<div class="staking-stat">
 			<span class="label">This month:</span>
-			<span class="value up">$7.42 <span class="arrow">&#9650;</span></span>
+			<span class="value">{monthLabel}</span>
 		</div>
 		<div class="staking-stat">
 			<span class="label">Earn APR:</span>
-			<span class="value">15%</span>
+			<span class="value">{aprLabel}</span>
+		</div>
+		<div class="staking-stat">
+			<span class="label">Currently Staked:</span>
+			<span class="value">{new CoinAmount($accountBalance.bal.hbd_savings, Coin.hbd, true)}</span>
 		</div>
 		<div class="staking-stat">
 			<span class="label">Next payout in:</span>
-			<span class="value">16h 30m</span>
+			<span class="value">—</span>
 		</div>
 	</div>
 </div>
@@ -100,18 +130,8 @@
 		font-size: 0.85rem;
 		white-space: nowrap;
 	}
-	.staking-stat .value.up {
-		color: var(--dash-accent-green);
-	}
-	.staking-stat .value.down {
-		color: var(--dash-accent-red);
-	}
-	.staking-stat .value .arrow {
-		font-size: 0.55rem;
-	}
 	.staking-action {
 		margin-left: auto;
 		flex-shrink: 0;
 	}
-
 </style>

--- a/src/lib/cards/StakingEarnings.svelte
+++ b/src/lib/cards/StakingEarnings.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-	import { CoinAmount } from '$lib/currency/CoinAmount';
 	import PillBtn from '$lib/PillButton.svelte';
-	import { Coin } from '$lib/sendswap/utils/sendOptions';
-	import { accountBalance } from '$lib/stores/currentBalance';
 
 	type Props = {
 		onStake: () => void;
@@ -15,38 +12,35 @@
 	<div class="staking-header">
 		<span class="status-dot"></span>
 		<h5>Staking earnings (sHBD)</h5>
-	</div>
-	<div class="staking-details">
-		<!-- <div class="staking-stat">
-			<span class="label">Today:</span>
-			<span class="value down">$0.18 <span class="arrow">&#9660;</span></span>
-		</div>
-		<div class="staking-stat">
-			<span class="label">This month:</span>
-			<span class="value up">$7.42 <span class="arrow">&#9650;</span></span>
-		</div> -->
-		<div class="staking-stat">
-			<span class="label">Earn APR:</span>
-			<span class="value">15%</span>
-		</div>
-		<div class="staking-stat">
-			<span class="label">Currently Staked:</span>
-			<span class="value">{new CoinAmount($accountBalance.bal.hbd_savings, Coin.hbd, true)}</span>
-		</div>
-		<!-- <div class="staking-stat">
-			<span class="label">Next payout in:</span>
-			<span class="value">16h 30m</span>
-		</div> -->
 		<div class="staking-action">
 			<PillBtn
 				theme="primary"
 				styleType="outline"
+				style="--height: 1.75rem; font-size: 0.75rem; padding: 0 0.6rem;"
 				onclick={() => {
 					onStake();
 				}}
 			>
 				Staking
 			</PillBtn>
+		</div>
+	</div>
+	<div class="staking-details">
+		<div class="staking-stat">
+			<span class="label">Today:</span>
+			<span class="value down">$0.18 <span class="arrow">&#9660;</span></span>
+		</div>
+		<div class="staking-stat">
+			<span class="label">This month:</span>
+			<span class="value up">$7.42 <span class="arrow">&#9650;</span></span>
+		</div>
+		<div class="staking-stat">
+			<span class="label">Earn APR:</span>
+			<span class="value">15%</span>
+		</div>
+		<div class="staking-stat">
+			<span class="label">Next payout in:</span>
+			<span class="value">16h 30m</span>
 		</div>
 	</div>
 </div>
@@ -66,6 +60,7 @@
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;
+		justify-content: space-between;
 	}
 	.status-dot {
 		width: 8px;
@@ -82,16 +77,16 @@
 	}
 	.staking-details {
 		display: flex;
-		flex-wrap: nowrap;
-		gap: 1rem;
-		align-items: center;
-		overflow-x: auto;
+		flex-wrap: wrap;
+		gap: 0.75rem 1.25rem;
+		align-items: flex-start;
 	}
 	.staking-stat {
 		display: flex;
 		flex-direction: column;
 		gap: 0.2rem;
-		flex-shrink: 0;
+		flex: 1 1 auto;
+		min-width: max-content;
 	}
 	.staking-stat .label {
 		color: var(--dash-text-muted);
@@ -116,5 +111,7 @@
 	}
 	.staking-action {
 		margin-left: auto;
+		flex-shrink: 0;
 	}
+
 </style>

--- a/src/lib/indexer/btcMappingQueries.ts
+++ b/src/lib/indexer/btcMappingQueries.ts
@@ -31,6 +31,21 @@ export interface BtcTransferEvent extends BtcMappingEventBase {
 	recipient: string; // recipient VSC DID
 }
 
+/**
+ * Returns true when Hasura errors indicate a schema-level issue (missing table or column)
+ * rather than a runtime failure. These are expected when the indexer build doesn't yet
+ * expose a particular table and should not be logged as errors.
+ */
+function isSchemaError(errors: Array<{ message: string }>): boolean {
+	return errors.some(
+		(e) =>
+			/field ['"]?\w+['"]? not found in type/i.test(e.message) ||
+			/no such field/i.test(e.message) ||
+			/column .* does not exist/i.test(e.message) ||
+			/relation .* does not exist/i.test(e.message)
+	);
+}
+
 /** Fetch a deposit (map) event by VSC transaction hash. */
 export async function fetchBtcDepositEvent(txHash: string): Promise<BtcDepositEvent | null> {
 	const query = `
@@ -46,7 +61,10 @@ export async function fetchBtcDepositEvent(txHash: string): Promise<BtcDepositEv
 			}
 		}
 	`;
-	const data = await hasuraQuery(query, { txHash });
+	const { data, errors } = await hasuraQueryRaw(query, { txHash });
+	if (errors && !isSchemaError(errors)) {
+		console.error('Hasura query error:', errors);
+	}
 	const rows = data?.btc_mapping_deposit_events as BtcDepositEvent[] | undefined;
 	return rows?.[0] ?? null;
 }
@@ -77,7 +95,11 @@ export async function fetchBtcUnmapEvent(txHash: string): Promise<BtcUnmapEvent 
 		result = await hasuraQueryRaw<UnmapResult>(buildQuery(false), { txHash });
 	}
 
-	if (result.errors) console.error('Hasura query error:', result.errors);
+	// Schema errors (table/column not present in this indexer build) → return null silently.
+	// Only log genuinely unexpected errors (non-schema failures).
+	if (result.errors && !isSchemaError(result.errors)) {
+		console.error('Hasura query error:', result.errors);
+	}
 	return result.data?.btc_mapping_unmap_events?.[0] ?? null;
 }
 
@@ -96,7 +118,11 @@ export async function fetchBtcTransferEvent(txHash: string): Promise<BtcTransfer
 			}
 		}
 	`;
-	const data = await hasuraQuery(query, { txHash });
+	const { data, errors } = await hasuraQueryRaw(query, { txHash });
+	// Schema errors → indexer doesn't have this table yet; return null silently.
+	if (errors && !isSchemaError(errors)) {
+		console.error('Hasura query error:', errors);
+	}
 	const rows = data?.btc_mapping_transfer_events as BtcTransferEvent[] | undefined;
 	return rows?.[0] ?? null;
 }

--- a/src/lib/stores/aprStore.ts
+++ b/src/lib/stores/aprStore.ts
@@ -1,0 +1,42 @@
+import { readable } from 'svelte/store';
+import { browser } from '$app/environment';
+import { DHive } from '$lib/magiTransactions/dhive';
+
+/**
+ * Fetch the current HBD savings interest rate from the Hive blockchain.
+ *
+ * `hbd_interest_rate` in dynamic global properties is stored in basis points
+ * (e.g. 1200 = 12%). We convert to a whole-number percentage integer.
+ *
+ * Falls back to 12 if the node is unreachable.
+ */
+async function fetchHbdApr(): Promise<number> {
+	try {
+		const props = await DHive.database.getDynamicGlobalProperties();
+		const bps = (props as unknown as { hbd_interest_rate?: number }).hbd_interest_rate;
+		if (typeof bps === 'number' && bps > 0) {
+			return Math.round(bps / 100);
+		}
+	} catch {
+		// Node unreachable — fall through
+	}
+	return 12;
+}
+
+// Lazy singleton — one fetch per page load, shared across all subscribers.
+let _cached: Promise<number> | null = null;
+
+/**
+ * Readable store that resolves to the current sHBD staking APR (whole-number
+ * percentage, e.g. 12). Starts as `null` while the fetch is in flight.
+ *
+ * Source: Hive blockchain `hbd_interest_rate` via dhive (same rate that Hive
+ * HBD savings pays — sHBD mirrors this yield).
+ */
+export const sHbdAprStore = readable<number | null>(null, (set) => {
+	if (!browser) return;
+	if (!_cached) {
+		_cached = fetchHbdApr();
+	}
+	_cached.then(set).catch(() => set(12));
+});

--- a/src/routes/(authed)/+page.svelte
+++ b/src/routes/(authed)/+page.svelte
@@ -178,9 +178,12 @@
 		opacity: 0.6;
 	}
 
-	@media (max-width: 1200px) {
+	@media (max-width: 1440px) {
 		.dashboard-wrapper {
 			flex-direction: column;
+		}
+		.dashboard-main {
+			width: 100%;
 		}
 		.dashboard-right {
 			width: 100%;
@@ -193,9 +196,25 @@
 		}
 	}
 
-	@media (max-width: 900px) {
+	@media (max-width: 1100px) {
 		.top-row {
 			grid-template-columns: 1fr;
+		}
+	}
+
+	@media (max-width: 600px) {
+		.dashboard-wrapper {
+			gap: 12px;
+		}
+		.dashboard-main {
+			gap: 12px;
+		}
+		.dashboard-right {
+			gap: 12px;
+		}
+		.card {
+			padding: 1rem;
+			border-radius: 20px;
 		}
 	}
 </style>

--- a/src/routes/(authed)/transactions/Table/StatusBadge.svelte
+++ b/src/routes/(authed)/transactions/Table/StatusBadge.svelte
@@ -24,7 +24,6 @@
 		border-radius: 0.5rem;
 		width: max-content;
 		display: inline-flex;
-		margin-right: 0.5rem;
 		height: 1.25rem;
 		align-items: center;
 	}

--- a/src/routes/(authed)/transactions/Table/Table.svelte
+++ b/src/routes/(authed)/transactions/Table/Table.svelte
@@ -52,6 +52,7 @@
 			if (action === 'unmap' || action === 'transfer' || action === 'transferFrom') {
 				return 'btc-vsc';
 			}
+			if (action === 'increaseAllowance') return null;
 			return 'contract';
 		}
 		return null;
@@ -169,9 +170,11 @@
 </script>
 
 <div class={['card', { small: size === 'small' }]}>
+	<div class="table-scroll">
 	<div class="header-row">
 		<div class="h h-date">Date</div>
 		<div class="h h-to-from">To/From</div>
+		<div class="h h-status">Status</div>
 		<div class="h h-amount">Amount</div>
 		<div class="h h-type">Type</div>
 	</div>
@@ -249,6 +252,7 @@
 						<tr class="skeleton-row blurred-skeleton">
 							<td><div class="skeleton-cell date"></div></td>
 							<td><div class="skeleton-cell to-from"></div></td>
+							<td><div class="skeleton-cell status"></div></td>
 							<td><div class="skeleton-cell amount"></div></td>
 							<td><div class="skeleton-cell type"></div></td>
 						</tr>
@@ -259,6 +263,7 @@
 						<tr class="skeleton-row">
 							<td><div class="skeleton-cell date"></div></td>
 							<td><div class="skeleton-cell to-from"></div></td>
+							<td><div class="skeleton-cell status"></div></td>
 							<td><div class="skeleton-cell amount"></div></td>
 							<td><div class="skeleton-cell type"></div></td>
 						</tr>
@@ -271,6 +276,7 @@
 				<div class="no-transactions-message">No transactions found</div>
 			</div>
 		{/if}
+	</div>
 	</div>
 </div>
 
@@ -287,9 +293,8 @@
 
 <style lang="scss">
 	.card {
-		display: grid;
-		grid-template-columns: auto minmax(0, 1fr) auto auto;
-		grid-template-rows: auto minmax(0, 1fr);
+		display: flex;
+		flex-direction: column;
 		width: 100%;
 		flex-grow: 1;
 		min-height: 0;
@@ -300,6 +305,23 @@
 		box-shadow: var(--dash-card-shadow);
 		padding: 1.25rem;
 		font-family: 'Nunito Sans', sans-serif;
+		/* overflow: clip preserves the border-radius visual clipping without
+		   blocking the child .table-scroll from showing its horizontal scrollbar. */
+		overflow: hidden; /* fallback for older browsers */
+		overflow: clip;
+	}
+	.table-scroll {
+		display: grid;
+		grid-template-columns:
+			minmax(5rem, 1fr)
+			minmax(12rem, 2fr)
+			minmax(8rem, 1fr)
+			minmax(min-content, 1fr)
+			minmax(min-content, 1fr);
+		grid-template-rows: auto minmax(0, 1fr);
+		flex: 1;
+		min-height: 0;
+		overflow-x: auto;
 	}
 	.header-row {
 		display: contents;
@@ -316,8 +338,10 @@
 	.h-to-from {
 		text-align: left;
 	}
-	.h-amount {
-		text-align: left;
+	.h-status,
+	.h-amount,
+	.h-type {
+		text-align: center;
 	}
 	.body-scroll {
 		grid-row: 2;
@@ -403,6 +427,7 @@
 		box-shadow: none;
 		background: transparent;
 		font-size: 0.8rem;
+		overflow: visible;
 	}
 	.card.small .h {
 		padding: 0.5rem 1rem 0.5rem 1.35rem;
@@ -428,8 +453,12 @@
 	}
 
 	@media (max-width: 600px) {
-		.card {
-			grid-template-columns: minmax(0, 1fr) auto auto;
+		.table-scroll {
+			grid-template-columns:
+				minmax(12rem, 2fr)
+				minmax(8rem, 1fr)
+				minmax(min-content, 1fr)
+				minmax(min-content, 1fr);
 		}
 		.h-date {
 			display: none;

--- a/src/routes/(authed)/transactions/Table/Table.svelte
+++ b/src/routes/(authed)/transactions/Table/Table.svelte
@@ -426,4 +426,16 @@
 			opacity: 0.5;
 		}
 	}
+
+	@media (max-width: 600px) {
+		.card {
+			grid-template-columns: minmax(0, 1fr) auto auto;
+		}
+		.h-date {
+			display: none;
+		}
+		.body-scroll :global(td:first-child) {
+			display: none;
+		}
+	}
 </style>

--- a/src/routes/(authed)/transactions/Table/tds/Amount.svelte
+++ b/src/routes/(authed)/transactions/Table/tds/Amount.svelte
@@ -3,8 +3,12 @@
 	import { Coin } from '$lib/sendswap/utils/sendOptions';
 	import { getHiveAssetName, getHbdAssetName } from '../../../../../client';
 
-	type Props = { amount: UnkCoinAmount; direction?: 'incoming' | 'outgoing' | 'swap' | 'contract' };
-	let { amount, direction = 'incoming' }: Props = $props();
+	type Props = {
+		amount: UnkCoinAmount;
+		direction?: 'incoming' | 'outgoing' | 'swap' | 'contract';
+		fromAmount?: UnkCoinAmount | null;
+	};
+	let { amount, direction = 'incoming', fromAmount = null }: Props = $props();
 
 	const displayUnit = $derived(
 		amount?.coin.value === Coin.hive.value
@@ -16,25 +20,26 @@
 </script>
 
 <td>
-	{#if direction === 'contract'}
-		<span class="sm-caption">Limit:</span>
-	{/if}
-	<span
-		class={[
-			'amount',
-			{
-				green: direction === 'incoming'
-			}
-		]}
-	>
-		{#if amount}
-			{(direction === 'outgoing' ? '-' : '') + amount.toPrettyAmountString()}
-		{:else}
-			invalid
+	{#if direction === 'swap' && fromAmount}
+		<span class="amount outgoing">{fromAmount.toPrettyAmountString()}</span>
+		<span class="token outgoing">{fromAmount.coin.unit}</span>
+		<span class="swap-arrow">→</span>
+		<span class="amount green">{amount.toPrettyAmountString()}</span>
+		<span class="token green">{displayUnit}</span>
+	{:else}
+		{#if direction === 'contract'}
+			<span class="sm-caption">Limit:</span>
 		{/if}
-	</span>
-	{#if amount}
-		<span class={['token', { green: direction === 'incoming' }]}>{displayUnit}</span>
+		<span class={['amount', { green: direction === 'incoming' }]}>
+			{#if amount}
+				{(direction === 'outgoing' ? '-' : '') + amount.toPrettyAmountString()}
+			{:else}
+				invalid
+			{/if}
+		</span>
+		{#if amount}
+			<span class={['token', { green: direction === 'incoming' }]}>{displayUnit}</span>
+		{/if}
 	{/if}
 </td>
 
@@ -58,6 +63,16 @@
 	}
 	td:has(.amount) {
 		padding-right: 0.5rem;
-		text-align: right;
+		justify-content: flex-end;
+		white-space: nowrap;
+		gap: 0.2rem;
+	}
+	.swap-arrow {
+		color: var(--dash-text-muted);
+		font-size: var(--text-sm);
+		margin: 0 0.1rem;
+	}
+	.outgoing {
+		color: var(--dash-text-secondary);
 	}
 </style>

--- a/src/routes/(authed)/transactions/Table/tds/ContractId.svelte
+++ b/src/routes/(authed)/transactions/Table/tds/ContractId.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import BasicCopy from '$lib/components/BasicCopy.svelte';
 	import { NotebookPen } from '@lucide/svelte';
-	import StatusBadge from '../StatusBadge.svelte';
 
-	const TRUNCATE_AT = 15;
+	const LONG_THRESHOLD = 16;
 
 	let isHovered = $state(false);
-	let { address, status }: { address: string; status?: string } = $props();
+	let { address }: { address: string } = $props();
 
-	const isLong = $derived(address.length > TRUNCATE_AT);
-	const displayText = $derived(isLong ? address.slice(0, TRUNCATE_AT) + '…' : address);
+	const isLong = $derived(address.length > LONG_THRESHOLD);
 </script>
 
 <td onmouseenter={() => (isHovered = true)} onmouseleave={() => (isHovered = false)}>
@@ -19,14 +17,9 @@
 		</span>
 		<span class="contract-address" class:small={isLong}>
 			<BasicCopy value={address} show={isHovered}>
-				{displayText}
+				{address}
 			</BasicCopy>
 		</span>
-		{#if status && status != 'CONFIRMED'}
-			<span class="status">
-				<StatusBadge {status} />
-			</span>
-		{/if}
 	</span>
 </td>
 
@@ -38,16 +31,13 @@
 	.to-from {
 		width: 100%;
 		display: grid;
-		grid-template: 'pfp toFrom memo status';
+		grid-template-areas: 'pfp toFrom';
+		grid-template-columns: auto minmax(0, 1fr);
 		justify-content: left;
 		column-gap: 0.25rem;
 		align-items: center;
 		align-content: center;
-	}
-	@media screen and (max-width: 450px) {
-		.to-from {
-			grid-template: 'pfp toFrom status';
-		}
+		overflow: hidden;
 	}
 	.pfp {
 		grid-area: pfp;
@@ -60,15 +50,32 @@
 		justify-content: center;
 		color: var(--dash-text-secondary);
 	}
-	.status {
-		grid-area: status;
-	}
 
 	.to-from > .contract-address,
 	.contract-address {
 		grid-area: toFrom;
+		display: flex;
+		align-items: center;
+		overflow: hidden;
+		min-width: 0;
 	}
 	.contract-address.small {
 		font-size: 0.75rem;
+	}
+	/* BasicCopy wrapper */
+	.contract-address :global(> span) {
+		min-width: 0;
+		overflow: hidden;
+		flex: 1;
+		display: flex;
+		align-items: center;
+	}
+	/* Text node inside BasicCopy */
+	.contract-address :global(> span > .content) {
+		display: block;
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		min-width: 0;
 	}
 </style>

--- a/src/routes/(authed)/transactions/Table/tds/Status.svelte
+++ b/src/routes/(authed)/transactions/Table/tds/Status.svelte
@@ -7,3 +7,9 @@
 <td>
 	<StatusBadge {status} />
 </td>
+
+<style>
+	td {
+		justify-content: center;
+	}
+</style>

--- a/src/routes/(authed)/transactions/Table/tds/ToFrom.svelte
+++ b/src/routes/(authed)/transactions/Table/tds/ToFrom.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import BasicCopy from '$lib/components/BasicCopy.svelte';
-	import { getAccountNameFromDid, getUsernameFromDid } from '$lib/getAccountName';
+	import { getUsernameFromDid } from '$lib/getAccountName';
 	import Avatar from '$lib/zag/Avatar.svelte';
-	import StatusBadge from '../StatusBadge.svelte';
 
 	let isHovered = $state(false);
 	let {
 		otherAccount,
-		memo,
-		status
-	}: { otherAccount: string; memo?: string | undefined; status?: string } = $props();
+		memo
+	}: { otherAccount: string; memo?: string | undefined } = $props();
 </script>
 
 <td onmouseenter={() => (isHovered = true)} onmouseleave={() => (isHovered = false)}>
@@ -19,17 +17,12 @@
 		</span>
 		<span class="toFrom">
 			<BasicCopy value={getUsernameFromDid(otherAccount)} show={isHovered}>
-				{getAccountNameFromDid(otherAccount)}
+				{getUsernameFromDid(otherAccount)}
 			</BasicCopy>
 		</span>
 		{#if memo}
 			<span class="memo">
 				"{memo}"
-			</span>
-		{/if}
-		{#if status && status != 'CONFIRMED'}
-			<span class="status">
-				<StatusBadge {status} />
 			</span>
 		{/if}
 	</span>
@@ -43,11 +36,13 @@
 	.to-from {
 		width: 100%;
 		display: grid;
-		grid-template: 'pfp toFrom memo status';
+		grid-template-areas: 'pfp toFrom memo';
+		grid-template-columns: auto minmax(0, 1fr) minmax(0, auto);
 		justify-content: left;
 		column-gap: 0.25rem;
 		align-items: center;
 		align-content: center;
+		overflow: hidden;
 		/* height: 4.5rem; */
 	}
 
@@ -56,9 +51,6 @@
 	}
 	.memo {
 		grid-area: memo;
-	}
-	.status {
-		grid-area: status;
 	}
 	.memo {
 		/* align-self: baseline; */
@@ -69,21 +61,41 @@
 		line-height: 1.5;
 	}
 
-	.to-from > .toFrom,
 	.to-from > .memo {
-		text-overflow: ellipsis;
 		overflow: hidden;
 		white-space: nowrap;
+		text-overflow: ellipsis;
 		display: flex;
 		align-items: center;
 		height: max-content;
 	}
 	.toFrom {
 		grid-area: toFrom;
+		display: flex;
+		align-items: center;
+		overflow: hidden;
+		min-width: 0;
+	}
+	/* BasicCopy wrapper — allow it to shrink and fill available space */
+	.toFrom :global(> span) {
+		min-width: 0;
+		overflow: hidden;
+		flex: 1;
+		display: flex;
+		align-items: center;
+	}
+	/* The actual text node inside BasicCopy — this is where ellipsis must live */
+	.toFrom :global(> span > .content) {
+		display: block;
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		min-width: 0;
 	}
 	@media screen and (max-width: 450px) {
 		.to-from {
-			grid-template: 'pfp toFrom status';
+			grid-template-areas: 'pfp toFrom';
+			grid-template-columns: auto minmax(0, 1fr);
 		}
 		.memo {
 			display: none !important;

--- a/src/routes/(authed)/transactions/Table/tds/Type.svelte
+++ b/src/routes/(authed)/transactions/Table/tds/Type.svelte
@@ -2,7 +2,7 @@
 	let { direction, t }: { direction: 'incoming' | 'outgoing' | 'swap' | 'contract'; t: string } = $props();
 </script>
 
-<td>
+<td class="type-cell">
 	<span class={['badge', direction === 'incoming'
 			? 'deposit'
 			: direction === 'swap'
@@ -19,6 +19,9 @@
 </td>
 
 <style>
+	.type-cell {
+		justify-content: center;
+	}
 	.badge {
 		display: inline-block;
 		padding: 0.2rem 0.6rem;
@@ -28,6 +31,7 @@
 		text-transform: uppercase;
 		background: rgba(255, 255, 255, 0.1);
 		color: var(--dash-text-primary);
+		white-space: nowrap;
 	}
 	.badge.withdraw {
 		background: var(--dash-badge-withdraw-bg);

--- a/src/routes/(authed)/transactions/Table/tr/BtcDepositTr.svelte
+++ b/src/routes/(authed)/transactions/Table/tr/BtcDepositTr.svelte
@@ -10,6 +10,7 @@
 	import { Coin, Network } from '$lib/sendswap/utils/sendOptions';
 	import { satsToBtc } from '$lib/sendswap/utils/units';
 	import ToFrom from '../tds/ToFrom.svelte';
+	import Status from '../tds/Status.svelte';
 	import StatusView from './StatusView.svelte';
 	import { BTC_MAPPING_CONTRACT_ID, getVscExplorerTxUrl } from '$lib/constants';
 
@@ -98,6 +99,7 @@
 >
 	<td class="date">{moment(anchorTs).format('MMM DD')}</td>
 	<ToFrom otherAccount={event.sender} />
+	<Status status="CONFIRMED" />
 	<Amount amount={displayAmount} direction="incoming" />
 	<Type direction="incoming" t="deposit" />
 </tr>

--- a/src/routes/(authed)/transactions/Table/tr/BtcMappingTr.svelte
+++ b/src/routes/(authed)/transactions/Table/tr/BtcMappingTr.svelte
@@ -15,6 +15,7 @@
 	import { Coin, Network } from '$lib/sendswap/utils/sendOptions';
 	import { satsToBtc } from '$lib/sendswap/utils/units';
 	import ToFrom from '../tds/ToFrom.svelte';
+	import Status from '../tds/Status.svelte';
 	import { getAuth } from '$lib/auth/store';
 	import StatusView from './StatusView.svelte';
 	import {
@@ -36,7 +37,7 @@
 	let fromAccount = $state('');
 	let toAccount = $state('');
 
-	const did = $derived(getAuth()().value!.did);
+	const did = $derived(getAuth()().value?.did ?? '');
 	const { anchr_height: block_height } = $derived(tx);
 
 	const contractInfo = $derived.by(() => {
@@ -60,10 +61,21 @@
 		};
 	});
 
-	// Fallback payload parsed from op.data — used while the indexer query is in flight.
+	// Fallback payload parsed from op.data — used while the indexer query is in flight
+	// and as a permanent fallback for internal VSC transfers that have no indexer event.
+	//
+	// Two payload shapes exist:
+	//   Plain JSON string  → op.data.payload = '{"amount":"432","to":"hive:v4vapp-test"}'
+	//   Legacy base64 obj  → op.data.payload = { Data: "<base64>" }
 	const payloadData = $derived.by(() => {
 		try {
-			const payloadDataBase64 = op.data?.payload?.Data;
+			const raw = op.data?.payload;
+			// Most common: plain JSON string (all new call/transfer and call/unmap ops)
+			if (typeof raw === 'string') {
+				return JSON.parse(raw) as { amount?: string; to?: string } | null;
+			}
+			// Legacy: payload is an object with a base64-encoded Data field
+			const payloadDataBase64 = raw?.Data;
 			if (!payloadDataBase64 || typeof payloadDataBase64 !== 'string') return null;
 			let decoded = atob(payloadDataBase64);
 			if (!decoded || decoded.trim() === '') return null;
@@ -101,14 +113,29 @@
 					fromAccount = result.event.sender || did;
 					toAccount = result.event.recipient || 'Unknown';
 				}
+			} else {
+				// No indexer entry — internal VSC transfers (call/transfer) never produce
+				// an on-chain BTC event so the indexer will always return null for them.
+				// Fall back to what we can read directly from the payload.
+				fromAccount = did;
+				toAccount = payloadData?.to ?? 'Unknown';
 			}
 		} catch (e) {
 			console.error('Failed to load BTC mapping indexer data', e);
+			fromAccount = did;
+			toAccount = payloadData?.to ?? 'Unknown';
 		}
 		loaded = true;
 	}
 
-	loadIndexerData();
+	// Run after auth resolves so `did` is populated for the fromAccount fallback.
+	// Re-runs if auth changes (e.g. wallet switch), resetting loaded so the drawer
+	// shows "Loading details..." rather than stale data from the previous account.
+	$effect(() => {
+		if (!did) return; // wait for auth to settle
+		loaded = false;
+		loadIndexerData();
+	});
 
 	// Amount: prefer indexer, fall back to op.data payload while loading.
 	// For unmap: use `deducted` (total cost to user). For transfer: use `amount`.
@@ -266,7 +293,8 @@
 	class="clickable-row"
 >
 	<td class="date">{moment(getTimestamp(tx)).format('MMM DD')}</td>
-	<ToFrom {otherAccount} status={tx.status} />
+	<ToFrom {otherAccount} />
+	<Status status={tx.status} />
 	<Amount amount={displayAmount} direction={contractInfo.direction} />
 	<Type direction={contractInfo.direction} t={contractInfo.displayType} />
 </tr>

--- a/src/routes/(authed)/transactions/Table/tr/ContractTr.svelte
+++ b/src/routes/(authed)/transactions/Table/tr/ContractTr.svelte
@@ -10,6 +10,7 @@
 	import { ExternalLink } from '@lucide/svelte';
 	import Clipboard from '$lib/zag/Clipboard.svelte';
 	import Amount from '../tds/Amount.svelte';
+	import Status from '../tds/Status.svelte';
 	import { CoinAmount } from '$lib/currency/CoinAmount';
 	import { Coin, Network } from '$lib/sendswap/utils/sendOptions';
 	import ContractId from '../tds/ContractId.svelte';
@@ -31,36 +32,80 @@
 		}
 	}
 
-	const amt: string = $derived.by(() => {
-		const intents = op.data.intents;
-		if (!intents) return '0';
-		return intents[0]?.args?.limit ?? '0';
+	// Parse the swap payload from call/execute ops.
+	// Two formats exist:
+	//   New router (Altera):  { type:"swap", asset_in, asset_out, amount_in, min_amount_out }
+	//   Old pool (legacy):    { type:"deposit", asset0, asset1, amount0, amount1 }
+	// Both are normalised to { asset0, amount0, asset1, amount1 } for display.
+	const swapPayload = $derived.by(() => {
+		try {
+			const parsed = JSON.parse(op.data.payload ?? '');
+			// New router format
+			if (
+				parsed?.type === 'swap' &&
+				parsed?.asset_in &&
+				parsed?.asset_out &&
+				parsed?.amount_in != null
+			) {
+				return {
+					asset0: String(parsed.asset_in).toLowerCase(),
+					amount0: String(parsed.amount_in),
+					asset1: String(parsed.asset_out).toLowerCase(),
+					// min_amount_out is a floor; fall back to '0' if absent
+					amount1: String(parsed.min_amount_out ?? '0')
+				};
+			}
+			// Old pool format
+			if (parsed?.asset0 && parsed?.asset1 && parsed?.amount0 != null && parsed?.amount1 != null) {
+				return parsed as { asset0: string; amount0: string; asset1: string; amount1: string };
+			}
+		} catch {}
+		return null;
 	});
-	const coinVal: string = $derived.by(() => {
-		const intents = op.data.intents;
-		if (!intents || intents.length === 0) return Coin.hive.value;
-		return intents[0]?.args?.token ?? Coin.hive.value;
-	});
-	const amount = $derived(
-		new CoinAmount(amt, Coin[coinVal.split('_')[0] as keyof typeof Coin] || Coin.hive, true)
+
+	const isSwap = $derived(op.data.action === 'execute' && swapPayload !== null);
+
+	// For swaps: fromAmount = what user sends (asset0), amount = what user receives (asset1).
+	// For other contract calls: amount comes from intents limit.
+	const fromAmount = $derived(
+		isSwap && swapPayload
+			? new CoinAmount(
+					swapPayload.amount0,
+					Coin[swapPayload.asset0.split('_')[0] as keyof typeof Coin] || Coin.unk,
+					true
+				)
+			: null
 	);
+	const amount = $derived.by(() => {
+		if (isSwap && swapPayload) {
+			return new CoinAmount(
+				swapPayload.amount1,
+				Coin[swapPayload.asset1.split('_')[0] as keyof typeof Coin] || Coin.unk,
+				true
+			);
+		}
+		const intents = op.data.intents;
+		const amt = intents?.[0]?.args?.limit ?? '0';
+		const coinVal = intents?.[0]?.args?.token ?? Coin.hive.value;
+		return new CoinAmount(amt, Coin[coinVal.split('_')[0] as keyof typeof Coin] || Coin.hive, true);
+	});
+
 	let inUsd = $state('');
 	$effect(() => {
-		amount.convertTo(Coin.usd, Network.lightning).then((amount) => {
-			inUsd = amount.toAmountString();
+		amount.convertTo(Coin.usd, Network.lightning).then((a) => {
+			inUsd = a.toAmountString();
 		});
 	});
 
 	const displayType: string = $derived.by(() => {
+		if (isSwap) return 'swap';
 		try {
 			const payloadStr = op.data.payload;
 			if (typeof payloadStr === 'string') {
 				const parsed = JSON.parse(payloadStr);
 				if (parsed?.type) return parsed.type.replace(/_/g, ' ');
 			}
-		} catch {
-			// ignore parse errors
-		}
+		} catch {}
 		return op.data.action ?? op.type ?? 'call';
 	});
 </script>
@@ -73,9 +118,10 @@
 	class="clickable-row"
 >
 	<td class="date">{moment(getTimestamp(tx)).format('MMM DD')}</td>
-	<ContractId address={op.data.contract_id ?? ''} status={tx.status} />
-	<Amount {amount} direction={'contract'} />
-	<Type direction="contract" t={displayType} />
+	<ContractId address={op.data.contract_id ?? ''} />
+	<Status status={tx.status} />
+	<Amount {amount} {fromAmount} direction={isSwap ? 'swap' : 'contract'} />
+	<Type direction={isSwap ? 'swap' : 'contract'} t={displayType} />
 </tr>
 
 {#snippet contractRowContent()}
@@ -86,8 +132,13 @@
 	</h2>
 	<div class="sections">
 		<div class="amount section">
-			<h3>Limit</h3>
-			{amount.toPrettyString()}
+			{#if isSwap && fromAmount}
+				<h3>Swap</h3>
+				{fromAmount.toPrettyString()} → {amount.toPrettyString()}
+			{:else}
+				<h3>Limit</h3>
+				{amount.toPrettyString()}
+			{/if}
 			<span class="approx-usd">
 				Approx. ${inUsd} USD
 			</span>

--- a/src/routes/(authed)/transactions/Table/tr/Tr.svelte
+++ b/src/routes/(authed)/transactions/Table/tr/Tr.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import ToFrom from '../tds/ToFrom.svelte';
+	import Status from '../tds/Status.svelte';
 	import Amount from '../tds/Amount.svelte';
 	import Type from '../tds/Type.svelte';
 	import { ExternalLink, X } from '@lucide/svelte';
@@ -28,7 +29,7 @@
 		onRowClick: (op: [string, number], content: () => ReturnType<Snippet>) => void;
 	};
 	let { tx, op, ledgerIndex, onRowClick }: Props = $props();
-	const did = $derived(getAuth()().value!.did);
+	const did = $derived(getAuth()().value?.did ?? '');
 	const {
 		ledger,
 		anchr_height: block_height,
@@ -197,7 +198,8 @@
 	class="clickable-row"
 >
 	<td class="date">{moment(timestamp).format('MMM DD')}</td>
-	<ToFrom {otherAccount} memo={memoNoId?.get('msg') ?? undefined} {status} />
+	<ToFrom {otherAccount} memo={memoNoId?.get('msg') ?? undefined} />
+	<Status {status} />
 	<Amount {amount} {direction} />
 	<Type {direction} {t} />
 </tr>
@@ -240,7 +242,7 @@
 				>
 				{#if to.slice(0, 5) === 'hive:' && from.slice(0, 5) === 'hive:'}
 					<a
-						href={'https://www.hiveblockexplorer.com/tx/' + tx.id}
+						href={'https://hivehub.dev/tx/' + tx.id}
 						target="_blank"
 						rel="noreferrer"
 					>

--- a/src/routes/(authed)/transactions/mock/+page.svelte
+++ b/src/routes/(authed)/transactions/mock/+page.svelte
@@ -1,0 +1,202 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import Table from '../Table/Table.svelte';
+	import { magiTxsStore, btcDepositStore } from '$lib/stores/txStores';
+	import type { TransactionInter } from '$lib/stores/txStores';
+	import type { BtcDepositEvent } from '$lib/indexer/btcMappingQueries';
+	import {
+		sampleTransfer,
+		sampleDeposit,
+		sampleWithdraw,
+		sampleStakeHbd,
+		sampleUnstakeHbd,
+		sampleConsensusStake,
+		sampleConsensusUnstake,
+		sampleSwapNewHiveToBtc,
+		sampleSwapNewHbdToHive,
+		sampleSwapNewBtcToHbd,
+		sampleSwapOld,
+		sampleAddLiquidity,
+		sampleRemoveLiquidity,
+		sampleBtcTransferToHive,
+		sampleBtcTransferToEvm,
+		sampleBtcUnmap,
+		sampleBtcDepositEvent,
+		sampleFailed
+	} from '../mockUp';
+
+	// Lift raw mock objects into the full TransactionInter shape that the table expects.
+	// Required extra fields: isPending, anchr_height, first_seen, output.
+	// anchr_ts may already be present; if not we supply a fallback.
+	function toTx(raw: Record<string, unknown>, fallbackTs = '2026-01-01T00:00:00'): TransactionInter {
+		return {
+			isPending: false,
+			anchr_height: 0,
+			first_seen: ((raw.anchr_ts as string | undefined) ?? fallbackTs) + 'Z',
+			output: null,
+			ledger: null,
+			...raw
+		} as unknown as TransactionInter;
+	}
+
+	// All VSC mock transactions in the order they should appear in the table.
+	const mockVscTxs: TransactionInter[] = [
+		toTx(sampleTransfer),
+		toTx(sampleDeposit),
+		toTx(sampleWithdraw),
+		toTx(sampleStakeHbd),
+		toTx(sampleUnstakeHbd, '2026-01-05T10:00:00'),
+		toTx(sampleConsensusStake, '2026-01-04T10:00:00'),
+		toTx(sampleConsensusUnstake, '2026-01-03T10:00:00'),
+		toTx(sampleSwapNewHiveToBtc),
+		toTx(sampleSwapNewHbdToHive),
+		toTx(sampleSwapNewBtcToHbd),
+		toTx(sampleSwapOld),
+		toTx(sampleAddLiquidity, '2026-01-02T10:00:00'),
+		toTx(sampleRemoveLiquidity, '2026-01-01T10:00:00'),
+		toTx(sampleBtcTransferToHive),
+		toTx(sampleBtcTransferToEvm),
+		toTx(sampleBtcUnmap),
+		toTx(sampleFailed)
+	];
+
+	const mockBtcDeposit: BtcDepositEvent = {
+		indexer_tx_hash: sampleBtcDepositEvent.indexer_tx_hash,
+		indexer_ts: sampleBtcDepositEvent.indexer_ts,
+		indexer_block_height: sampleBtcDepositEvent.indexer_block_height,
+		indexer_contract_id: 'vsc1BdrQ6EtbQ64rq2PkPd21x4MaLnVRcJj85d',
+		amount: sampleBtcDepositEvent.amount,
+		recipient: sampleBtcDepositEvent.recipient,
+		sender: 'bc1qexamplesenderaddress000000000000000000'
+	};
+
+	// Total mock items = VSC txs + 1 BTC deposit event.
+	// Passed as `limit` to Table so it shows all items AND skips the initial fetch
+	// (Table only calls fetchTxs when allTransactionsStore.length < limit).
+	const MOCK_ITEM_COUNT = mockVscTxs.length + 1;
+
+	// Populate stores synchronously (before Table's onMount runs) so that:
+	//   allTransactionsStore.length >= MOCK_ITEM_COUNT → Table skips the 'set' fetch.
+	// The 'update' interval uses FETCH_DID which is a non-existent account, so the
+	// API returns empty/null and the 'update' path bails without touching the store.
+	const FETCH_DID = 'hive:__mock_preview__';
+	magiTxsStore.set(mockVscTxs);
+	btcDepositStore.set([mockBtcDeposit]);
+
+	onMount(() => {
+		// Clear mock data when navigating away so normal pages see empty stores
+		// (they refetch from their own onMount).
+		return () => {
+			magiTxsStore.set([]);
+			btcDepositStore.set([]);
+		};
+	});
+</script>
+
+<document:head>
+	<title>Mock Transactions Preview</title>
+</document:head>
+
+<div class="page">
+	<div class="banner">
+		⚠️ Dev preview — mock data only, no real account loaded
+	</div>
+	<div class="legend">
+		<h2>Transaction Type Coverage</h2>
+		<div class="grid">
+			<span class="tag verified">✅ Transfer</span>
+			<span class="tag verified">✅ Deposit</span>
+			<span class="tag verified">✅ Withdraw</span>
+			<span class="tag verified">✅ Stake HBD (FAILED)</span>
+			<span class="tag constructed">🔧 Unstake HBD</span>
+			<span class="tag constructed">🔧 Consensus Stake</span>
+			<span class="tag constructed">🔧 Consensus Unstake</span>
+			<span class="tag verified">✅ Swap HIVE→BTC (new router)</span>
+			<span class="tag verified">✅ Swap HBD→HIVE (new router)</span>
+			<span class="tag verified">✅ Swap BTC→HBD (old pool)</span>
+			<span class="tag verified">✅ Swap old pool format</span>
+			<span class="tag constructed">🔧 Add Liquidity</span>
+			<span class="tag constructed">🔧 Remove Liquidity</span>
+			<span class="tag verified">✅ BTC Transfer → Hive acct</span>
+			<span class="tag verified">✅ BTC Transfer → EVM addr</span>
+			<span class="tag verified">✅ BTC Unmap (withdraw)</span>
+			<span class="tag verified">✅ BTC Deposit (indexer event)</span>
+			<span class="tag verified">✅ Failed transaction</span>
+		</div>
+		<p class="note">
+			✅ verified from real on-chain data &nbsp;|&nbsp; 🔧 constructed from source code
+		</p>
+	</div>
+
+	<div class="table-wrapper">
+		<!--
+			did={FETCH_DID}  → a non-existent account so the 2-second update interval
+			                    fetches nothing and never overwrites mock data.
+			limit={MOCK_ITEM_COUNT} → prevents the initial 'set' fetch (Table only fetches
+			                          when store.length < limit, and we pre-populate above).
+		-->
+		<Table did={FETCH_DID} limit={MOCK_ITEM_COUNT} allowPopup={true} />
+	</div>
+</div>
+
+<style>
+	.page {
+		display: flex;
+		flex-direction: column;
+		gap: 1.5rem;
+		padding: 1.5rem;
+		min-height: 100vh;
+	}
+	.banner {
+		background: rgba(255, 165, 0, 0.15);
+		border: 1px solid rgba(255, 165, 0, 0.4);
+		border-radius: 10px;
+		padding: 0.75rem 1.25rem;
+		font-size: 0.9rem;
+		color: var(--dash-text-secondary);
+		font-weight: 500;
+	}
+	.legend {
+		background: var(--dash-card-bg);
+		border: 1px solid var(--dash-card-border);
+		border-radius: 16px;
+		padding: 1.25rem;
+	}
+	h2 {
+		margin: 0 0 1rem;
+		font-size: 1rem;
+		font-weight: 600;
+		color: var(--dash-text-primary);
+	}
+	.grid {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+	.tag {
+		display: inline-block;
+		padding: 0.25rem 0.75rem;
+		border-radius: 2rem;
+		font-size: 0.75rem;
+		font-weight: 500;
+	}
+	.tag.verified {
+		background: rgba(0, 200, 100, 0.12);
+		color: var(--dash-accent-green-light, #4caf7d);
+	}
+	.tag.constructed {
+		background: rgba(111, 106, 248, 0.12);
+		color: #6f6af8;
+	}
+	.note {
+		margin: 0.75rem 0 0;
+		font-size: 0.75rem;
+		color: var(--dash-text-muted);
+	}
+	.table-wrapper {
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+		min-height: 0;
+	}
+</style>

--- a/src/routes/(authed)/transactions/mock/+page.ts
+++ b/src/routes/(authed)/transactions/mock/+page.ts
@@ -1,0 +1,8 @@
+import { dev } from '$app/environment';
+import { error } from '@sveltejs/kit';
+
+export async function load() {
+	if (!dev) {
+		error(404, { message: 'Not found' });
+	}
+}

--- a/src/routes/(authed)/transactions/mockUp.ts
+++ b/src/routes/(authed)/transactions/mockUp.ts
@@ -1,0 +1,776 @@
+/**
+ * mockUp.ts — DEAD FILE, reference only.
+ *
+ * Documents every VSC operation type that Altera can CREATE or DISPLAY,
+ * with annotated real (or constructed) payload shapes.
+ *
+ * ── AMOUNT ENCODING ──────────────────────────────────────────────────────────
+ *   HIVE / HBD  → 3 decimal places  (1 000  = 1.000)
+ *   BTC / sats  → 8 decimal places  (667188 = 0.00667188 BTC)
+ *
+ *   op.data.amount can be:
+ *     decimal string  "5.000"  → isPreshifted = false
+ *     integer         500000   → isPreshifted = true  (typeof === 'number')
+ *
+ * ── CONTRACT IDs (mainnet) ────────────────────────────────────────────────────
+ *   DEX Router       vsc1Brvi4YZHLkocYNAFd7Gf1JpsPjzNnv4i45
+ *   BTC Mapping      vsc1BdrQ6EtbQ64rq2PkPd21x4MaLnVRcJj85d
+ *
+ * ── VERIFICATION ─────────────────────────────────────────────────────────────
+ *   ✅ verified — real tx from hive:milo-hpr fetched from api.vsc.eco
+ *   🔧 constructed — payload shape derived from Altera source code;
+ *                    not yet seen in milo-hpr's last 50 txs
+ *
+ * ── DISPLAY ROUTING ──────────────────────────────────────────────────────────
+ *   getOpTrType() in Table.svelte routes each op to a TR component:
+ *     'regular'   → Tr.svelte           (has from/to/asset/amount fields)
+ *     'btc-vsc'   → BtcMappingTr.svelte (call action = unmap | transfer | transferFrom)
+ *     'contract'  → ContractTr.svelte   (all other call/call_contract ops)
+ *     null        → hidden              (increaseAllowance + infrastructure)
+ *   btc-deposit events → BtcDepositTr.svelte (separate store, not VSC ops)
+ */
+
+// ─── CONTRACT IDs ────────────────────────────────────────────────────────────
+export const DEX_ROUTER  = 'vsc1Brvi4YZHLkocYNAFd7Gf1JpsPjzNnv4i45';
+export const BTC_MAPPING = 'vsc1BdrQ6EtbQ64rq2PkPd21x4MaLnVRcJj85d';
+
+// ─── 1. TRANSFER ✅ ──────────────────────────────────────────────────────────
+// VSC-to-VSC value transfer. from / to can be any DID or hive: account.
+// Sent with custom_json id = "vsc.transfer".
+//
+// TR component : Tr.svelte
+// Table display:
+//   Date    | To/From (other account)  | Status    | ±amount asset  | Transfer
+export const sampleTransfer = {
+	id: 'bafyreify4q4mwtjz4gri6jv73ti6yzj3qvcy5ydbemaxifitjldwpxipti',
+	type: 'vsc',
+	status: 'CONFIRMED',
+	anchr_ts: '2026-04-18T00:08:45',
+	rc_limit: 500,
+	ledger: [
+		{
+			amount: 1000, // integer, preshifted — 1.000 HBD (3 dp)
+			asset: 'hbd',
+			from: 'did:pkh:eip155:1:0x9861820c2E8399AEbf96D4e23A30DEA4AF2d532D',
+			to: 'hive:milo-hpr',
+			type: 'transfer',
+			memo: ''
+		}
+	],
+	ops: [
+		{
+			index: 0,
+			type: 'transfer',
+			data: {
+				amount: '1.000', // decimal string — NOT preshifted
+				asset: 'hbd',
+				from: 'did:pkh:eip155:1:0x9861820c2E8399AEbf96D4e23A30DEA4AF2d532D',
+				to: 'hive:milo-hpr',
+				memo: ''
+			}
+		}
+	]
+};
+
+// ─── 2. DEPOSIT ✅ ──────────────────────────────────────────────────────────
+// Hive L1 → VSC bridge-in. from === to (always self). Ledger is EMPTY.
+// op.data.amount is an INTEGER (preshifted). tx.type = 'hive' (standard Hive transfer op).
+//
+// TR component : Tr.svelte
+// Table display:
+//   Date    | Self / "Hive"  | Status    | +amount asset (green)  | Deposit
+export const sampleDeposit = {
+	id: 'd9a969e30fd3d032e7155ba01358bd9583f64f53',
+	type: 'hive',
+	status: 'CONFIRMED',
+	anchr_ts: '2026-02-24T16:09:21',
+	rc_limit: 0,
+	ledger: [], // always empty for deposit
+	ledger_actions: [],
+	ops: [
+		{
+			index: 0,
+			type: 'deposit',
+			data: {
+				amount: 104000, // integer! preshifted: 104000 = 104.000 HBD
+				asset: 'hbd',
+				from: 'hive:milo-hpr',
+				to: 'hive:milo-hpr', // always self
+				memo: 'to=milo-hpr'
+			}
+		}
+	]
+};
+
+// ─── 3. WITHDRAW ✅ ─────────────────────────────────────────────────────────
+// VSC → Hive L1 bridge-out. from === to (always self).
+// Has ledger entry (type:"withdraw") AND ledger_actions.
+// ledger_actions[].asset may differ, e.g. "hbd_savings" for savings withdraw.
+//
+// TR component : Tr.svelte
+// Table display:
+//   Date    | Self / "Hive"  | Status    | -amount asset  | Withdraw
+export const sampleWithdraw = {
+	id: 'e1703c9b2ba3d069fc01bce709c7d2de4b09e5a9',
+	type: 'hive',
+	status: 'CONFIRMED',
+	anchr_ts: '2026-02-24T16:03:18',
+	rc_limit: 0,
+	ledger: [
+		{
+			amount: 100000, // 100.000 HBD (preshifted)
+			asset: 'hbd',
+			from: 'hive:milo-hpr',
+			to: 'hive:milo-hpr',
+			type: 'withdraw',
+			memo: ''
+		}
+	],
+	ledger_actions: [
+		{
+			amount: 100000,
+			asset: 'hbd', // 'hbd_savings' when withdrawing from savings
+			data: null,
+			memo: ''
+		}
+	],
+	ops: [
+		{
+			index: 0,
+			type: 'withdraw',
+			data: {
+				amount: '100.000', // decimal string here
+				asset: 'hbd',
+				from: 'hive:milo-hpr',
+				to: 'hive:milo-hpr',
+				memo: ''
+			}
+		}
+	]
+};
+
+// ─── 4. STAKE HBD ✅ ────────────────────────────────────────────────────────
+// Lock HBD into savings. from === to (always self).
+// Verified from hive:lordbutterfly (both real txs were FAILED, so ledger is empty,
+// but the op.data shape is confirmed).
+// On success: ledger type = "stake", ledger_actions asset = "hbd_savings".
+// Sent with custom_json id = "vsc.stake_hbd".
+// NOTE: op.data has NO memo field (unlike transfer/deposit).
+//
+// TR component : Tr.svelte
+// Table display:
+//   Date    | Self  | Status    | amount HBD  | Stake HBD
+export const sampleStakeHbd = {
+	id: 'eea7b9502c7dd6009edb2750e89f3e19b07bab1d', // real tx, hive:lordbutterfly, FAILED
+	type: 'hive',
+	status: 'FAILED',
+	anchr_ts: '2026-04-12T15:58:57',
+	rc_limit: 0,
+	ledger: [], // empty because FAILED; on success would have type:"stake" entry
+	ledger_actions: [], // empty because FAILED; on success: [{ asset:"hbd_savings", amount:... }]
+	ops: [
+		{
+			index: 0,
+			type: 'stake_hbd',
+			data: {
+				amount: '1.000', // decimal string — NOT preshifted
+				asset: 'hbd',
+				from: 'hive:lordbutterfly',
+				to: 'hive:lordbutterfly'
+				// No memo field on stake_hbd ops
+			}
+		}
+	]
+};
+
+// ─── 5. UNSTAKE HBD 🔧 ──────────────────────────────────────────────────────
+// Withdraw HBD from savings. Mirror image of stake_hbd.
+// Sent with custom_json id = "vsc.unstake_hbd".
+//
+// TR component : Tr.svelte
+// Table display:
+//   Date    | Self  | Status    | amount HBD  | Unstake HBD
+export const sampleUnstakeHbd = {
+	id: 'sample-unstake-hbd',
+	type: 'hive',
+	status: 'CONFIRMED',
+	rc_limit: 0,
+	ledger: [
+		{
+			amount: 657,
+			asset: 'hbd',
+			from: 'hive:milo-hpr',
+			to: 'hive:milo-hpr',
+			type: 'unstake',
+			memo: ''
+		}
+	],
+	ledger_actions: [
+		{
+			amount: 657,
+			asset: 'hbd_savings',
+			data: null,
+			memo: ''
+		}
+	],
+	ops: [
+		{
+			index: 0,
+			type: 'unstake_hbd',
+			data: {
+				amount: '0.657',
+				asset: 'hbd',
+				from: 'hive:milo-hpr',
+				to: 'hive:milo-hpr'
+			}
+		}
+	]
+};
+
+// ─── 6. CONSENSUS STAKE 🔧 ──────────────────────────────────────────────────
+// Delegate HIVE to a node runner for consensus participation.
+// from = delegator (self), to = node runner account.
+// Sent with custom_json id = "vsc.consensus_stake".
+//
+// TR component : Tr.svelte
+// Table display:
+//   Date    | node-runner-account  | Status    | amount HIVE  | Consensus Stake
+export const sampleConsensusStake = {
+	id: 'sample-consensus-stake',
+	type: 'hive',
+	status: 'CONFIRMED',
+	rc_limit: 0,
+	ledger: [],
+	ops: [
+		{
+			index: 0,
+			type: 'consensus_stake',
+			data: {
+				amount: '100.000',
+				asset: 'hive',
+				from: 'hive:milo-hpr',
+				to: 'hive:some-node-runner'
+			}
+		}
+	]
+};
+
+// ─── 7. CONSENSUS UNSTAKE 🔧 ────────────────────────────────────────────────
+// Remove HIVE delegation from a node runner.
+// Sent with custom_json id = "vsc.consensus_unstake".
+//
+// TR component : Tr.svelte
+// Table display:
+//   Date    | node-runner-account  | Status    | amount HIVE  | Consensus Unstake
+export const sampleConsensusUnstake = {
+	id: 'sample-consensus-unstake',
+	type: 'hive',
+	status: 'CONFIRMED',
+	rc_limit: 0,
+	ledger: [],
+	ops: [
+		{
+			index: 0,
+			type: 'consensus_unstake',
+			data: {
+				amount: '100.000',
+				asset: 'hive',
+				from: 'hive:milo-hpr',
+				to: 'hive:some-node-runner'
+			}
+		}
+	]
+};
+
+// ─── 8. SWAP — new router format ✅ ─────────────────────────────────────────
+// Altera DEX swap via the router contract (vsc.call + action:"execute").
+// Verified extensively from hive:lordbutterfly.
+//
+// KEY FACTS confirmed from real txs:
+//   • payload.asset_in / asset_out are UPPERCASE ("HBD", "HIVE", "BTC")
+//   • payload.amount_in is an INTEGER STRING (preshifted, same unit as ledger amounts)
+//   • intents[].args.limit is a DECIMAL STRING ("1.000") — different from amount_in!
+//   • payload.min_amount_out is preshifted integer; can be "0" (no slippage protection)
+//   • destination_chain optional: "HIVE" or "BTC" for cross-chain; absent for VSC-internal
+//   • recipient: Hive account, BTC address, or contract address
+//   • increaseAllowance companion op: ONLY when asset_in is BTC (hidden by getOpTrType)
+//   • For HIVE/HBD inputs: single execute op, no increaseAllowance companion
+//
+// SETTLED AMOUNT vs MIN:
+//   min_amount_out is the slippage floor, NOT the settled amount. For confirmed txs,
+//   the actual output is in the ledger — last entry where to = recipient (for VSC-
+//   internal swaps) or going to the BTC mapping contract (for BTC destination).
+//   For VSC-internal HIVE/HBD out: last ledger entry {to: recipient, type:"withdraw"}
+//   For BTC destination: ledger shows intermediate HBD going to BTC_MAPPING; the
+//     actual BTC output is tracked by the BTC indexer, not in VSC ledger.
+//
+// TR component : ContractTr.svelte
+// Table display:
+//   Date    | DEX Router (short)  | Status    | amount_in → min_amount_out  | Swap
+
+// Example A: HIVE→BTC cross-chain swap (no increaseAllowance, Altera fee present)
+export const sampleSwapNewHiveToBtc = {
+	id: 'f9666960099d227965b6355aeaeeb87c57e4d063', // real tx, hive:lordbutterfly
+	type: 'hive',
+	status: 'CONFIRMED',
+	anchr_ts: '2026-04-18T01:42:15',
+	rc_limit: 0,
+	ledger: [
+		{ amount: 20000, asset: 'hive', from: 'hive:lordbutterfly', to: `contract:${DEX_ROUTER}`, type: 'transfer', memo: '' },
+		{ amount: 20000, asset: 'hive', from: `contract:${DEX_ROUTER}`, to: 'contract:vsc1BoaniA5HW56GuQy6pVdoZfMcVaaDfnC8kp', type: 'transfer', memo: '' },
+		// Intermediate HBD goes to BTC mapping contract — actual BTC tracked by indexer:
+		{ amount: 1258, asset: 'hbd', from: 'contract:vsc1BoaniA5HW56GuQy6pVdoZfMcVaaDfnC8kp', to: `contract:${DEX_ROUTER}`, type: 'transfer', memo: '' },
+		{ amount: 1258, asset: 'hbd', from: `contract:${DEX_ROUTER}`, to: `contract:${BTC_MAPPING}`, type: 'transfer', memo: '' }
+	],
+	ops: [
+		// Single op — no increaseAllowance for HIVE/HBD inputs
+		{
+			index: 0,
+			type: 'call',
+			data: {
+				action: 'execute',
+				contract_id: DEX_ROUTER,
+				intents: [
+					// limit is DECIMAL string ("20.000"), while payload.amount_in is INTEGER ("20000")
+					{ type: 'transfer.allow', args: { limit: '20.000', token: 'hive' } }
+				],
+				payload: JSON.stringify({
+					type: 'swap',
+					version: '1.0.0',
+					asset_in: 'HIVE',    // UPPERCASE
+					asset_out: 'BTC',    // UPPERCASE
+					amount_in: '20000',  // preshifted integer string (20.000 HIVE)
+					min_amount_out: '1103', // preshifted integer string (min sats out)
+					recipient: 'bc1q5hnuykyu0ejkwktheh5mq2v9dp2y3674ep0kss', // BTC destination address
+					destination_chain: 'BTC',              // cross-chain flag
+					beneficiary: 'hive:altera.app',         // Altera fee
+					ref_bps: 25
+				}),
+				rc_limit: 100000
+			}
+		}
+	]
+};
+
+// Example B: HBD→HIVE VSC-internal swap (settled amount visible in ledger)
+export const sampleSwapNewHbdToHive = {
+	id: '666309ade014f86972240d697ffd702d9feb77ae', // real tx, hive:lordbutterfly
+	type: 'hive',
+	status: 'CONFIRMED',
+	anchr_ts: '2026-04-18T14:04:51',
+	rc_limit: 0,
+	ledger: [
+		{ amount: 1000, asset: 'hbd', from: 'hive:lordbutterfly', to: `contract:${DEX_ROUTER}`, type: 'transfer', memo: '' },
+		{ amount: 1000, asset: 'hbd', from: `contract:${DEX_ROUTER}`, to: 'contract:vsc1BoaniA5HW56GuQy6pVdoZfMcVaaDfnC8kp', type: 'transfer', memo: '' },
+		{ amount: 17752, asset: 'hive', from: 'contract:vsc1BoaniA5HW56GuQy6pVdoZfMcVaaDfnC8kp', to: `contract:${DEX_ROUTER}`, type: 'transfer', memo: '' },
+		// Settled amount: actual HIVE the user received (better than min_amount_out: 17590)
+		{ amount: 17752, asset: 'hive', from: `contract:${DEX_ROUTER}`, to: 'hive:lordbutterfly', type: 'withdraw', memo: '' }
+	],
+	ops: [
+		{
+			index: 0,
+			type: 'deposit', // bundled deposit op (same tx, index 0) — shown as separate row
+			data: {
+				amount: 1000,
+				asset: 'hbd',
+				from: 'hive:lordbutterfly',
+				memo: 'to=lordbutterfly',
+				to: 'hive:lordbutterfly'
+			}
+		},
+		{
+			index: 1,
+			type: 'call',
+			data: {
+				action: 'execute',
+				contract_id: DEX_ROUTER,
+				intents: [{ type: 'transfer.allow', args: { limit: '1.000', token: 'hbd' } }],
+				payload: JSON.stringify({
+					type: 'swap',
+					version: '1.0.0',
+					asset_in: 'HBD',
+					asset_out: 'HIVE',
+					amount_in: '1000',          // preshifted (1.000 HBD)
+					min_amount_out: '17590',    // preshifted floor; actual settled was 17752
+					recipient: 'hive:lordbutterfly',
+					destination_chain: 'HIVE'  // cross-chain to Hive L1
+				}),
+				rc_limit: 10000
+			}
+		}
+	]
+};
+
+// Example C: BTC→HBD swap (has increaseAllowance companion — HIDDEN)
+export const sampleSwapNewBtcToHbd = {
+	id: '24e25445ab74f6c165d4b711199f47048b706164', // real tx, hive:lordbutterfly
+	type: 'hive',
+	status: 'CONFIRMED',
+	anchr_ts: '2026-04-21T14:38:15',
+	rc_limit: 0,
+	ledger: [
+		{ amount: 498000, asset: 'hbd', from: 'hive:lordbutterfly', to: `contract:${DEX_ROUTER}`, type: 'transfer', memo: '' },
+		{ amount: 498000, asset: 'hbd', from: `contract:${DEX_ROUTER}`, to: 'contract:vsc1BVb95YKRHAEy24XgRSaW4L6d9vB88AdwjM', type: 'transfer', memo: '' }
+	],
+	ops: [
+		// Op 0: increaseAllowance — HIDDEN by getOpTrType (BTC input requires this)
+		{
+			index: 0,
+			type: 'call',
+			data: {
+				action: 'increaseAllowance',
+				contract_id: BTC_MAPPING,
+				intents: [],
+				payload: JSON.stringify({ spender: `contract:${DEX_ROUTER}`, amount: '682941' }),
+				rc_limit: 1000
+			}
+		},
+		// Note: this particular tx used the OLD pool format (payload.type="deposit").
+		// A BTC→HBD swap via the NEW router would have payload.type="swap" instead.
+		{
+			index: 1,
+			type: 'call',
+			data: {
+				action: 'execute',
+				contract_id: DEX_ROUTER,
+				intents: [{ args: { limit: '498000', token: 'hbd' }, type: 'transfer.allow' }],
+				payload: JSON.stringify({
+					type: 'deposit', // old pool format (still detected as swap by ContractTr)
+					version: '1.0.0',
+					asset0: 'btc',
+					asset1: 'hbd',
+					amount0: '682941', // sats in
+					amount1: '498000', // milliHBD out (settled)
+					recipient: 'hive:lordbutterfly'
+				}),
+				rc_limit: 2000
+			}
+		}
+	]
+};
+
+// ─── 9. SWAP — old pool format ✅ ───────────────────────────────────────────
+// Historical: direct call to an AMM pool (pre-router era). New swaps use #8.
+// payload.type = "deposit" (the pool's internal instruction name — confusing but correct).
+// amount0/amount1 are SETTLED values (confirmed tx), so display is accurate.
+//
+// TR component : ContractTr.svelte
+// Table display:
+//   Date    | pool addr (short)  | Status    | amount0 → amount1  | Swap
+export const sampleSwapOld = {
+	id: 'dbd48d6e2c54822021d058770251c995e545d106',
+	type: 'hive',
+	status: 'CONFIRMED',
+	anchr_ts: '2026-04-17T03:05:24',
+	rc_limit: 0,
+	ledger: [
+		{ amount: 500000, asset: 'hbd', from: 'hive:milo-hpr', to: `contract:${DEX_ROUTER}`, type: 'transfer', memo: '' },
+		{ amount: 500000, asset: 'hbd', from: `contract:${DEX_ROUTER}`, to: 'contract:vsc1BVb95YKRHAEy24XgRSaW4L6d9vB88AdwjM', type: 'transfer', memo: '' }
+	],
+	ops: [
+		{
+			index: 0,
+			type: 'call',
+			data: {
+				action: 'increaseAllowance', // HIDDEN by getOpTrType
+				contract_id: BTC_MAPPING,
+				intents: [],
+				payload: JSON.stringify({ spender: `contract:${DEX_ROUTER}`, amount: '667188' }),
+				rc_limit: 1000
+			}
+		},
+		{
+			index: 1,
+			type: 'call',
+			data: {
+				action: 'execute',
+				contract_id: 'vsc1Brvi4YZHLkocYNAFd7Gf1JpsPjzNnv4i45', // the AMM pool directly
+				intents: [{ args: { limit: '500000', token: 'hbd' }, type: 'transfer.allow' }],
+				payload: JSON.stringify({
+					type: 'deposit', // AMM pool instruction — not a liquidity deposit
+					version: '1.0.0',
+					asset0: 'btc',    // what went IN
+					asset1: 'hbd',    // what came OUT
+					amount0: '667188', // 0.00667188 BTC (sats)
+					amount1: '500000', // 500.000 HBD (milliHBD) — settled
+					recipient: 'hive:milo-hpr'
+				}),
+				rc_limit: 5000
+			}
+		}
+	]
+};
+
+// ─── 10. ADD LIQUIDITY 🔧 ───────────────────────────────────────────────────
+// Deposit both sides of a pool pair via the DEX router.
+// payload.type = "deposit" on DEX_ROUTER — same key as old swap (#9) but on the router.
+// Both amount0 + amount1 are sent IN (no output amount in the payload).
+//
+// Distinguish from old swap: contract_id === DEX_ROUTER and payload.type === "deposit".
+//
+// TR component : ContractTr.svelte (currently shows as generic contract op)
+// Current display: first intent amount as "limit" → not ideal
+// Ideal display: amount0 asset0 + amount1 asset1 | Add Liquidity
+export const sampleAddLiquidity = {
+	id: 'sample-add-liquidity',
+	type: 'hive',
+	status: 'CONFIRMED',
+	rc_limit: 0,
+	ledger: [],
+	ops: [
+		{
+			index: 0,
+			type: 'call',
+			data: {
+				action: 'execute',
+				contract_id: DEX_ROUTER,
+				intents: [
+					{ type: 'transfer.allow', args: { limit: '50000', token: 'hbd' } },
+					{ type: 'transfer.allow', args: { limit: '12345', token: 'hive' } }
+				],
+				payload: JSON.stringify({
+					type: 'deposit', // "add liquidity" instruction to the router
+					version: '1.0.0',
+					asset0: 'hbd',    // alphabetical order enforced by getAddLiquidityOp()
+					asset1: 'hive',
+					amount0: '50000', // 50.000 HBD
+					amount1: '12345', // 12.345 HIVE
+					recipient: 'hive:milo-hpr'
+				}),
+				rc_limit: 100000
+			}
+		}
+	]
+};
+
+// ─── 11. REMOVE LIQUIDITY 🔧 ────────────────────────────────────────────────
+// Burn LP tokens to withdraw both underlying assets from a pool via the DEX router.
+// payload.type = "withdrawal". No intents (user is not sending assets in).
+// lp_amount = LP tokens to burn; actual output amounts come from ledger after confirmation.
+//
+// TR component : ContractTr.svelte (currently shows as generic contract op with 0 amount)
+// Ideal display: lp_amount LP tokens | Remove Liquidity
+export const sampleRemoveLiquidity = {
+	id: 'sample-remove-liquidity',
+	type: 'hive',
+	status: 'CONFIRMED',
+	rc_limit: 0,
+	ledger: [],
+	ops: [
+		{
+			index: 0,
+			type: 'call',
+			data: {
+				action: 'execute',
+				contract_id: DEX_ROUTER,
+				intents: [], // no assets sent in
+				payload: JSON.stringify({
+					type: 'withdrawal', // "remove liquidity"
+					version: '1.0.0',
+					asset0: 'hbd',
+					asset1: 'hive',
+					lp_amount: '2594', // LP tokens to burn
+					recipient: 'hive:milo-hpr'
+				}),
+				rc_limit: 100000
+			}
+		}
+	]
+};
+
+// ─── 12. BTC TRANSFER (VSC-internal) ✅ ─────────────────────────────────────
+// Transfer mapped BTC between VSC accounts via the BTC mapping contract.
+// Verified from hive:devser.v4vapp (real txs from issue #62).
+//
+// payload = plain JSON string: { "amount": "<sats>", "to": "<recipient DID or hive:>" }
+// ⚠ The payload is a plain JSON STRING, not a base64-encoded object.
+//   BtcMappingTr.payloadData must handle this case — the `op.data.payload.Data`
+//   base64 path is for a legacy format only.
+//
+// Internal VSC transfers produce NO indexer event — the BTC indexer only tracks
+// on-chain Bitcoin transactions (unmap). fromAccount and toAccount must be
+// populated from the payload when the indexer returns null.
+//
+// TR component : BtcMappingTr.svelte (action = "transfer")
+// Table display:
+//   Date    | recipient address  | Status    | amount BTC (outgoing)  | Transfer
+export const sampleBtcTransferToHive = {
+	id: '286d5bdf4f35d68445ce0dfb48718d6271170e5e', // real tx, hive:devser.v4vapp
+	type: 'hive',
+	status: 'CONFIRMED',
+	anchr_ts: '2026-04-22T07:53:30',
+	rc_limit: 0,
+	ledger: [], // always empty for internal BTC transfers
+	ops: [
+		{
+			index: 0,
+			type: 'call',
+			data: {
+				action: 'transfer',
+				contract_id: BTC_MAPPING,
+				intents: null,
+				payload: JSON.stringify({
+					amount: '432', // sats — plain JSON string, NOT base64
+					to: 'hive:v4vapp-test'
+				}),
+				rc_limit: 1000
+			}
+		}
+	]
+};
+
+export const sampleBtcTransferToEvm = {
+	id: 'bd3f27ad88e00a78995e67d60f5994cc01f858f4', // real tx, hive:devser.v4vapp
+	type: 'hive',
+	status: 'CONFIRMED',
+	anchr_ts: '2026-04-22T09:37:33',
+	rc_limit: 0,
+	ledger: [],
+	ops: [
+		{
+			index: 0,
+			type: 'call',
+			data: {
+				action: 'transfer',
+				contract_id: BTC_MAPPING,
+				intents: null,
+				payload: JSON.stringify({
+					amount: '1230', // sats
+					to: 'did:pkh:eip155:1:0x3Bb63EDd3Ff0F285997C52D8ee362dd40d3B2AAd' // EVM address DID
+				}),
+				rc_limit: 1000
+			}
+		}
+	]
+};
+
+// ─── 13. BTC UNMAP (withdraw to mainnet) ✅ ──────────────────────────────────
+// Withdraw BTC from VSC to a mainnet Bitcoin address.
+// Ledger is always EMPTY — amount resolved asynchronously by the BTC indexer.
+// Optional fields: deduct_fee (boolean), max_fee (sats).
+//
+// TR component : BtcMappingTr.svelte (action = "unmap")
+// Table display:
+//   Date    | bc1q… address  | Status    | amount BTC  | Withdraw
+export const sampleBtcUnmap = {
+	id: 'c2e07e2616844f4aaf93a1961e0728326f8707aa',
+	type: 'hive',
+	status: 'CONFIRMED',
+	anchr_ts: '2026-04-14T21:24:33',
+	rc_limit: 0,
+	ledger: [], // always empty — fetched from BTC indexer separately
+	ops: [
+		{
+			index: 0,
+			type: 'call',
+			data: {
+				action: 'unmap',
+				contract_id: BTC_MAPPING,
+				intents: null,
+				payload: JSON.stringify({
+					amount: '5000',   // sats
+					to: 'bc1q0c3tjrfmg4f8y3c2peylezcanplk0xvmpc32u9',
+					deduct_fee: true  // optional — fee deducted from output
+					// max_fee: 500  // optional — cap in sats
+				}),
+				rc_limit: 5000
+			}
+		}
+	]
+};
+
+// ─── 14. BTC DEPOSIT (mainnet → VSC) ─────────────────────────────────────────
+// Bitcoin sent from mainnet to a mapped VSC address. NOT a VSC op — this
+// comes from a separate BTC indexer and lives in btcDepositStore (BtcDepositEvent).
+// Displayed by BtcDepositTr.svelte, not from the normal ops pipeline.
+//
+// Table display:
+//   Date    | Self / "Bitcoin"  | Status (always CONFIRMED)  | +amount BTC (green)  | BTC Deposit
+export const sampleBtcDepositEvent = {
+	// BtcDepositEvent shape from src/lib/indexer/btcMappingQueries.ts
+	indexer_tx_hash: 'abc123...',
+	indexer_ts: '2026-04-10T12:00:00',
+	indexer_block_height: 850000,
+	amount: '667188', // sats as string (BtcDepositEvent.amount is string)
+	recipient: 'hive:milo-hpr'
+};
+
+// ─── 15. FAILED TRANSACTION ✅ ───────────────────────────────────────────────
+// Any op type can fail. Ledger is EMPTY on failure.
+// Display like normal but with status = "FAILED".
+export const sampleFailed = {
+	id: 'f800359987e539c41973b6c361d333b9496a719e',
+	type: 'hive',
+	status: 'FAILED',
+	anchr_ts: '2026-04-17T19:23:18',
+	rc_limit: 0,
+	ledger: [], // always empty on failure
+	ops: [
+		{
+			index: 0,
+			type: 'transfer',
+			data: {
+				amount: '50.000',
+				asset: 'hive',
+				from: 'hive:milo-hpr',
+				to: 'did:pkh:bip122:000000000933ea01ad0ee984209779ba:tb1qw0ssk7ef83esfc3e4k5gtmxhntshyawsrztz8p',
+				memo: ''
+			}
+		}
+	]
+};
+
+// ─── 16. INFRASTRUCTURE CALLS (hidden from wallet UI) ────────────────────────
+// Protocol-level ops with no monetary value. getOpTrType() currently returns null
+// for 'increaseAllowance'. The following actions should also be hidden:
+//
+// RECOMMENDATION: extend the null-return list in getOpTrType() to cover:
+//   'map'                 — BTC deposit proof submission
+//   'add_blocks'          — BTC light client block relay
+//   'seed_blocks'         — BTC light client seed
+//   'register_public_key' — node key registration
+//   'create_key_pair'     — key pair generation
+//   'echo'                — test / debug
+//   'dumpEnv'             — test / debug
+export const infrastructureActions = [
+	'map',
+	'add_blocks',
+	'seed_blocks',
+	'register_public_key',
+	'create_key_pair',
+	'echo',
+	'dumpEnv'
+] as const;
+
+// ─── DISPLAY DECISION TABLE ──────────────────────────────────────────────────
+//
+// op.type          │ action / payload.type    │ TR           │ To/From           │ Amount                   │ Type label
+// ─────────────────┼──────────────────────────┼──────────────┼───────────────────┼──────────────────────────┼──────────────────
+// transfer         │ —                        │ Tr           │ other account     │ ±amount asset            │ Transfer
+// deposit          │ —                        │ Tr           │ Self / "Hive"     │ +amount asset (green)    │ Deposit
+// withdraw         │ —                        │ Tr           │ Self / "Hive"     │ -amount asset            │ Withdraw
+// stake_hbd        │ —                        │ Tr           │ Self              │ amount HBD               │ Stake HBD
+// unstake_hbd      │ —                        │ Tr           │ Self              │ amount HBD               │ Unstake HBD
+// consensus_stake  │ —                        │ Tr           │ node runner       │ amount HIVE              │ Consensus Stake
+// consensus_unstake│ —                        │ Tr           │ node runner       │ amount HIVE              │ Consensus Unstake
+// call             │ execute / type:"swap"    │ ContractTr   │ DEX Router short  │ amount_in→min_amt_out    │ Swap
+// call             │ execute / type:"deposit" │ ContractTr   │ pool/router short │ amount0→amount1          │ Swap (old pool)
+// call             │ execute / type:"deposit" │ ContractTr   │ DEX Router short  │ amount0+amount1 (ideal)  │ Add Liquidity
+// call             │ execute / type:"withdraw"│ ContractTr   │ DEX Router short  │ lp_amount (ideal)        │ Remove Liquidity
+// call             │ transfer                 │ BtcMapping   │ recipient addr    │ -amount BTC              │ BTC Transfer
+// call             │ unmap                    │ BtcMapping   │ BTC address       │ amount BTC               │ Withdraw
+// btc-deposit      │ (indexer event)          │ BtcDeposit   │ Self / "Bitcoin"  │ +amount BTC (green)      │ BTC Deposit
+// call             │ increaseAllowance        │ null/hidden  │ —                 │ —                        │ —
+// call             │ map/add_blocks/etc.      │ null/hidden  │ —                 │ —                        │ — (see #16)
+//
+// ─── CONSISTENT FIELDS ACROSS ALL OP TYPES ───────────────────────────────────
+// ALWAYS present and meaningful for the table:
+//   tx.anchr_ts     — timestamp (fall back to tx.first_seen)
+//   tx.status       — CONFIRMED | FAILED | UNCONFIRMED
+//   tx.id           — for link/copy in detail drawer
+//
+// CONDITIONAL (parse from op.data or payload):
+//   from / to       — present on Tr ops; absent on call/execute (use caller + contract_id)
+//   amount + asset  — present on Tr ops; absent on call/execute (parse payload)
+//   payload         — string JSON; only on call ops; source of swap/liquidity amounts
+//   intents         — array; fallback amount source on call/execute when payload is opaque

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import PillButton from '$lib/PillButton.svelte';
+
+	const is404 = page.status === 404;
+	const title = is404 ? 'Page not found' : 'Something went wrong';
+	const message = is404
+		? "This page doesn't exist or you don't have access to it."
+		: page.error?.message ?? 'An unexpected error occurred.';
+</script>
+
+<svelte:head>
+	<title>{page.status} · Altera</title>
+</svelte:head>
+
+<div class="bg-mesh"></div>
+
+<div class="shell">
+	<div class="card">
+		<div class="logo-wrap">
+			<img src="/magi.svg" alt="Altera" class="logo" />
+			<div class="glow"></div>
+		</div>
+
+		<div class="code">{page.status}</div>
+		<h1>{title}</h1>
+		<p>{message}</p>
+
+		<PillButton href="/" styleType="invert">Go to dashboard</PillButton>
+	</div>
+
+	<footer>
+		<span>Altera &mdash; VSC Multi-Chain Wallet</span>
+	</footer>
+</div>
+
+<style>
+	:global(body) {
+		margin: 0;
+		background: #0a0a12;
+		font-family: 'DM Sans Variable', 'DM Sans', sans-serif;
+		color: #ffffff;
+		min-height: 100dvh;
+	}
+
+	/* Same gradient mesh as the authed layout */
+	.bg-mesh {
+		position: fixed;
+		inset: 0;
+		z-index: 0;
+		pointer-events: none;
+		background:
+			radial-gradient(ellipse at 15% 10%, hsla(243, 90%, 65%, 0.45) 0px, transparent 40%),
+			radial-gradient(ellipse at 80% 8%, hsla(238, 60%, 55%, 0.3) 0px, transparent 38%),
+			radial-gradient(ellipse at 88% 50%, hsla(235, 50%, 50%, 0.2) 0px, transparent 40%),
+			radial-gradient(ellipse at 5% 70%, hsla(245, 70%, 55%, 0.25) 0px, transparent 35%),
+			radial-gradient(ellipse at 50% 35%, hsla(230, 50%, 40%, 0.2) 0px, transparent 45%),
+			radial-gradient(ellipse at 75% 80%, hsla(240, 50%, 45%, 0.15) 0px, transparent 35%);
+	}
+
+	.shell {
+		position: relative;
+		z-index: 1;
+		min-height: 100dvh;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		padding: 2rem 1rem;
+		gap: 2rem;
+	}
+
+	.card {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		text-align: center;
+		gap: 1rem;
+		background: #1a1a25;
+		border: 1px solid #252533;
+		border-radius: 24px;
+		padding: 3rem 2.5rem;
+		max-width: 420px;
+		width: 100%;
+		box-shadow:
+			0 0 0 1px rgba(108, 92, 231, 0.08),
+			0 24px 48px rgba(0, 0, 0, 0.4);
+	}
+
+	/* Logo + glow halo */
+	.logo-wrap {
+		position: relative;
+		width: 88px;
+		height: 88px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		margin-bottom: 0.5rem;
+	}
+
+	.logo {
+		width: 64px;
+		height: 64px;
+		position: relative;
+		z-index: 1;
+		opacity: 0.9;
+		filter: drop-shadow(0 0 12px rgba(212, 71, 255, 0.5));
+		animation: float 4s ease-in-out infinite;
+	}
+
+	.glow {
+		position: absolute;
+		inset: 0;
+		border-radius: 50%;
+		background: radial-gradient(ellipse at center, rgba(108, 92, 231, 0.25) 0%, transparent 70%);
+		animation: pulse-glow 4s ease-in-out infinite;
+	}
+
+	.code {
+		font-size: 5rem;
+		font-weight: 800;
+		line-height: 1;
+		letter-spacing: -0.04em;
+		background: linear-gradient(135deg, #6c5ce7 0%, #d447ff 100%);
+		-webkit-background-clip: text;
+		-webkit-text-fill-color: transparent;
+		background-clip: text;
+	}
+
+	h1 {
+		margin: 0;
+		font-size: 1.25rem;
+		font-weight: 600;
+		color: #ffffff;
+	}
+
+	p {
+		margin: 0;
+		font-size: 0.9rem;
+		color: #9ca3af;
+		line-height: 1.6;
+		max-width: 300px;
+	}
+
+footer {
+		font-size: 0.75rem;
+		color: #6b7280;
+		letter-spacing: 0.02em;
+	}
+
+	@keyframes float {
+		0%, 100% { transform: translateY(0px); }
+		50%       { transform: translateY(-6px); }
+	}
+
+	@keyframes pulse-glow {
+		0%, 100% { opacity: 0.6; transform: scale(1); }
+		50%       { opacity: 1;   transform: scale(1.15); }
+	}
+</style>


### PR DESCRIPTION
## Summary

Four commits, each self-contained:

1. **[dashboard] Responsive layout improvements**
   - Refactored `AccBalance` balance list — wrapped coin name + amount into a `name-row` div for correct horizontal alignment at all screen sizes
   - Added `PortfolioValue` card to the dashboard right column
   - Dashboard grid improvements in `+page.svelte` for small screens
   - `Table.svelte` initial scroll/sizing groundwork

2. **[transactions] Table layout overhaul, BTC mapping fixes, error handling**
   - `Table.svelte`: replaced flat grid with a `flex + .table-scroll` wrapper — proper horizontal scroll on small screens, Status column added, responsive column breakpoints
   - All table cell components (`Amount`, `ContractId`, `Status`, `ToFrom`, `Type`): visual alignment and layout polish
   - `BtcMappingTr` + `Tr`: fixed crash when auth hasn't resolved yet (`value!.did` → `value?.did ?? ''`); moved `loadIndexerData()` into a `$effect` with an auth guard so it only runs once the DID is known
   - `btcMappingQueries`: added `isSchemaError()` helper — BTC mapping event queries now use `hasuraQueryRaw` and silently return `null` when the indexer doesn't expose those tables yet, rather than logging noisy errors on every row
   - `ContractTr`: display improvements
   - `mockUp.ts` + `/transactions/mock`: dev-only preview page rendering all 18 transaction types through the real Table component — gated to dev builds via a `+page.ts` load guard (404 in production)

3. **[app] Branded 404/error page + Chrome DevTools noise fix**
   - `+error.svelte`: custom error page matching the app design system — magi.svg logo with float animation, gradient status code, correct message for 404 vs other errors, `PillButton` CTA back to dashboard
   - `hooks.server.ts`: silent 204 response for `/.well-known/appspecific/com.chrome.devtools.json` Chrome DevTools probes (was flooding the dev server log with 404s); existing domain redirect preserved

4. **[dashboard] Live sHBD APR and real earning estimates**
   - `aprStore.ts` (new): fetches `hbd_interest_rate` from the Hive blockchain via the existing `DHive` client — the actual rate HBD savings pays, converted from basis points to a whole-number percentage; lazy singleton with 12% fallback if the node is unreachable
   - `StakingEarnings`: APR is now live from the chain; Today and This month show estimated earnings computed from the user's real `hbd_savings` balance × APR (HBD ≈ $1); Currently Staked shows the actual balance; Next payout shows `—` (Hive credits interest on-demand, not on a fixed schedule)
   - `AccBalance`: sHBD tooltip APR reads from the same store

## Test plan
- [ ] Dashboard loads — balances align correctly at all screen widths
- [ ] Transactions page — all row types render, table scrolls horizontally on small screens, no crashes on BTC mapping rows
- [ ] `/transactions/mock` in dev — all 18 transaction types visible; returns 404 in `pnpm preview`
- [ ] Navigate to a non-existent path — branded error page appears, "Go to dashboard" goes to `/`
- [ ] Dev server log — no `/.well-known/appspecific/com.chrome.devtools.json` 404 noise
- [ ] Dashboard staking card — APR fetched from Hive (check Network tab for `api.hive.blog` call); with sHBD staked, Today/This month show real estimates