### PR TITLE
feat(swap): fee transparency, price impact, pool depth guard, responsive layout

### DIFF
--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -17,7 +17,7 @@
 	let navWidth = $state(100);
 	let bodyWidth = $state(0);
 	let { visible = $bindable(false) } = $props();
-	let actuallyVisible = $derived(visible || bodyWidth >= 620);
+	let actuallyVisible = $derived(visible || bodyWidth >= 860);
 	let preload = $state(true);
 	let auth = $derived(getAuth()());
 
@@ -163,7 +163,7 @@
 	.preload {
 		transition-duration: 0.0001s !important;
 	}
-	@media screen and (min-width: 620px) {
+	@media screen and (min-width: 860px) {
 		nav {
 			z-index: 1;
 			position: sticky;
@@ -174,7 +174,7 @@
 			display: none !important;
 		}
 	}
-	@media screen and (max-width: 619px) {
+	@media screen and (max-width: 859px) {
 		.desktop-only {
 			display: none !important;
 		}

--- a/src/lib/Topbar/Topbar.svelte
+++ b/src/lib/Topbar/Topbar.svelte
@@ -193,7 +193,7 @@
 	.mobile-menu {
 		display: none;
 	}
-	@media screen and (max-width: 620px) {
+	@media screen and (max-width: 860px) {
 		.mobile-menu {
 			display: flex;
 		}

--- a/src/lib/cards/QuickSwap.svelte
+++ b/src/lib/cards/QuickSwap.svelte
@@ -40,6 +40,7 @@
 		getOrderedDepthsFor,
 		calculateSwap,
 		calculateTwoHopSwap,
+		checkExceedsPoolDepth,
 		type TypedPoolDepths,
 		type SwapCalcResult
 	} from '$lib/pools/swapCalc';
@@ -294,6 +295,37 @@
 					fromInTo = amt.toPrettyMinFigs();
 				});
 		}
+	});
+
+	let fromPriceUsdRaw = $state(0);
+	let toPriceUsdRaw = $state(0);
+	$effect(() => {
+		if ($SendTxDetails.fromCoin) {
+			new CoinAmount(1, $SendTxDetails.fromCoin.coin)
+				.convertTo(Coin.usd, Network.lightning)
+				.then((amt) => { fromPriceUsdRaw = amt.toNumber(); });
+		}
+		if ($SendTxDetails.toCoin) {
+			new CoinAmount(1, $SendTxDetails.toCoin.coin)
+				.convertTo(Coin.usd, Network.lightning)
+				.then((amt) => { toPriceUsdRaw = amt.toNumber(); });
+		}
+	});
+
+	let priceImpactPct = $derived.by(() => {
+		const fromCoin = $SendTxDetails.fromCoin;
+		const fromAmount = $SendTxDetails.fromAmount;
+		if (!swapResult || !fromCoin || !fromAmount || fromAmount === '0') return 0;
+		if (fromPriceUsdRaw <= 0 || toPriceUsdRaw <= 0) return 0;
+		const inputAmt = parseFloat(fromAmount);
+		if (!Number.isFinite(inputAmt) || inputAmt <= 0) return 0;
+		const toCoinDef = $SendTxDetails.toCoin;
+		if (!toCoinDef) return 0;
+		const outputAmt = Number(swapResult.expectedOutput) / 10 ** toCoinDef.coin.decimalPlaces;
+		const inputUsd = inputAmt * fromPriceUsdRaw;
+		const outputUsd = outputAmt * toPriceUsdRaw;
+		if (inputUsd <= 0) return 0;
+		return Math.max(0, ((inputUsd - outputUsd) / inputUsd) * 100);
 	});
 
 	// Pool-based fee calculation — resolve both HIVE/HBD and BTC/HBD
@@ -640,12 +672,48 @@
 		return entered > maxSmallest;
 	});
 
+	const exceedsPoolDepth = $derived.by(() => {
+		const fromCoin = $SendTxDetails.fromCoin;
+		const toCoin = $SendTxDetails.toCoin;
+		const fromAmount = $SendTxDetails.fromAmount;
+		if (!fromCoin || !toCoin || !fromAmount || fromAmount === '0') return false;
+		const fromAmountInt = new CoinAmount(fromAmount, fromCoin.coin).amount;
+		if (!Number.isFinite(fromAmountInt) || fromAmountInt <= 0) return false;
+		return checkExceedsPoolDepth(
+			BigInt(fromAmountInt),
+			fromCoin.coin.value,
+			toCoin.coin.value,
+			hiveHbdPool,
+			btcHbdPool
+		);
+	});
+
 	// Slippage tolerance in basis points. Matches the SwapOptions presets
 	// on the /swap page so the behavior is identical here.
 	const slippageOptions = [50, 100, 200, 300];
 	let slippageBps = $state(100);
 	let customSlippageOpen = $state(false);
 	let customSlippageInput = $state('');
+	let customSlippageInputEl: HTMLInputElement | null = $state(null);
+
+	$effect(() => {
+		if (customSlippageOpen && customSlippageInputEl) {
+			customSlippageInputEl.focus();
+			customSlippageInputEl.select();
+		}
+	});
+
+	function applyCustomSlippage() {
+		const raw = customSlippageInput.replace(',', '.').trim();
+		const v = parseFloat(raw);
+		if (!raw || isNaN(v) || v < 0.01 || v > 99.99) {
+			customSlippageOpen = false;
+			return;
+		}
+		slippageBps = Math.round(v * 100);
+		customSlippageInput = parseFloat(v.toFixed(2)).toString();
+		customSlippageOpen = false;
+	}
 
 	function setError(msg: string) {
 		swapStatus = msg;
@@ -698,6 +766,10 @@
 		}
 		if (exceedsBalance) {
 			setError('Amount exceeds your wallet balance');
+			return false;
+		}
+		if (exceedsPoolDepth) {
+			setError('Amount exceeds 50% of pool depth — reduce the amount to continue');
 			return false;
 		}
 
@@ -1126,17 +1198,16 @@
 			{#if customSlippageOpen}
 				<div class="custom-slippage">
 					<input
+						bind:this={customSlippageInputEl}
 						type="text"
 						inputmode="decimal"
-						placeholder="e.g. 5"
+						placeholder="0.5"
 						bind:value={customSlippageInput}
-						oninput={() => {
-							customSlippageInput = customSlippageInput.replace(',', '.');
-							let v = parseFloat(customSlippageInput);
-							if (isNaN(v)) return;
-							if (v < 0.01) v = 0.01;
-							if (v > 99.99) v = 99.99;
-							slippageBps = Math.round(v * 100);
+						oninput={() => { customSlippageInput = customSlippageInput.replace(',', '.'); }}
+						onblur={applyCustomSlippage}
+						onkeydown={(e) => {
+							if (e.key === 'Enter') { applyCustomSlippage(); e.currentTarget.blur(); }
+							if (e.key === 'Escape') { customSlippageOpen = false; }
 						}}
 					/>
 					<span>%</span>
@@ -1147,10 +1218,12 @@
 					class:active={!slippageOptions.includes(slippageBps)}
 					onclick={() => {
 						customSlippageOpen = true;
-						customSlippageInput = (slippageBps / 100).toFixed(1);
+						customSlippageInput = slippageOptions.includes(slippageBps)
+							? ''
+							: parseFloat((slippageBps / 100).toFixed(2)).toString();
 					}}
 				>
-					{slippageOptions.includes(slippageBps) ? 'Custom' : `${(slippageBps / 100).toFixed(1)}%`}
+					{slippageOptions.includes(slippageBps) ? 'Custom' : `${parseFloat((slippageBps / 100).toFixed(2))}%`}
 				</button>
 			{/if}
 		</div>
@@ -1170,26 +1243,7 @@
 			<div class="detail-row">
 				<span class="detail-label">Fee</span>
 				<span class="detail-value">
-					{#if swapResult && $SendTxDetails.toCoin}
-						{#if swapResult.hop1Fee}
-							{@const hopCoin =
-								swapResult.hop1Fee.asset === Coin.hbd.value
-									? Coin.hbd
-									: swapResult.hop1Fee.asset === Coin.hive.value
-										? Coin.hive
-										: Coin.btc}
-							{formatFee(swapResult.hop1Fee.totalFee, hopCoin.decimalPlaces)}
-							{hopCoin.label}
-							and
-							{formatFee(swapResult.totalFee, $SendTxDetails.toCoin.coin.decimalPlaces)}
-							{$SendTxDetails.toCoin.coin.label}
-						{:else}
-							{formatFee(swapResult.totalFee, $SendTxDetails.toCoin.coin.decimalPlaces)}
-							{$SendTxDetails.toCoin.coin.label}
-						{/if}
-					{:else}
-						0.08% + CLP
-					{/if}
+					Protocol fee ({swapResult?.hop1Fee ? '0.16%' : '0.08%'})
 				</span>
 			</div>
 			<div class="detail-row">
@@ -1203,19 +1257,42 @@
 					{$SendTxDetails.toCoin.coin.label}
 				</span>
 			</div>
+			{#if swapResult && priceImpactPct > 0}
+				<div class="detail-row">
+					<span class="detail-label">Price Impact</span>
+					<span
+						class="detail-value impact-pct"
+						class:good={priceImpactPct < 2}
+						class:medium={priceImpactPct >= 2 && priceImpactPct < 10}
+						class:bad={priceImpactPct >= 10}
+					>{priceImpactPct.toFixed(2)}%</span>
+				</div>
+			{/if}
 		</div>
+	{/if}
+
+	{#if priceImpactPct >= 10}
+		<p class="swap-status error" class:severe={priceImpactPct >= 15}>
+			{#if priceImpactPct >= 15}
+				⚠ Very high price impact — pool liquidity is low. Try a smaller amount.
+			{:else}
+				⚠ High price impact — consider a smaller amount for better rates.
+			{/if}
+		</p>
 	{/if}
 
 	{#if sameCoinSelected}
 		<p class="swap-status error">From and To assets must be different.</p>
 	{:else if exceedsBalance}
 		<p class="swap-status error">Amount exceeds your wallet balance.</p>
+	{:else if exceedsPoolDepth}
+		<p class="swap-status error">Amount exceeds 50% of pool depth — reduce the amount.</p>
 	{/if}
 
 	<!-- Exchange -->
 	<PillButton
 		onclick={requestSwap}
-		disabled={swapLoading || !hasAmount || sameCoinSelected || missingReceiver || exceedsBalance}
+		disabled={swapLoading || !hasAmount || sameCoinSelected || missingReceiver || exceedsBalance || exceedsPoolDepth}
 		styleType="invert submit"
 	>
 		{swapLoading ? 'Swapping...' : 'Swap'}
@@ -1694,6 +1771,12 @@
 	.detail-value.route {
 		color: #6f6af8;
 		font-weight: 600;
+	}
+	.impact-pct {
+		font-weight: 600;
+		&.good { color: var(--dash-success, #22c55e); }
+		&.medium { color: var(--dash-warning, #f59e0b); }
+		&.bad { color: var(--dash-error, #ef4444); }
 	}
 
 	.swap-status {

--- a/src/lib/cards/QuickSwap.svelte
+++ b/src/lib/cards/QuickSwap.svelte
@@ -1729,6 +1729,7 @@
 	}
 	.custom-slippage input {
 		width: 3rem;
+		height: auto;
 		border: none;
 		background: transparent;
 		color: var(--dash-text-primary);

--- a/src/lib/cards/QuickSwap.svelte
+++ b/src/lib/cards/QuickSwap.svelte
@@ -37,10 +37,11 @@
 	import { modal } from '$lib/auth/reown';
 	import {
 		fetchTypedPoolDepths,
-		getOrderedDepthsFor,
 		calculateSwap,
 		calculateTwoHopSwap,
+		getOrderedDepthsFor,
 		checkExceedsPoolDepth,
+		calculatePriceImpact,
 		type TypedPoolDepths,
 		type SwapCalcResult
 	} from '$lib/pools/swapCalc';
@@ -313,19 +314,51 @@
 	});
 
 	let priceImpactPct = $derived.by(() => {
-		const fromCoin = $SendTxDetails.fromCoin;
-		const fromAmount = $SendTxDetails.fromAmount;
-		if (!swapResult || !fromCoin || !fromAmount || fromAmount === '0') return 0;
-		if (fromPriceUsdRaw <= 0 || toPriceUsdRaw <= 0) return 0;
-		const inputAmt = parseFloat(fromAmount);
-		if (!Number.isFinite(inputAmt) || inputAmt <= 0) return 0;
+		const fromCoinDef = $SendTxDetails.fromCoin;
 		const toCoinDef = $SendTxDetails.toCoin;
-		if (!toCoinDef) return 0;
-		const outputAmt = Number(swapResult.expectedOutput) / 10 ** toCoinDef.coin.decimalPlaces;
-		const inputUsd = inputAmt * fromPriceUsdRaw;
-		const outputUsd = outputAmt * toPriceUsdRaw;
-		if (inputUsd <= 0) return 0;
-		return Math.max(0, ((inputUsd - outputUsd) / inputUsd) * 100);
+		const fromAmount = $SendTxDetails.fromAmount;
+		if (!fromCoinDef || !toCoinDef || !fromAmount || fromAmount === '0') return 0;
+		if (!swapResult || swapResult.expectedOutput <= 0n) return 0;
+		const fromAmountInt = new CoinAmount(fromAmount, fromCoinDef.coin).amount;
+		if (!Number.isFinite(fromAmountInt) || fromAmountInt <= 0) return 0;
+		return calculatePriceImpact(
+			BigInt(fromAmountInt),
+			fromCoinDef.coin.value,
+			toCoinDef.coin.value,
+			hiveHbdPool,
+			btcHbdPool
+		);
+	});
+
+	function formatUsd(amount: number): string {
+		return amount.toLocaleString(undefined, {
+			useGrouping: true,
+			minimumFractionDigits: 2,
+			maximumFractionDigits: 2
+		});
+	}
+
+	let inputAmountUsd = $derived.by(() => {
+		if (fromPriceUsdRaw <= 0) return null;
+		const amt = inputAmount.toNumber();
+		if (!Number.isFinite(amt) || amt <= 0) return null;
+		return amt * fromPriceUsdRaw;
+	});
+
+	let expectedOutputUsd = $derived.by(() => {
+		const toCoinDef = $SendTxDetails.toCoin;
+		if (!swapResult || swapResult.expectedOutput <= 0n || toPriceUsdRaw <= 0 || !toCoinDef) return null;
+		return (Number(swapResult.expectedOutput) / 10 ** toCoinDef.coin.decimalPlaces) * toPriceUsdRaw;
+	});
+
+	/** Exchange fee: 0.25% (Altera) when selling HIVE/HBD for BTC, 0% on BTC→HIVE/HBD, hidden for HIVE↔HBD (TBD) */
+	let exchangeFeePct = $derived.by(() => {
+		const assetOut = $SendTxDetails.toCoin?.coin.value;
+		const assetIn = $SendTxDetails.fromCoin?.coin.value;
+		if (!assetOut || !assetIn) return null;
+		if (assetOut === Coin.btc.value) return 0.25;
+		if (assetIn === Coin.btc.value) return 0;
+		return null; // HIVE↔HBD fee TBD
 	});
 
 	// Pool-based fee calculation — resolve both HIVE/HBD and BTC/HBD
@@ -1241,11 +1274,21 @@
 				>
 			</div>
 			<div class="detail-row">
-				<span class="detail-label">Fee</span>
-				<span class="detail-value">
-					Protocol fee ({swapResult?.hop1Fee ? '0.16%' : '0.08%'})
-				</span>
+				<span class="detail-label">Protocol fee</span>
+				<span class="detail-value">{swapResult?.hop1Fee ? '0.16%' : '0.08%'}</span>
 			</div>
+			{#if exchangeFeePct !== null}
+				<div class="detail-row">
+					<span class="detail-label">Exchange fee <span class="detail-sublabel">(Altera)</span></span>
+					<span
+						class="detail-value"
+						class:detail-free={exchangeFeePct === 0}
+						class:detail-cost={exchangeFeePct > 0}
+					>
+						{exchangeFeePct === 0 ? 'Free' : `${exchangeFeePct}%`}
+					</span>
+				</div>
+			{/if}
 			<div class="detail-row">
 				<span class="detail-label">Route</span>
 				<span class="detail-value route">
@@ -1257,6 +1300,14 @@
 					{$SendTxDetails.toCoin.coin.label}
 				</span>
 			</div>
+			{#if swapResult && swapResult.minAmountOut > 0n && $SendTxDetails.toCoin}
+				{@const toCoinDef = $SendTxDetails.toCoin.coin}
+				{@const minOut = formatFee(swapResult.minAmountOut, toCoinDef.decimalPlaces)}
+				<div class="detail-row">
+					<span class="detail-label">Min amount received</span>
+					<span class="detail-value">{minOut} {toCoinDef.unit}</span>
+				</div>
+			{/if}
 			{#if swapResult && priceImpactPct > 0}
 				<div class="detail-row">
 					<span class="detail-label">Price Impact</span>
@@ -1771,6 +1822,23 @@
 	.detail-value.route {
 		color: #6f6af8;
 		font-weight: 600;
+	}
+	.detail-sublabel {
+		font-size: 0.65rem;
+		opacity: 0.7;
+	}
+	.detail-free {
+		color: var(--dash-accent-green) !important;
+	}
+	.detail-cost {
+		color: #f59e0b !important;
+	}
+	.field-usd-approx {
+		display: block;
+		font-size: 0.7rem;
+		color: var(--dash-text-muted);
+		margin-top: 0.2rem;
+		font-family: 'Noto Sans Mono Variable', monospace;
 	}
 	.impact-pct {
 		font-weight: 600;

--- a/src/lib/cards/QuickSwap.svelte
+++ b/src/lib/cards/QuickSwap.svelte
@@ -51,7 +51,9 @@
 		SWAP_CONTRACT_ID,
 		qualifiesForAlteraFee,
 		ALTERA_FEE_BENEFICIARY,
-		ALTERA_FEE_BPS
+		ALTERA_FEE_BPS,
+		ALTERA_FEE_ACTIVE,
+		getAlteraFeePct
 	} from '$lib/magiTransactions/hive/vscOperations/swap';
 	import { getHiveDepositOp } from '$lib/magiTransactions/hive/vscOperations/deposit';
 	import { executeTx } from '$lib/magiTransactions/hive';
@@ -293,19 +295,13 @@
 			new CoinAmount(1, $SendTxDetails.fromCoin.coin)
 				.convertTo($SendTxDetails.toCoin.coin, Network.lightning)
 				.then((amt) => {
-					fromInTo = amt.toPrettyMinFigs();
+					fromInTo = formatRateAmount(amt);
 				});
 		}
 	});
 
-	let fromPriceUsdRaw = $state(0);
 	let toPriceUsdRaw = $state(0);
 	$effect(() => {
-		if ($SendTxDetails.fromCoin) {
-			new CoinAmount(1, $SendTxDetails.fromCoin.coin)
-				.convertTo(Coin.usd, Network.lightning)
-				.then((amt) => { fromPriceUsdRaw = amt.toNumber(); });
-		}
 		if ($SendTxDetails.toCoin) {
 			new CoinAmount(1, $SendTxDetails.toCoin.coin)
 				.convertTo(Coin.usd, Network.lightning)
@@ -338,27 +334,46 @@
 		});
 	}
 
-	let inputAmountUsd = $derived.by(() => {
-		if (fromPriceUsdRaw <= 0) return null;
-		const amt = inputAmount.toNumber();
-		if (!Number.isFinite(amt) || amt <= 0) return null;
-		return amt * fromPriceUsdRaw;
-	});
+	/**
+	 * Formats a coin amount for the Rate row — always decimal notation, no scientific
+	 * notation, trailing zeros stripped, thousands separator on the integer part only.
+	 *   0.00000079 BTC  (not "7.900e-7 BTC" or "0.00000079000000 BTC")
+	 *   0.07 HBD        (not "0.070 HBD")
+	 *   1,265,822 HIVE
+	 */
+	function formatRateAmount(amt: CoinAmount<Coin>): string {
+		const val = amt.toNumber();
+		if (val === 0) return `0 ${amt.getDisplayUnit()}`;
+		const fixed = val
+			.toFixed(amt.coin.decimalPlaces)
+			.replace(/(\.\d*[1-9])0+$/, '$1')  // strip trailing zeros
+			.replace(/\.0*$/, '');              // strip trailing dot
+		const [intPart, decPart] = fixed.split('.');
+		const formatted = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',') + (decPart ? `.${decPart}` : '');
+		return `${formatted} ${amt.getDisplayUnit()}`;
+	}
 
-	let expectedOutputUsd = $derived.by(() => {
+	let exchangeFeePct = $derived(
+		getAlteraFeePct(
+			$SendTxDetails.fromCoin?.coin.value ?? '',
+			$SendTxDetails.toCoin?.coin.value ?? ''
+		)
+	);
+
+	/**
+	 * Total protocol fee across all hops in USD.
+	 * For two-hop routes (BTC↔HIVE), the intermediate hop fee is denominated in
+	 * HBD (≈ $1 pegged). Final-hop fee is in the output coin.
+	 */
+	let totalProtocolFeeUsd = $derived.by(() => {
 		const toCoinDef = $SendTxDetails.toCoin;
-		if (!swapResult || swapResult.expectedOutput <= 0n || toPriceUsdRaw <= 0 || !toCoinDef) return null;
-		return (Number(swapResult.expectedOutput) / 10 ** toCoinDef.coin.decimalPlaces) * toPriceUsdRaw;
-	});
-
-	/** Exchange fee: 0.25% (Altera) when selling HIVE/HBD for BTC, 0% on BTC→HIVE/HBD, hidden for HIVE↔HBD (TBD) */
-	let exchangeFeePct = $derived.by(() => {
-		const assetOut = $SendTxDetails.toCoin?.coin.value;
-		const assetIn = $SendTxDetails.fromCoin?.coin.value;
-		if (!assetOut || !assetIn) return null;
-		if (assetOut === Coin.btc.value) return 0.25;
-		if (assetIn === Coin.btc.value) return 0;
-		return null; // HIVE↔HBD fee TBD
+		if (!swapResult || toPriceUsdRaw <= 0 || !toCoinDef) return null;
+		const finalHopUsd =
+			(Number(swapResult.baseFee) / 10 ** toCoinDef.coin.decimalPlaces) * toPriceUsdRaw;
+		if (!swapResult.hop1Fee) return finalHopUsd;
+		// hop1 intermediate is always HBD for BTC↔HIVE routes; HBD ≈ $1 pegged
+		const hop1Usd = Number(swapResult.hop1Fee.baseFee) / 10 ** Coin.hbd.decimalPlaces;
+		return hop1Usd + finalHopUsd;
 	});
 
 	// Pool-based fee calculation — resolve both HIVE/HBD and BTC/HBD
@@ -1010,7 +1025,7 @@
 			} else {
 				// EVM reown wallet path (no BTC reown since BTC is
 				// handled above).
-				const feeQualifies = await qualifiesForAlteraFee(
+				const feeQualifies = ALTERA_FEE_ACTIVE && await qualifiesForAlteraFee(
 					amount as CoinAmount<typeof Coin.hive | typeof Coin.hbd | typeof Coin.btc>,
 					toCoinDef as typeof Coin.hive | typeof Coin.hbd | typeof Coin.btc,
 					destinationChain || undefined
@@ -1269,13 +1284,22 @@
 				<span class="detail-label">Rate</span>
 				<span class="detail-value"
 					>{fromInTo
-						? `1 ${$SendTxDetails.fromCoin.coin.label} ≈ ${fromInTo} ${$SendTxDetails.toCoin.coin.label}`
+						? `1 ${$SendTxDetails.fromCoin.coin.label} ≈ ${fromInTo}`
 						: '—'}</span
 				>
 			</div>
 			<div class="detail-row">
-				<span class="detail-label">Protocol fee</span>
-				<span class="detail-value">{swapResult?.hop1Fee ? '0.16%' : '0.08%'}</span>
+				<span class="detail-label">
+					Protocol fee
+					<span class="detail-sublabel">({swapResult?.hop1Fee ? '0.16%' : '0.08%'})</span>
+				</span>
+				<span class="detail-value">
+					{#if totalProtocolFeeUsd !== null}
+						≈ ${formatUsd(totalProtocolFeeUsd)}
+					{:else}
+						—
+					{/if}
+				</span>
 			</div>
 			{#if exchangeFeePct !== null}
 				<div class="detail-row">
@@ -1809,6 +1833,7 @@
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
+		margin-bottom: 1px;
 	}
 	.detail-label {
 		color: var(--dash-text-muted);

--- a/src/lib/cards/QuickSwap.svelte
+++ b/src/lib/cards/QuickSwap.svelte
@@ -305,7 +305,9 @@
 		if ($SendTxDetails.toCoin) {
 			new CoinAmount(1, $SendTxDetails.toCoin.coin)
 				.convertTo(Coin.usd, Network.lightning)
-				.then((amt) => { toPriceUsdRaw = amt.toNumber(); });
+				.then((amt) => {
+					toPriceUsdRaw = amt.toNumber();
+				});
 		}
 	});
 
@@ -346,10 +348,11 @@
 		if (val === 0) return `0 ${amt.getDisplayUnit()}`;
 		const fixed = val
 			.toFixed(amt.coin.decimalPlaces)
-			.replace(/(\.\d*[1-9])0+$/, '$1')  // strip trailing zeros
-			.replace(/\.0*$/, '');              // strip trailing dot
+			.replace(/(\.\d*[1-9])0+$/, '$1') // strip trailing zeros
+			.replace(/\.0*$/, ''); // strip trailing dot
 		const [intPart, decPart] = fixed.split('.');
-		const formatted = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',') + (decPart ? `.${decPart}` : '');
+		const formatted =
+			intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',') + (decPart ? `.${decPart}` : '');
 		return `${formatted} ${amt.getDisplayUnit()}`;
 	}
 
@@ -1025,11 +1028,13 @@
 			} else {
 				// EVM reown wallet path (no BTC reown since BTC is
 				// handled above).
-				const feeQualifies = ALTERA_FEE_ACTIVE && await qualifiesForAlteraFee(
-					amount as CoinAmount<typeof Coin.hive | typeof Coin.hbd | typeof Coin.btc>,
-					toCoinDef as typeof Coin.hive | typeof Coin.hbd | typeof Coin.btc,
-					destinationChain || undefined
-				);
+				const feeQualifies =
+					ALTERA_FEE_ACTIVE &&
+					(await qualifiesForAlteraFee(
+						amount as CoinAmount<typeof Coin.hive | typeof Coin.hbd | typeof Coin.btc>,
+						toCoinDef as typeof Coin.hive | typeof Coin.hbd | typeof Coin.btc,
+						destinationChain || undefined
+					));
 				const storeMin = $SendTxDetails.minAmountOut;
 				// Contract validates min_amount_out AFTER altera deduction,
 				// so scale the store's pre-fee min down by the same bps.
@@ -1251,11 +1256,18 @@
 						inputmode="decimal"
 						placeholder="0.5"
 						bind:value={customSlippageInput}
-						oninput={() => { customSlippageInput = customSlippageInput.replace(',', '.'); }}
+						oninput={() => {
+							customSlippageInput = customSlippageInput.replace(',', '.');
+						}}
 						onblur={applyCustomSlippage}
 						onkeydown={(e) => {
-							if (e.key === 'Enter') { applyCustomSlippage(); e.currentTarget.blur(); }
-							if (e.key === 'Escape') { customSlippageOpen = false; }
+							if (e.key === 'Enter') {
+								applyCustomSlippage();
+								e.currentTarget.blur();
+							}
+							if (e.key === 'Escape') {
+								customSlippageOpen = false;
+							}
 						}}
 					/>
 					<span>%</span>
@@ -1271,7 +1283,9 @@
 							: parseFloat((slippageBps / 100).toFixed(2)).toString();
 					}}
 				>
-					{slippageOptions.includes(slippageBps) ? 'Custom' : `${parseFloat((slippageBps / 100).toFixed(2))}%`}
+					{slippageOptions.includes(slippageBps)
+						? 'Custom'
+						: `${parseFloat((slippageBps / 100).toFixed(2))}%`}
 				</button>
 			{/if}
 		</div>
@@ -1283,9 +1297,7 @@
 			<div class="detail-row">
 				<span class="detail-label">Rate</span>
 				<span class="detail-value"
-					>{fromInTo
-						? `1 ${$SendTxDetails.fromCoin.coin.label} ≈ ${fromInTo}`
-						: '—'}</span
+					>{fromInTo ? `1 ${$SendTxDetails.fromCoin.coin.label} ≈ ${fromInTo}` : '—'}</span
 				>
 			</div>
 			<div class="detail-row">
@@ -1303,7 +1315,9 @@
 			</div>
 			{#if exchangeFeePct !== null}
 				<div class="detail-row">
-					<span class="detail-label">Exchange fee <span class="detail-sublabel">(Altera)</span></span>
+					<span class="detail-label"
+						>Exchange fee <span class="detail-sublabel">(Altera)</span></span
+					>
 					<span
 						class="detail-value"
 						class:detail-free={exchangeFeePct === 0}
@@ -1339,8 +1353,8 @@
 						class="detail-value impact-pct"
 						class:good={priceImpactPct < 2}
 						class:medium={priceImpactPct >= 2 && priceImpactPct < 10}
-						class:bad={priceImpactPct >= 10}
-					>{priceImpactPct.toFixed(2)}%</span>
+						class:bad={priceImpactPct >= 10}>{priceImpactPct.toFixed(2)}%</span
+					>
 				</div>
 			{/if}
 		</div>
@@ -1349,9 +1363,9 @@
 	{#if priceImpactPct >= 10}
 		<p class="swap-status error" class:severe={priceImpactPct >= 15}>
 			{#if priceImpactPct >= 15}
-				⚠ Very high price impact — pool liquidity is low. Try a smaller amount.
+				⚠ Very high price impact. Pool liquidity is low. Try a smaller amount.
 			{:else}
-				⚠ High price impact — consider a smaller amount for better rates.
+				⚠ High price impact. Consider a smaller amount for better rates.
 			{/if}
 		</p>
 	{/if}
@@ -1367,7 +1381,12 @@
 	<!-- Exchange -->
 	<PillButton
 		onclick={requestSwap}
-		disabled={swapLoading || !hasAmount || sameCoinSelected || missingReceiver || exceedsBalance || exceedsPoolDepth}
+		disabled={swapLoading ||
+			!hasAmount ||
+			sameCoinSelected ||
+			missingReceiver ||
+			exceedsBalance ||
+			exceedsPoolDepth}
 		styleType="invert submit"
 	>
 		{swapLoading ? 'Swapping...' : 'Swap'}
@@ -1406,7 +1425,9 @@
 				{#if btcDepositQr}
 					<div class="btc-deposit-qr">
 						<img src={btcDepositQr} alt="Deposit address QR code" width="220" height="220" />
-						<span class="btc-deposit-qr-hint">Scan with a Bitcoin wallet to prefill address &amp; amount</span>
+						<span class="btc-deposit-qr-hint"
+							>Scan with a Bitcoin wallet to prefill address &amp; amount</span
+						>
 					</div>
 				{/if}
 				<div class="btc-deposit-field">
@@ -1867,9 +1888,15 @@
 	}
 	.impact-pct {
 		font-weight: 600;
-		&.good { color: var(--dash-success, #22c55e); }
-		&.medium { color: var(--dash-warning, #f59e0b); }
-		&.bad { color: var(--dash-error, #ef4444); }
+		&.good {
+			color: var(--dash-success, #22c55e);
+		}
+		&.medium {
+			color: var(--dash-warning, #f59e0b);
+		}
+		&.bad {
+			color: var(--dash-error, #ef4444);
+		}
 	}
 
 	.swap-status {

--- a/src/lib/currency/AmountInput.svelte
+++ b/src/lib/currency/AmountInput.svelte
@@ -22,6 +22,7 @@
 		hideUnit = false,
 		borderless = false,
 		hideNetwork = false,
+		hideUsd = false,
 		id = $bindable(''),
 		disabled = false
 	}: {
@@ -36,6 +37,7 @@
 		hideUnit?: boolean;
 		borderless?: boolean;
 		hideNetwork?: boolean;
+		hideUsd?: boolean;
 		id?: string;
 		disabled?: boolean;
 	} = $props();
@@ -147,6 +149,7 @@
 	);
 
 	let showUsd = $derived(
+		!hideUsd &&
 		!(connectedCoinAmount?.coin.value === Coin.usd.value || selected.coin.value === Coin.usd.value)
 	);
 

--- a/src/lib/currency/CoinAmount.ts
+++ b/src/lib/currency/CoinAmount.ts
@@ -12,6 +12,8 @@ export class CoinAmount<C extends Coin> {
 		if (num == '' || Number.isNaN(num)) num = '0';
 		if (typeof num == 'number') {
 			amount = Math.round(num * (preshiftedInt ? 1 : 10 ** coin.decimalPlaces));
+		} else if (preshiftedInt && num.indexOf('.') === -1) {
+			amount = Number.parseInt(num);
 		} else {
 			const decIdx = num.indexOf('.');
 			if (decIdx == -1) {

--- a/src/lib/magiTransactions/hive/vscOperations/swap.ts
+++ b/src/lib/magiTransactions/hive/vscOperations/swap.ts
@@ -8,6 +8,32 @@ import { getCryptoPrices } from '$lib/sendswap/v4v/api-types/cryptoprices';
 export const ALTERA_FEE_BENEFICIARY = 'hive:altera.app';
 export const ALTERA_FEE_BPS = 25;
 export const ALTERA_FEE_USD_THRESHOLD = 0;
+/**
+ * Master switch for the Altera exchange fee.
+ * Set to true to start charging ALTERA_FEE_BPS on qualifying swaps
+ * and show the amber fee badge in the UI.
+ * Set to false → fee is not charged and the UI shows "Free" (green).
+ */
+export const ALTERA_FEE_ACTIVE = false;
+
+/**
+ * Returns the exchange fee percentage to display in the UI for a given swap pair.
+ *
+ * - HIVE/HBD → BTC: ALTERA_FEE_ACTIVE ? ALTERA_FEE_BPS/100 : 0  (amber when >0, green "Free" when 0)
+ * - BTC → HIVE/HBD: always 0  ("Free" — Altera never charges on BTC purchases)
+ * - HIVE ↔ HBD:     null       (row hidden — no Altera fee applies)
+ *
+ * To change the fee rate: update ALTERA_FEE_BPS.
+ * To enable/disable:      flip ALTERA_FEE_ACTIVE.
+ */
+export function getAlteraFeePct(assetIn: string, assetOut: string): number | null {
+	const aIn = assetIn.toLowerCase();
+	const aOut = assetOut.toLowerCase();
+	const effectivePct = ALTERA_FEE_ACTIVE ? ALTERA_FEE_BPS / 100 : 0;
+	if (aOut === 'btc') return effectivePct;
+	if (aIn === 'btc') return 0; // BTC → HIVE/HBD always free
+	return null; // HIVE ↔ HBD — no Altera fee
+}
 
 /**
  * Altera charges a UI usage fee on swaps that leave the Hive/Magi ecosystem
@@ -100,10 +126,11 @@ export async function getHiveSwapOp(
 	const caller = `hive:${username}`;
 	const isNative = assetIn.value === Coin.hive.value || assetIn.value === Coin.hbd.value;
 
-	// TODO (temporary): Restore this after cost investigation. Disabled this way because the refBps
-	// is a check for nil value not a check for  0
+	// Gated by ALTERA_FEE_ACTIVE — set that to true (and restore the real call below)
+	// to re-enable. Note: refBps is a nil check on the contract, not a zero check,
+	// so we cannot disable by setting BPS to 0; we must omit the field entirely.
 	// const feeQualifies = await qualifiesForAlteraFee(amount, assetOut, destinationChain);
-	const feeQualifies = false;
+	const feeQualifies = ALTERA_FEE_ACTIVE && await qualifiesForAlteraFee(amount, assetOut, destinationChain);
 	// Contract validates min_amount_out AFTER the referral/altera deduction.
 	// Scale the caller's pre-fee min down by the same bps so slippage
 	// tolerance is measured against what the user actually receives.

--- a/src/lib/pools/swapCalc.test.ts
+++ b/src/lib/pools/swapCalc.test.ts
@@ -15,6 +15,7 @@ import {
 	calculateTwoHopSwap,
 	getOrderedDepthsFor,
 	checkExceedsPoolDepth,
+	calculatePriceImpact,
 	type TypedPoolDepths
 } from './swapCalc';
 
@@ -220,5 +221,132 @@ describe('calculateTwoHopSwap', () => {
 		expect(r0.minAmountOut).toBe(r0.expectedOutput);
 		// slippage=100 (1%) → minAmountOut = expectedOutput * 99%
 		expect(r100.minAmountOut).toBe((r100.expectedOutput * 9900n) / 10000n);
+	});
+});
+
+// ─── calculatePriceImpact ─────────────────────────────────────────────────────
+//
+// Pool fixtures (from the top of this file):
+//   hiveHbdPool: X_HIVE = 2,221,000 units, X_HBD = 2,221,000 units
+//   btcHbdPool:  X_BTC  = 3,340 sats,      X_HBD = 3,340,000 units
+//
+// Hand-computed expected values for each case are shown inline.
+
+describe('calculatePriceImpact', () => {
+	it('returns 0 for zero input', () => {
+		expect(calculatePriceImpact(0n, 'hive', 'hbd', hiveHbdPool, btcHbdPool)).toBe(0);
+	});
+
+	it('returns 0 when pool is null', () => {
+		expect(calculatePriceImpact(1_000n, 'hive', 'hbd', null, btcHbdPool)).toBe(0);
+		expect(calculatePriceImpact(100n, 'btc', 'hbd', hiveHbdPool, null)).toBe(0);
+		expect(calculatePriceImpact(1_000n, 'hive', 'btc', null, btcHbdPool)).toBe(0);
+		expect(calculatePriceImpact(1_000n, 'hive', 'btc', hiveHbdPool, null)).toBe(0);
+	});
+
+	it('result is always in [0, 100] range', () => {
+		const cases: Array<[bigint, string, string]> = [
+			[300n,     'hive', 'hbd'],   // tiny HIVE→HBD
+			[1_000n,   'hive', 'hbd'],   // 1 HIVE
+			[100_000n, 'hive', 'hbd'],   // 100 HIVE
+			[1n,       'btc',  'hbd'],   // 1 sat
+			[100n,     'btc',  'hbd'],   // 100 sat
+			[300n,     'hive', 'btc'],   // tiny HIVE→BTC two-hop
+			[100_000n, 'hive', 'btc'],   // 100 HIVE→BTC two-hop
+			[50n,      'btc',  'hive'],  // 50 sat→HIVE two-hop
+		];
+		for (const [x, aIn, aOut] of cases) {
+			const pct = calculatePriceImpact(x, aIn, aOut, hiveHbdPool, btcHbdPool);
+			expect(pct, `${x} ${aIn}→${aOut}`).toBeGreaterThanOrEqual(0);
+			expect(pct, `${x} ${aIn}→${aOut}`).toBeLessThanOrEqual(100);
+		}
+	});
+
+	// ── HIVE ↔ HBD single-hop ──
+
+	it('tiny HIVE trade ($0.06 ≈ 0.3 HIVE = 300 units) has near-zero impact', () => {
+		// impact = 300 / (2,221,000 + 300) = 300 / 2,221,300 ≈ 0.0135%
+		const pct = calculatePriceImpact(300n, 'hive', 'hbd', hiveHbdPool, btcHbdPool);
+		expect(pct).toBeLessThan(0.05);
+		expect(pct).toBeGreaterThanOrEqual(0);
+	});
+
+	it('1 HIVE (1,000 units) has near-zero impact', () => {
+		// impact = 1,000 / (2,221,000 + 1,000) = 1,000 / 2,222,000 ≈ 0.045%
+		const pct = calculatePriceImpact(1_000n, 'hive', 'hbd', hiveHbdPool, btcHbdPool);
+		expect(pct).toBeCloseTo(0.045, 2);
+	});
+
+	it('100 HIVE (100,000 units) has ~4.3% impact on this pool', () => {
+		// impact = 100,000 / (2,221,000 + 100,000) = 100,000 / 2,321,000 ≈ 4.31%
+		const pct = calculatePriceImpact(100_000n, 'hive', 'hbd', hiveHbdPool, btcHbdPool);
+		expect(pct).toBeCloseTo(4.31, 1);
+	});
+
+	it('impact scales proportionally for HBD→HIVE (symmetric pool)', () => {
+		// Same pool, symmetric reserves → same impact formula
+		const hiveIn = calculatePriceImpact(10_000n, 'hive', 'hbd', hiveHbdPool, btcHbdPool);
+		const hbdIn  = calculatePriceImpact(10_000n, 'hbd',  'hive', hiveHbdPool, btcHbdPool);
+		expect(hiveIn).toBeCloseTo(hbdIn, 5); // identical since reserves are equal
+	});
+
+	// ── BTC ↔ HBD single-hop ──
+
+	it('1 sat BTC→HBD has tiny impact', () => {
+		// impact = 1 / (3,340 + 1) = 1 / 3,341 ≈ 0.030%
+		const pct = calculatePriceImpact(1n, 'btc', 'hbd', hiveHbdPool, btcHbdPool);
+		expect(pct).toBeCloseTo(0.030, 2);
+	});
+
+	it('100 sat BTC→HBD reflects shallow pool depth', () => {
+		// impact = 100 / (3,340 + 100) = 100 / 3,440 ≈ 2.91%
+		// NOTE: this pool has only 3,340 sat of BTC — shallow is expected
+		const pct = calculatePriceImpact(100n, 'btc', 'hbd', hiveHbdPool, btcHbdPool);
+		expect(pct).toBeCloseTo(2.91, 1);
+	});
+
+	it('HBD→BTC: 1,000 mHBD (1.000 HBD) has small impact', () => {
+		// impact = 1,000 / (3,340,000 + 1,000) = 1,000 / 3,341,000 ≈ 0.030%
+		const pct = calculatePriceImpact(1_000n, 'hbd', 'btc', hiveHbdPool, btcHbdPool);
+		expect(pct).toBeCloseTo(0.030, 2);
+	});
+
+	// ── BTC ↔ HIVE two-hop ──
+
+	it('tiny HIVE→BTC two-hop (300 units ≈ 0.3 HIVE) shows near-zero impact', () => {
+		// hop1: x=300, X_hive=2,221,000 → impact1 = 300/2,221,300 ≈ 0.0135%
+		//   hop1Out ≈ 300 * 2,221,000 / 2,221,300 ≈ 299.96 HBD units
+		// hop2: x=299.96, X_hbd=3,340,000 → impact2 ≈ 299.96/3,340,299 ≈ 0.00898%
+		// combined ≈ 0.0225%
+		const pct = calculatePriceImpact(300n, 'hive', 'btc', hiveHbdPool, btcHbdPool);
+		expect(pct).toBeLessThan(0.1);
+		expect(pct).toBeGreaterThanOrEqual(0);
+	});
+
+	it('50 sat BTC→HIVE two-hop has small impact', () => {
+		// hop1: x=50, X_btc=3,340 → impact1 = 50/3,390 ≈ 1.475%
+		//   hop1Out ≈ 50 * 3,340,000 / 3,390 ≈ 49,261 HBD units
+		// hop2: x=49,261, X_hbd=2,221,000 → impact2 = 49,261/2,270,261 ≈ 2.17%
+		// combined = 1 - (1-0.01475)*(1-0.0217) ≈ 3.62%
+		const pct = calculatePriceImpact(50n, 'btc', 'hive', hiveHbdPool, btcHbdPool);
+		expect(pct).toBeGreaterThan(0);
+		expect(pct).toBeLessThan(10);
+	});
+
+	it('impact increases monotonically with trade size', () => {
+		const sizes = [100n, 1_000n, 10_000n, 100_000n];
+		let prev = -1;
+		for (const x of sizes) {
+			const pct = calculatePriceImpact(x, 'hive', 'hbd', hiveHbdPool, btcHbdPool);
+			expect(pct).toBeGreaterThan(prev);
+			prev = pct;
+		}
+	});
+
+	it('two-hop impact is higher than either single-hop alone for same input', () => {
+		// HIVE→BTC via HBD should have more impact than just HIVE→HBD alone
+		const twoHop   = calculatePriceImpact(100_000n, 'hive', 'btc', hiveHbdPool, btcHbdPool);
+		const singleH  = calculatePriceImpact(100_000n, 'hive', 'hbd', hiveHbdPool, btcHbdPool);
+		expect(twoHop).toBeGreaterThan(singleH);
 	});
 });

--- a/src/lib/pools/swapCalc.test.ts
+++ b/src/lib/pools/swapCalc.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for swapCalc.ts — pure math functions only (no network calls).
+ *
+ * Pool sizes use realistic approximations of mainnet reserves at the time
+ * the pool-depth cap was introduced:
+ *   HIVE/HBD pool: ~2,221,000 mHIVE : ~2,221,000 mHBD  (equal-value sides)
+ *   BTC/HBD pool:  ~1,670 sat       : ~1,670,000 mHBD
+ *
+ * All amounts are in smallest units (3 dp for HIVE/HBD → ×1000, 8 dp for BTC → ×1e8).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	calculateSwap,
+	calculateTwoHopSwap,
+	getOrderedDepthsFor,
+	checkExceedsPoolDepth,
+	type TypedPoolDepths
+} from './swapCalc';
+
+// ─── Realistic pool fixtures ──────────────────────────────────────────────────
+
+/** HIVE/HBD pool: reserve0=HIVE, reserve1=HBD (smallest units, 3 dp) */
+const hiveHbdPool: TypedPoolDepths = {
+	contractId: 'vs41q9c3yetfkv8xssdqtuy9jq3g25f3tjzsy82m4',
+	asset0: 'hive',
+	asset1: 'hbd',
+	reserve0: 2_221_000n, // 2,221.000 HIVE
+	reserve1: 2_221_000n  // 2,221.000 HBD (1:1 peg for simplicity)
+};
+
+/** BTC/HBD pool: reserve0=BTC (satoshis, 8 dp), reserve1=HBD (3 dp) */
+const btcHbdPool: TypedPoolDepths = {
+	contractId: 'vs41q9c3yetfkv8xssdqtuy9jq3g25f3tjzsy82m4b',
+	asset0: 'btc',
+	asset1: 'hbd',
+	reserve0: 3_340n,       // 0.00003340 BTC ≈ $3,340 at $100k/BTC
+	reserve1: 3_340_000n    // 3,340.000 HBD ≈ $3,340
+};
+
+// ─── getOrderedDepthsFor ──────────────────────────────────────────────────────
+
+describe('getOrderedDepthsFor', () => {
+	it('returns X=reserve0, Y=reserve1 when assetIn matches asset0', () => {
+		const d = getOrderedDepthsFor(hiveHbdPool, 'hive');
+		expect(d).toEqual({ X: 2_221_000n, Y: 2_221_000n });
+	});
+
+	it('returns X=reserve1, Y=reserve0 when assetIn matches asset1', () => {
+		const d = getOrderedDepthsFor(hiveHbdPool, 'hbd');
+		expect(d).toEqual({ X: 2_221_000n, Y: 2_221_000n });
+	});
+
+	it('is case-insensitive', () => {
+		expect(getOrderedDepthsFor(hiveHbdPool, 'HIVE')).toEqual({ X: 2_221_000n, Y: 2_221_000n });
+		expect(getOrderedDepthsFor(btcHbdPool, 'BTC')).toEqual({ X: 3_340n, Y: 3_340_000n });
+	});
+
+	it('returns null when assetIn is not in pool', () => {
+		expect(getOrderedDepthsFor(hiveHbdPool, 'btc')).toBeNull();
+		expect(getOrderedDepthsFor(btcHbdPool, 'hive')).toBeNull();
+	});
+});
+
+// ─── calculateSwap ───────────────────────────────────────────────────────────
+
+describe('calculateSwap', () => {
+	it('returns zeros for zero input', () => {
+		const r = calculateSwap(0n, 1_000_000n, 1_000_000n, 100);
+		expect(r.expectedOutput).toBe(0n);
+		expect(r.minAmountOut).toBe(0n);
+	});
+
+	it('returns zeros for zero reserves', () => {
+		const r = calculateSwap(1000n, 0n, 1_000_000n, 100);
+		expect(r.expectedOutput).toBe(0n);
+	});
+
+	it('small trade on deep pool has low price impact', () => {
+		// 10 HIVE (10,000 units) into a 2,221 HIVE pool → ~0.45% of reserve
+		const r = calculateSwap(10_000n, 2_221_000n, 2_221_000n, 100);
+		expect(r.expectedOutput).toBeGreaterThan(0n);
+		// grossOut ≈ 9,955 mHBD; after fees should be >9,900 mHBD
+		expect(r.expectedOutput).toBeGreaterThan(9_900n);
+	});
+
+	it('large trade near 50% cap has very high CLP fee', () => {
+		// 1,110 HIVE (1,110,000 units) = exactly 50% of reserve
+		const r50pct = calculateSwap(1_110_000n, 2_221_000n, 2_221_000n, 100);
+		// 10 HIVE trade for reference
+		const rSmall = calculateSwap(10_000n, 2_221_000n, 2_221_000n, 100);
+
+		// At 50%, CLP fee should dominate — effective rate much worse
+		const rate50 = Number(r50pct.expectedOutput) / 1_110_000;
+		const rateSmall = Number(rSmall.expectedOutput) / 10_000;
+		expect(rate50).toBeLessThan(rateSmall * 0.7); // at least 30% worse rate
+	});
+
+	it('applies slippage correctly to minAmountOut', () => {
+		const r = calculateSwap(10_000n, 2_221_000n, 2_221_000n, 100); // 1% slippage
+		const expected = (r.expectedOutput * 9900n) / 10000n;
+		expect(r.minAmountOut).toBe(expected);
+	});
+
+	it('minAmountOut ≤ expectedOutput always', () => {
+		const r = calculateSwap(10_000n, 2_221_000n, 2_221_000n, 200);
+		expect(r.minAmountOut).toBeLessThanOrEqual(r.expectedOutput);
+	});
+});
+
+// ─── checkExceedsPoolDepth ────────────────────────────────────────────────────
+
+describe('checkExceedsPoolDepth', () => {
+	// ── Single-hop: HIVE → HBD ──
+
+	it('returns false for zero input', () => {
+		expect(checkExceedsPoolDepth(0n, 'hive', 'hbd', hiveHbdPool, btcHbdPool)).toBe(false);
+	});
+
+	it('returns false when input is exactly 50% of reserve (boundary)', () => {
+		// x * 2 === X  →  NOT strictly greater, should pass
+		const halfReserve = 2_221_000n / 2n; // 1,110,500 — floor of half
+		expect(checkExceedsPoolDepth(halfReserve, 'hive', 'hbd', hiveHbdPool, null)).toBe(false);
+	});
+
+	it('returns true when input is just over 50% of reserve', () => {
+		// reserve = 2,221,000 → half = 1,110,500 → one unit over
+		const justOver = 2_221_000n / 2n + 1n;
+		expect(checkExceedsPoolDepth(justOver, 'hive', 'hbd', hiveHbdPool, null)).toBe(true);
+	});
+
+	it('returns true for clearly excessive HIVE amount', () => {
+		// 3,000 HIVE (3,000,000 units) >> 2,221 HIVE reserve
+		expect(checkExceedsPoolDepth(3_000_000n, 'hive', 'hbd', hiveHbdPool, btcHbdPool)).toBe(true);
+	});
+
+	it('returns false for a reasonable HIVE→HBD trade', () => {
+		// 100 HIVE = ~4.5% of reserve — fine
+		expect(checkExceedsPoolDepth(100_000n, 'hive', 'hbd', hiveHbdPool, btcHbdPool)).toBe(false);
+	});
+
+	it('returns false when pool not loaded (null)', () => {
+		expect(checkExceedsPoolDepth(3_000_000n, 'hive', 'hbd', null, btcHbdPool)).toBe(false);
+	});
+
+	// ── Single-hop: HBD → HIVE ──
+
+	it('works symmetrically for HBD→HIVE', () => {
+		const justOver = 2_221_000n / 2n + 1n;
+		expect(checkExceedsPoolDepth(justOver, 'hbd', 'hive', hiveHbdPool, null)).toBe(true);
+	});
+
+	// ── Single-hop: BTC ↔ HBD ──
+
+	it('returns true for BTC→HBD exceeding btcHbdPool input reserve', () => {
+		// BTC reserve = 3,340 sat; just over half = 1,671 sat
+		expect(checkExceedsPoolDepth(1_671n, 'btc', 'hbd', hiveHbdPool, btcHbdPool)).toBe(true);
+	});
+
+	it('returns false for small BTC→HBD trade', () => {
+		// 100 sat = ~3% of btc reserve
+		expect(checkExceedsPoolDepth(100n, 'btc', 'hbd', hiveHbdPool, btcHbdPool)).toBe(false);
+	});
+
+	it('returns true for HBD→BTC exceeding btcHbdPool HBD reserve', () => {
+		// HBD reserve = 3,340,000; just over half = 1,670,001
+		expect(checkExceedsPoolDepth(1_670_001n, 'hbd', 'btc', hiveHbdPool, btcHbdPool)).toBe(true);
+	});
+
+	// ── Two-hop: BTC ↔ HIVE ──
+
+	it('returns true for large BTC→HIVE when BTC input exceeds btcHbd reserve', () => {
+		// 2,000 sat >> 1,670 (half of 3,340 btc reserve)
+		expect(checkExceedsPoolDepth(2_000n, 'btc', 'hive', hiveHbdPool, btcHbdPool)).toBe(true);
+	});
+
+	it('returns false for small BTC→HIVE trade on both hops', () => {
+		// 50 sat → hop1 gives ~50,000 mHBD intermediate; hbd pool has 3,340,000 mHBD → fine
+		expect(checkExceedsPoolDepth(50n, 'btc', 'hive', hiveHbdPool, btcHbdPool)).toBe(false);
+	});
+
+	it('returns false for small HIVE→BTC trade', () => {
+		// 100 HIVE (100,000 units) into 2,221,000 reserve → ~4.5% — fine
+		expect(checkExceedsPoolDepth(100_000n, 'hive', 'btc', hiveHbdPool, btcHbdPool)).toBe(false);
+	});
+
+	it('returns false when one pool is null for two-hop route', () => {
+		expect(checkExceedsPoolDepth(3_000_000n, 'hive', 'btc', null, btcHbdPool)).toBe(false);
+		expect(checkExceedsPoolDepth(3_000_000n, 'hive', 'btc', hiveHbdPool, null)).toBe(false);
+	});
+});
+
+// ─── calculateTwoHopSwap ─────────────────────────────────────────────────────
+
+describe('calculateTwoHopSwap', () => {
+	it('produces a hop1Fee for two-hop routes', () => {
+		// 50 sat BTC → HIVE via HBD
+		const r = calculateTwoHopSwap(50n, btcHbdPool, hiveHbdPool, 'btc', 'hbd', 'hive', 100);
+		expect(r.hop1Fee).toBeDefined();
+		expect(r.hop1Fee!.asset).toBe('hbd');
+		expect(r.hop1Fee!.totalFee).toBeGreaterThan(0n);
+	});
+
+	it('returns zero output for excessive input (> 50% reserve)', () => {
+		// 3,000 sat >> 3,340 BTC reserve — hop1 gross output will drain pool
+		const r = calculateTwoHopSwap(3_000n, btcHbdPool, hiveHbdPool, 'btc', 'hbd', 'hive', 100);
+		// Output may be 0 or near-0 since grossOut - fees < 0
+		expect(r.expectedOutput).toBeGreaterThanOrEqual(0n);
+	});
+
+	it('minAmountOut ≤ expectedOutput', () => {
+		const r = calculateTwoHopSwap(50n, btcHbdPool, hiveHbdPool, 'btc', 'hbd', 'hive', 200);
+		expect(r.minAmountOut).toBeLessThanOrEqual(r.expectedOutput);
+	});
+
+	it('applies slippage only to final output', () => {
+		const r100 = calculateTwoHopSwap(50n, btcHbdPool, hiveHbdPool, 'btc', 'hbd', 'hive', 100);
+		const r0 = calculateTwoHopSwap(50n, btcHbdPool, hiveHbdPool, 'btc', 'hbd', 'hive', 0);
+		// slippage=0 → minAmountOut == expectedOutput
+		expect(r0.minAmountOut).toBe(r0.expectedOutput);
+		// slippage=100 (1%) → minAmountOut = expectedOutput * 99%
+		expect(r100.minAmountOut).toBe((r100.expectedOutput * 9900n) / 10000n);
+	});
+});

--- a/src/lib/pools/swapCalc.ts
+++ b/src/lib/pools/swapCalc.ts
@@ -316,6 +316,58 @@ export async function fetchTypedPoolDepths(
 }
 
 /**
+ * Returns true when the input amount `x` would be rejected on-chain because
+ * it exceeds 50 % of the input-side reserve in one or both hops.
+ *
+ * The contract hard-rejects any swap where the input is greater than half the
+ * pool's input reserve (i.e. `x * 2 > X`). For two-hop routes we also check
+ * the intermediate output against the second pool's input reserve.
+ *
+ * All amounts are in smallest units. Asset names are lowercase strings.
+ */
+export function checkExceedsPoolDepth(
+	x: bigint,
+	assetIn: string,
+	assetOut: string,
+	hiveHbdPool: TypedPoolDepths | null,
+	btcHbdPool: TypedPoolDepths | null
+): boolean {
+	if (x <= 0n) return false;
+
+	const aIn = assetIn.toLowerCase();
+	const aOut = assetOut.toLowerCase();
+	const involvesBtc = aIn === 'btc' || aOut === 'btc';
+
+	if (!involvesBtc) {
+		// Single-hop: HIVE ↔ HBD
+		if (!hiveHbdPool) return false;
+		const d = getOrderedDepthsFor(hiveHbdPool, aIn);
+		return !!d && x * 2n > d.X;
+	}
+
+	if ((aIn === 'btc' && aOut === 'hbd') || (aIn === 'hbd' && aOut === 'btc')) {
+		// Single-hop: BTC ↔ HBD
+		if (!btcHbdPool) return false;
+		const d = getOrderedDepthsFor(btcHbdPool, aIn);
+		return !!d && x * 2n > d.X;
+	}
+
+	// Two-hop: BTC ↔ HIVE via HBD
+	if (!btcHbdPool || !hiveHbdPool) return false;
+	const pool1 = aIn === 'btc' ? btcHbdPool : hiveHbdPool;
+	const pool2 = aIn === 'btc' ? hiveHbdPool : btcHbdPool;
+	const d1 = getOrderedDepthsFor(pool1, aIn);
+	if (!d1) return false;
+	// Check hop1 input against pool1 input reserve
+	if (x * 2n > d1.X) return true;
+	// Estimate intermediate output (net of fees) and check against pool2 input reserve
+	const d2 = getOrderedDepthsFor(pool2, 'hbd');
+	if (!d2) return false;
+	const hop1Out = calculateSwap(x, d1.X, d1.Y, 0).expectedOutput;
+	return hop1Out * 2n > d2.X;
+}
+
+/**
  * Execute a two-hop swap calc: input → hopAsset (in pool1) →
  * output (in pool2). Fees accumulate from both hops. Slippage is
  * applied only to the FINAL output, which matches the router's

--- a/src/lib/pools/swapCalc.ts
+++ b/src/lib/pools/swapCalc.ts
@@ -316,6 +316,60 @@ export async function fetchTypedPoolDepths(
 }
 
 /**
+ * AMM-based price impact in percent (0–100) using the constant-product
+ * formula  impact = x / (X + x)  where X is the pool's input-side reserve
+ * and x is the trade size. Both must be in the same smallest-unit base.
+ *
+ * For two-hop routes (BTC ↔ HIVE via HBD) the impacts compound:
+ *   combined = 1 - (1 - impact1) × (1 - impact2)
+ *
+ * Returns 0 when any required pool data is missing.
+ */
+export function calculatePriceImpact(
+	x: bigint,
+	assetIn: string,
+	assetOut: string,
+	hiveHbdPool: TypedPoolDepths | null,
+	btcHbdPool: TypedPoolDepths | null
+): number {
+	if (x <= 0n) return 0;
+	const aIn = assetIn.toLowerCase();
+	const aOut = assetOut.toLowerCase();
+	const involvesBtc = aIn === 'btc' || aOut === 'btc';
+
+	if (!involvesBtc) {
+		// Single-hop: HIVE ↔ HBD
+		if (!hiveHbdPool) return 0;
+		const d = getOrderedDepthsFor(hiveHbdPool, aIn);
+		if (!d || d.X <= 0n) return 0;
+		// Use floating-point division — reserves are far below Number.MAX_SAFE_INTEGER
+		return (Number(x) / Number(d.X + x)) * 100;
+	}
+
+	if ((aIn === 'btc' && aOut === 'hbd') || (aIn === 'hbd' && aOut === 'btc')) {
+		// Single-hop: BTC ↔ HBD
+		if (!btcHbdPool) return 0;
+		const d = getOrderedDepthsFor(btcHbdPool, aIn);
+		if (!d || d.X <= 0n) return 0;
+		return (Number(x) / Number(d.X + x)) * 100;
+	}
+
+	// Two-hop: BTC ↔ HIVE via HBD
+	if (!btcHbdPool || !hiveHbdPool) return 0;
+	const pool1 = aIn === 'btc' ? btcHbdPool : hiveHbdPool;
+	const pool2 = aIn === 'btc' ? hiveHbdPool : btcHbdPool;
+	const d1 = getOrderedDepthsFor(pool1, aIn);
+	const d2 = getOrderedDepthsFor(pool2, 'hbd');
+	if (!d1 || !d2 || d1.X <= 0n || d2.X <= 0n) return 0;
+	const impact1 = Number(x) / Number(d1.X + x);
+	// Estimate intermediate grossOut (pre-fee) for sizing the second hop
+	const hop1Out = (x * d1.Y) / (d1.X + x);
+	if (hop1Out <= 0n) return 0;
+	const impact2 = Number(hop1Out) / Number(d2.X + hop1Out);
+	return (1 - (1 - impact1) * (1 - impact2)) * 100;
+}
+
+/**
  * Returns true when the input amount `x` would be rejected on-chain because
  * it exceeds 50 % of the input-side reserve in one or both hops.
  *

--- a/src/lib/sendswap/stages/ReviewSwap.svelte
+++ b/src/lib/sendswap/stages/ReviewSwap.svelte
@@ -339,6 +339,30 @@
 			swapFeeInUsd = hop1Usd ? hop2Usd.add(hop1Usd) : hop2Usd;
 		});
 	});
+	// USD equivalent of the expected output amount.
+	let outputInUsd = $state<CoinAmount<Coin>>();
+	$effect(() => {
+		const amt = convertedToAmount;
+		if (!amt) { outputInUsd = undefined; return; }
+		amt.convertTo(Coin.usd, Network.lightning).then((usd) => { outputInUsd = usd; });
+	});
+
+	// USD equivalent of the min-amount-out (after Altera fee deduction if applicable).
+	let minAmountInUsd = $state<CoinAmount<Coin>>();
+	$effect(() => {
+		const minRaw = $SendTxDetails.minAmountOut;
+		if (!minRaw || !$SendTxDetails.toCoin) { minAmountInUsd = undefined; return; }
+		const minNet = alteraFeeApplies
+			? Math.floor((Number(minRaw) * (10000 - ALTERA_FEE_BPS)) / 10000)
+			: Number(minRaw);
+		new CoinAmount(minNet, toCoin, true)
+			.convertTo(Coin.usd, Network.lightning)
+			.then((usd) => { minAmountInUsd = usd; });
+	});
+
+	// Whether this is a two-hop swap (determines fee label %).
+	const isTwoHopSwap = $derived(!!$SendTxDetails.swapHop1Fee);
+
 	let today = moment().format('MMM D, YYYY');
 
 	const senderAddress = $derived(
@@ -409,29 +433,32 @@
 							<td class="sm-caption label">Fee</td>
 							<td class="content">
 								{#if $SendTxDetails.swapTotalFee && $SendTxDetails.toCoin}
-									{#if $SendTxDetails.swapHop1Fee}
-										{@const hopCoin =
-											$SendTxDetails.swapHop1Fee.asset === Coin.hbd.value
-												? Coin.hbd
-												: $SendTxDetails.swapHop1Fee.asset === Coin.hive.value
-													? Coin.hive
-													: Coin.btc}
-										{prettyWithDisplayUnit(
-											new CoinAmount(Number($SendTxDetails.swapHop1Fee.totalFee), hopCoin, true)
-										)}
-										and
-										{prettyWithDisplayUnit(
-											new CoinAmount(Number($SendTxDetails.swapTotalFee), toCoin, true)
-										)}
-									{:else}
-										{prettyWithDisplayUnit(
-											new CoinAmount(Number($SendTxDetails.swapTotalFee), toCoin, true)
-										)}
-									{/if}
-									{#if swapFeeInUsd}
-										<EqualApproximately size={16} />
-										{swapFeeInUsd.toPrettyString()}
-									{/if}
+									{@const hop1 = $SendTxDetails.swapHop1Fee}
+									{@const hop1Coin = hop1
+										? hop1.asset === Coin.hbd.value
+											? Coin.hbd
+											: hop1.asset === Coin.hive.value
+												? Coin.hive
+												: Coin.btc
+										: null}
+									<div class="swap-fee-detail">
+										<span class="fee-protocol-label">
+											Protocol fee ({isTwoHopSwap ? '0.16%' : '0.08%'})
+										</span>
+										<span class="fee-amounts-line">
+											{#if hop1 && hop1Coin}
+												{prettyWithDisplayUnit(new CoinAmount(Number(hop1.totalFee), hop1Coin, true))}
+												+
+												{prettyWithDisplayUnit(new CoinAmount(Number($SendTxDetails.swapTotalFee), toCoin, true))}
+											{:else}
+												{prettyWithDisplayUnit(new CoinAmount(Number($SendTxDetails.swapTotalFee), toCoin, true))}
+											{/if}
+											{#if swapFeeInUsd}
+												<EqualApproximately size={14} />
+												{swapFeeInUsd.toPrettyString()}
+											{/if}
+										</span>
+									</div>
 								{:else if $SendTxDetails.method?.value === TransferMethod.magiTransfer.value}
 									No fee
 								{:else if !$SendTxDetails.fee || !feeInUsd}
@@ -498,6 +525,10 @@
 										)}
 									{:else}
 										{prettyWithDisplayUnit(new CoinAmount(netToAmount, toCoin, true))}
+										{#if outputInUsd}
+											<EqualApproximately size={16} />
+											{outputInUsd.toPrettyString()}
+										{/if}
 									{/if}
 								</td>
 							</tr>
@@ -527,6 +558,10 @@
 												)}
 											{:else}
 												Min. {prettyWithDisplayUnit(new CoinAmount(minRaw, toCoin, true))}
+												{#if minAmountInUsd}
+													<EqualApproximately size={16} />
+													{minAmountInUsd.toPrettyString()}
+												{/if}
 											{/if}
 										{:else}
 											—
@@ -601,6 +636,10 @@
 		display: flex;
 		flex-direction: column;
 		gap: 1.5rem;
+		/* Ensure the dialog is wide enough on medium+ screens so values
+		   don't wrap onto a second line. max-content dialog sizing means
+		   this sets the effective minimum dialog width. */
+		min-width: clamp(22rem, 88vw, 36rem);
 	}
 	.line-positioner {
 		position: relative;
@@ -653,6 +692,8 @@
 		flex-basis: 0;
 		flex-grow: 1;
 		grid-area: area-content;
+		flex-wrap: wrap;
+		gap: 0.25rem;
 		:global(.lucide-equal-approximately) {
 			min-width: 16px;
 		}
@@ -661,6 +702,24 @@
 		height: 20px;
 		display: flex;
 		align-items: center;
+	}
+	.swap-fee-detail {
+		display: flex;
+		flex-direction: column;
+		gap: 0.125rem;
+	}
+	.fee-protocol-label {
+		color: var(--dash-text-secondary);
+		font-size: var(--text-xs);
+	}
+	.fee-amounts-line {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+		flex-wrap: wrap;
+		:global(.lucide-equal-approximately) {
+			min-width: 14px;
+		}
 	}
 	li {
 		display: flex;

--- a/src/lib/sendswap/stages/ReviewSwap.svelte
+++ b/src/lib/sendswap/stages/ReviewSwap.svelte
@@ -20,7 +20,8 @@
 	} from '$lib/magiTransactions/bitcoin/btcFeeEstimate';
 	import {
 		ALTERA_FEE_BPS,
-		ALTERA_FEE_USD_THRESHOLD
+		ALTERA_FEE_USD_THRESHOLD,
+		getAlteraFeePct
 	} from '$lib/magiTransactions/hive/vscOperations/swap';
 
 	const auth = $derived(getAuth()());
@@ -373,12 +374,7 @@
 		isBtcSwap ? 'About 10 minutes' : ($SendTxDetails.method?.length ?? '')
 	);
 
-	/** Exchange fee: 0.25% (Altera) when selling HIVE/HBD for BTC, 0% on BTC→HIVE/HBD, null otherwise */
-	const exchangeFeePct = $derived.by(() => {
-		if (toCoin.value === Coin.btc.value) return 0.25;
-		if (fromCoin.value === Coin.btc.value) return 0;
-		return null;
-	});
+	const exchangeFeePct = $derived(getAlteraFeePct(fromCoin.value, toCoin.value));
 </script>
 
 {#snippet reviewContent()}
@@ -438,16 +434,10 @@
 											Protocol fee ({isTwoHopSwap ? '0.16%' : '0.08%'})
 										</span>
 										<span class="fee-amounts-line">
-											{#if hop1 && hop1Coin}
-												{prettyWithDisplayUnit(new CoinAmount(Number(hop1.totalFee), hop1Coin, true))}
-												+
-												{prettyWithDisplayUnit(new CoinAmount(Number($SendTxDetails.swapTotalFee), toCoin, true))}
-											{:else}
-												{prettyWithDisplayUnit(new CoinAmount(Number($SendTxDetails.swapTotalFee), toCoin, true))}
-											{/if}
 											{#if swapFeeInUsd}
-												<EqualApproximately size={14} />
-												{swapFeeInUsd.toPrettyString()}
+												≈ {swapFeeInUsd.toPrettyString()}
+											{:else}
+												—
 											{/if}
 										</span>
 									</div>

--- a/src/lib/sendswap/stages/ReviewSwap.svelte
+++ b/src/lib/sendswap/stages/ReviewSwap.svelte
@@ -236,12 +236,8 @@
 		if (!$SendTxDetails.fromCoin || !$SendTxDetails.toCoin) return;
 
 		// Prefer the pool-math effective rate (expectedOutput / input)
-		// over the lightning off-chain reference rate. Otherwise the
-		// Market Rate row and the To row disagree whenever the pool is
-		// not at the lightning price — user sees "1 X = 0.06 Y" with
-		// "To 0.642 Y" for a 10 X input and it looks like broken math.
-		// Fees are output-denominated now, so the full entered amount
-		// is what goes into the pool.
+		// over the lightning off-chain reference rate. Fees are
+		// output-denominated, so the full entered amount goes into the pool.
 		const expectedRaw = $SendTxDetails.expectedOutput;
 		if (expectedRaw && expectedRaw !== '0') {
 			const expected = Number(expectedRaw);
@@ -376,6 +372,13 @@
 	const settlementTime = $derived(
 		isBtcSwap ? 'About 10 minutes' : ($SendTxDetails.method?.length ?? '')
 	);
+
+	/** Exchange fee: 0.25% (Altera) when selling HIVE/HBD for BTC, 0% on BTC→HIVE/HBD, null otherwise */
+	const exchangeFeePct = $derived.by(() => {
+		if (toCoin.value === Coin.btc.value) return 0.25;
+		if (fromCoin.value === Coin.btc.value) return 0;
+		return null;
+	});
 </script>
 
 {#snippet reviewContent()}
@@ -417,17 +420,6 @@
 								{inUsd?.toPrettyString()}
 							</td>
 						</tr>
-						{#if $SendTxDetails.fromCoin?.coin !== $SendTxDetails.toCoin?.coin}
-							<tr>
-								<td class="icon"><Dot size="32" /></td>
-								<td class="sm-caption label">Market Rate</td>
-								<td class="content">
-									{prettyMinFigsWithDisplayUnit(new CoinAmount(1, fromCoin))}
-									<EqualApproximately size="16" />
-									{fromInTo ? prettyWithDisplayUnit(fromInTo) : ''}
-								</td>
-							</tr>
-						{/if}
 						<tr>
 							<td class="icon"><Dot size="32" /></td>
 							<td class="sm-caption label">Fee</td>
@@ -470,6 +462,15 @@
 								{/if}
 							</td>
 						</tr>
+						{#if exchangeFeePct !== null}
+							<tr>
+								<td class="icon"><Dot size="32" /></td>
+								<td class="sm-caption label">Exchange Fee (Altera)</td>
+								<td class="content" class:fee-free={exchangeFeePct === 0} class:fee-cost={exchangeFeePct > 0}>
+									{exchangeFeePct === 0 ? 'Free' : `${exchangeFeePct}%`}
+								</td>
+							</tr>
+						{/if}
 						{#if $SendTxDetails.toCoin && $SendTxDetails.toNetwork}
 							{@const rawTo = convertedToAmount ?? new CoinAmount(effectiveToAmount, toCoin)}
 							{@const netToAmount = Math.max(0, rawTo.amount - (alteraFeeAmount?.amount ?? 0))}
@@ -535,11 +536,7 @@
 							{#if $SendTxDetails.slippageBps != null}
 								<tr>
 									<td class="icon"><Dot size="32" /></td>
-									<td class="sm-caption label"
-										>Slippage ({($SendTxDetails.slippageBps / 100).toFixed(
-											$SendTxDetails.slippageBps % 100 === 0 ? 0 : 1
-										)}%)</td
-									>
+									<td class="sm-caption label">Min amount received</td>
 									<td class="content">
 										{#if $SendTxDetails.minAmountOut && $SendTxDetails.toCoin}
 											{@const minRaw = alteraFeeApplies
@@ -548,7 +545,7 @@
 													)
 												: Number($SendTxDetails.minAmountOut)}
 											{#if btcFeeEstimate}
-												Min. ~{prettyRangeWithDisplayUnit(
+												~{prettyRangeWithDisplayUnit(
 													new CoinAmount(
 														Math.max(0, minRaw - btcFeeEstimate.maxSats),
 														toCoin,
@@ -557,7 +554,7 @@
 													new CoinAmount(Math.max(0, minRaw - btcFeeEstimate.minSats), toCoin, true)
 												)}
 											{:else}
-												Min. {prettyWithDisplayUnit(new CoinAmount(minRaw, toCoin, true))}
+												{prettyWithDisplayUnit(new CoinAmount(minRaw, toCoin, true))}
 												{#if minAmountInUsd}
 													<EqualApproximately size={16} />
 													{minAmountInUsd.toPrettyString()}
@@ -686,6 +683,12 @@
 	}
 	.label {
 		grid-area: area-label;
+	}
+	.fee-free {
+		color: var(--dash-accent-green) !important;
+	}
+	.fee-cost {
+		color: #f59e0b !important;
 	}
 	.content {
 		line-height: 1.2;

--- a/src/lib/sendswap/stages/SwapOptions.svelte
+++ b/src/lib/sendswap/stages/SwapOptions.svelte
@@ -49,10 +49,9 @@
 		fetchTypedPoolDepths,
 		getOrderedDepthsFor,
 		calculateTwoHopSwap,
+		checkExceedsPoolDepth,
 		type TypedPoolDepths,
 		calculateSwap,
-		getOrderedDepths,
-		type PoolDepths,
 		type SwapCalcResult
 	} from '$lib/pools/swapCalc';
 	import CoinNetworkIcon from '$lib/currency/CoinNetworkIcon.svelte';
@@ -88,12 +87,6 @@
 			]);
 			if (hiveHbd) hiveHbdPool = hiveHbd;
 			if (btcHbd) btcHbdPool = btcHbd;
-			// Keep the legacy `poolDepths` populated from the HIVE/HBD
-			// pool so downstream code paths that still read it (e.g.
-			// any fallback UI) stay consistent.
-			if (hiveHbd) {
-				poolDepths = { reserve0: hiveHbd.reserve0, reserve1: hiveHbd.reserve1 };
-			}
 		})();
 	});
 	onDestroy(() => {
@@ -101,7 +94,6 @@
 	});
 
 	// Pool depths and swap calculation state
-	let poolDepths: PoolDepths | null = $state(null);
 	let hiveHbdPool = $state<TypedPoolDepths | null>(null);
 	let btcHbdPool = $state<TypedPoolDepths | null>(null);
 	let swapResult: SwapCalcResult | null = $state(null);
@@ -297,6 +289,26 @@
 		});
 	}
 
+	function formatUsd(amount: number): string {
+		return amount.toLocaleString(numberFormatLanguage, {
+			useGrouping: true,
+			minimumFractionDigits: 2,
+			maximumFractionDigits: 2
+		});
+	}
+
+	let expectedOutputUsd = $derived.by(() => {
+		const toCoinDef = $SendTxDetails.toCoin;
+		if (!swapResult || swapResult.expectedOutput <= 0n || toPriceUsdRaw <= 0 || !toCoinDef) return null;
+		return (Number(swapResult.expectedOutput) / 10 ** toCoinDef.coin.decimalPlaces) * toPriceUsdRaw;
+	});
+
+	let minAmountOutUsd = $derived.by(() => {
+		const toCoinDef = $SendTxDetails.toCoin;
+		if (!swapResult || swapResult.minAmountOut <= 0n || toPriceUsdRaw <= 0 || !toCoinDef) return null;
+		return (Number(swapResult.minAmountOut) / 10 ** toCoinDef.coin.decimalPlaces) * toPriceUsdRaw;
+	});
+
 	const auth = $derived(getAuth()());
 
 	// ── Destination state (from SwapDestination) ──
@@ -389,10 +401,35 @@
 		return true;
 	});
 
+	/**
+	 * True when the input amount exceeds 50% of the relevant pool's input-side
+	 * reserve. The contract hard-caps swaps at this threshold; any transaction
+	 * beyond it will be rejected on-chain, so we block submission here.
+	 * For two-hop routes we check both pools: the direct input vs pool1, and
+	 * the estimated intermediate amount vs pool2's input reserve.
+	 */
+	let exceedsPoolDepth = $derived.by(() => {
+		const fromCoin = $SendTxDetails.fromCoin;
+		const toCoin = $SendTxDetails.toCoin;
+		const fromAmount = $SendTxDetails.fromAmount;
+		if (!fromCoin || !toCoin || !fromAmount || fromAmount === '0') return false;
+
+		const fromAmountInt = new CoinAmount(fromAmount, fromCoin.coin).amount;
+		if (!Number.isFinite(fromAmountInt) || fromAmountInt <= 0) return false;
+
+		return checkExceedsPoolDepth(
+			BigInt(fromAmountInt),
+			fromCoin.coin.value,
+			toCoin.coin.value,
+			hiveHbdPool,
+			btcHbdPool
+		);
+	});
+
 	// Combined: enable button when swap fields valid, destination valid, not same coin, and has balance
 	$effect(() => {
 		if (!isActive) return;
-		editStage(swapFieldsValid && destValid && !sameCoinError && !insufficientBalance);
+		editStage(swapFieldsValid && destValid && !sameCoinError && !insufficientBalance && !exceedsPoolDepth);
 	});
 
 	let { assetOptions, networkOptions } = $state<ReturnType<typeof solveNetworkConstraints>>({
@@ -1029,6 +1066,13 @@
 					<span class="error">Insufficient {coinDisplayLabel($SendTxDetails.fromCoin.coin)} balance. You don't have enough funds for this swap.</span>
 				</div>
 			{/if}
+
+			<!-- Pool depth cap error -->
+			{#if exceedsPoolDepth && !sameCoinError && !insufficientBalance}
+				<div class="same-coin-error">
+					<span class="error">Amount exceeds 50% of pool depth — the swap will fail on-chain. Reduce the amount to continue.</span>
+				</div>
+			{/if}
 		</div>
 
 	</div>
@@ -1234,13 +1278,19 @@
 					<div class="fee-details">
 						<div class="fee-row">
 							<span class="fee-label">Expected Output</span>
-							<span class="fee-value"
-								>{formatSmallUnits(swapResult.expectedOutput, toDec)} {toUnit}</span
-							>
+							<span class="fee-value fee-value-stack">
+								<span>{formatSmallUnits(swapResult.expectedOutput, toDec)} {toUnit}</span>
+								{#if expectedOutputUsd !== null}
+									<span class="usd-approx">≈ ${formatUsd(expectedOutputUsd)}</span>
+								{/if}
+							</span>
 						</div>
-						<!-- Base Fee (0.08% of gross output at each pool) -->
+						<!-- Base fee: 0.08% per pool (0.16% total for two-hop routes) -->
 						<div class="fee-row">
-							<span class="fee-label">Base Fee <span class="fee-sublabel">(0.08%)</span></span>
+							<span class="fee-label">
+								Base Fee
+								<span class="fee-sublabel">({swapResult.hop1Fee ? '0.16%' : '0.08%'})</span>
+							</span>
 							{#if swapResult.hop1Fee && hop1FeeCoin}
 								<span class="fee-value fee-value-stack">
 									<span>{formatSmallUnits(swapResult.hop1Fee.baseFee, hop1FeeCoin.decimalPlaces)} {coinDisplayLabel(hop1FeeCoin)}</span>
@@ -1250,34 +1300,14 @@
 								<span class="fee-value">{formatSmallUnits(swapResult.baseFee, toDec)} {toUnit}</span>
 							{/if}
 						</div>
-						<!-- CLP Fee (quadratic, grows with trade size relative to pool depth) -->
-						<div class="fee-row">
-							<span class="fee-label">CLP Fee <span class="fee-sublabel">(liquidity)</span></span>
-							{#if swapResult.hop1Fee && hop1FeeCoin}
-								<span class="fee-value fee-value-stack">
-									<span>{formatSmallUnits(swapResult.hop1Fee.clpFee, hop1FeeCoin.decimalPlaces)} {coinDisplayLabel(hop1FeeCoin)}</span>
-									<span>{formatSmallUnits(swapResult.clpFee, toDec)} {toUnit}</span>
-								</span>
-							{:else}
-								<span class="fee-value">{formatSmallUnits(swapResult.clpFee, toDec)} {toUnit}</span>
-							{/if}
-						</div>
-						<div class="fee-row highlight">
-							<span class="fee-label">Total Fee</span>
-							{#if swapResult.hop1Fee && hop1FeeCoin}
-								<span class="fee-value fee-value-stack">
-									<span>{formatSmallUnits(swapResult.hop1Fee.totalFee, hop1FeeCoin.decimalPlaces)} {coinDisplayLabel(hop1FeeCoin)}</span>
-									<span>{formatSmallUnits(swapResult.totalFee, toDec)} {toUnit}</span>
-								</span>
-							{:else}
-								<span class="fee-value">{formatSmallUnits(swapResult.totalFee, toDec)} {toUnit}</span>
-							{/if}
-						</div>
 						<div class="fee-row">
 							<span class="fee-label">Min. Amount Out</span>
-							<span class="fee-value"
-								>{formatSmallUnits(swapResult.minAmountOut, toDec)} {toUnit}</span
-							>
+							<span class="fee-value fee-value-stack">
+								<span>{formatSmallUnits(swapResult.minAmountOut, toDec)} {toUnit}</span>
+								{#if minAmountOutUsd !== null}
+									<span class="usd-approx">≈ ${formatUsd(minAmountOutUsd)}</span>
+								{/if}
+							</span>
 						</div>
 					</div>
 				{/if}
@@ -1433,6 +1463,7 @@
 		flex-direction: column;
 		gap: 16px;
 		min-width: 0;
+		padding-bottom: 16px;
 	}
 
 	/* ── Quick Swap Card ── */
@@ -1638,7 +1669,6 @@
 
 	/* ── Fees Section (collapsible) ── */
 	.swap-fees {
-		margin-top: 0.375rem;
 		display: flex;
 		flex-direction: column;
 		border: 1px solid var(--dash-card-border);
@@ -1674,13 +1704,6 @@
 		align-items: baseline;
 		gap: 0.75rem;
 		padding: 0.125rem 0;
-		&.highlight {
-			padding-top: 0.375rem;
-			margin-top: 0.125rem;
-			border-top: 1px solid var(--dash-card-border);
-			font-weight: 500;
-			align-items: start;
-		}
 	}
 	.fee-label {
 		color: var(--dash-text-muted);
@@ -1704,6 +1727,10 @@
 		align-items: flex-end;
 		gap: 0.125rem;
 		span { white-space: nowrap; }
+	}
+	.usd-approx {
+		font-size: var(--text-xs);
+		color: var(--dash-text-muted);
 	}
 	.slippage-options {
 		display: flex;

--- a/src/lib/sendswap/stages/SwapOptions.svelte
+++ b/src/lib/sendswap/stages/SwapOptions.svelte
@@ -23,9 +23,9 @@
 		ArrowUpDown,
 		ArrowUpRight,
 		ChevronDown,
-		ChevronUp,
 		Search,
 		Send,
+		TriangleAlert,
 		Wallet,
 		X
 	} from '@lucide/svelte';
@@ -109,6 +109,41 @@
 	const slippageOptions = [50, 100, 200, 300]; // 0.5%, 1%, 2%, 3%
 	let customSlippageOpen = $state(false);
 	let customSlippageInput = $state('');
+	let customSlippageInputEl: HTMLInputElement | null = $state(null);
+
+	// Auto-focus the custom input when it opens and pre-select the text.
+	$effect(() => {
+		if (customSlippageOpen && customSlippageInputEl) {
+			customSlippageInputEl.focus();
+			customSlippageInputEl.select();
+		}
+	});
+
+	// Whether the raw custom input is syntactically invalid (for red border).
+	let customSlippageInvalid = $derived.by(() => {
+		if (!customSlippageInput.trim()) return false;
+		const v = parseFloat(customSlippageInput.replace(',', '.'));
+		return isNaN(v) || v <= 0 || v > 99.99;
+	});
+
+	function applyCustomSlippage() {
+		const raw = customSlippageInput.replace(',', '.').trim();
+		if (!raw) {
+			customSlippageOpen = false;
+			return;
+		}
+		let v = parseFloat(raw);
+		if (isNaN(v) || v <= 0) {
+			customSlippageOpen = false;
+			return;
+		}
+		v = Math.min(Math.max(v, 0.01), 99.99);
+		// Round to at most 2 decimal places and strip trailing zeroes.
+		customSlippageInput = parseFloat(v.toFixed(2)).toString();
+		slippageBps = Math.round(v * 100);
+		// Collapse back to pill — shows as active button with the custom value.
+		customSlippageOpen = false;
+	}
 
 	// Mirror slippage into the shared store regardless of pair. The
 	// calculate-swap effect below only runs for HIVE↔HBD pairs, so for
@@ -545,11 +580,14 @@
 	let fromInUsd = $state('');
 	let fromInTo = $state('');
 	let toInUsd = $state('');
+	let fromPriceUsdRaw = $state(0);
+	let toPriceUsdRaw = $state(0);
 	$effect(() => {
 		if ($SendTxDetails.fromCoin) {
 			const oneFrom = new CoinAmount(1, $SendTxDetails.fromCoin.coin);
 			oneFrom.convertTo(Coin.usd, Network.lightning).then((amt) => {
 				fromInUsd = amt.toPrettyMinFigs();
+				fromPriceUsdRaw = amt.toNumber();
 			});
 			if ($SendTxDetails.toCoin) {
 				oneFrom.convertTo($SendTxDetails.toCoin.coin, Network.lightning).then((amt) => {
@@ -562,6 +600,7 @@
 				.convertTo(Coin.usd, Network.lightning)
 				.then((amt) => {
 					toInUsd = amt.toPrettyMinFigs();
+					toPriceUsdRaw = amt.toNumber();
 				});
 		}
 	});
@@ -651,7 +690,6 @@
 		return new CoinAmount(bal, from.coin, true);
 	});
 
-	let feesExpanded = $state(false);
 
 	let dialogOpen = $state(false);
 	let toggle = $state<(open?: boolean) => void>(() => {});
@@ -751,6 +789,24 @@
 	}
 
 	let toCoin = $derived($SendTxDetails.toCoin?.coin ?? Coin.unk);
+
+	/** Estimated price impact in percent (0–100). Compares the USD value of
+	 *  `expectedOutput` against the USD value of the input using cached spot
+	 *  prices. Returns 0 when prices aren't loaded yet or no swap is active. */
+	let priceImpactPct = $derived.by(() => {
+		const fromCoinDef = $SendTxDetails.fromCoin;
+		const toCoinDef = $SendTxDetails.toCoin;
+		const fromAmount = $SendTxDetails.fromAmount;
+		if (!swapResult || swapResult.expectedOutput <= 0n) return 0;
+		if (!fromCoinDef || !toCoinDef || !fromAmount || fromAmount === '0') return 0;
+		if (fromPriceUsdRaw <= 0 || toPriceUsdRaw <= 0) return 0;
+		const inputAmt = new CoinAmount(fromAmount, fromCoinDef.coin).toNumber();
+		const inputUsd = inputAmt * fromPriceUsdRaw;
+		if (inputUsd <= 0) return 0;
+		const outputAmt = Number(swapResult.expectedOutput) / 10 ** toCoinDef.coin.decimalPlaces;
+		const outputUsd = outputAmt * toPriceUsdRaw;
+		return Math.max(0, ((inputUsd - outputUsd) / inputUsd) * 100);
+	});
 </script>
 
 {#snippet percentArrow(percent: number)}
@@ -1094,6 +1150,21 @@
 							: null)
 				: null}
 			<div class="swap-fees">
+				<!-- Always visible: price impact summary row -->
+				<div class="fees-impact-row">
+					<span class="fee-label">Price Impact</span>
+					{#if swapResult && priceImpactPct > 0}
+						<span
+							class="impact-pct"
+							class:good={priceImpactPct < 2}
+							class:medium={priceImpactPct >= 2 && priceImpactPct < 10}
+							class:bad={priceImpactPct >= 10}
+						>{priceImpactPct.toFixed(2)}%</span>
+					{:else}
+						<span class="impact-pct-empty">—</span>
+					{/if}
+				</div>
+
 				<!-- Always visible: slippage + toggle header -->
 				<div class="fees-header">
 					<span class="fee-label">Slippage Tolerance</span>
@@ -1108,55 +1179,58 @@
 								</button>
 							{/each}
 							{#if customSlippageOpen}
-								<div class="custom-slippage">
+								<div class="custom-slippage" class:invalid={customSlippageInvalid}>
 									<input
+										bind:this={customSlippageInputEl}
 										type="text"
 										inputmode="decimal"
-										placeholder="e.g. 5"
+										placeholder="0.5"
 										bind:value={customSlippageInput}
 										oninput={() => {
+											// Normalise decimal separator only — validate on commit.
 											customSlippageInput = customSlippageInput.replace(',', '.');
-											let v = parseFloat(customSlippageInput);
-											if (isNaN(v)) return;
-											if (v < 0.01) v = 0.01;
-											if (v > 99.99) v = 99.99;
-											slippageBps = Math.round(v * 100);
+										}}
+										onblur={applyCustomSlippage}
+										onkeydown={(e) => {
+											if (e.key === 'Enter') { applyCustomSlippage(); e.currentTarget.blur(); }
+											if (e.key === 'Escape') { customSlippageOpen = false; }
 										}}
 									/>
-									<span>%</span>
+									<span class="custom-slippage-unit">%</span>
 								</div>
 							{:else}
 								<button
 									class={{ active: !slippageOptions.includes(slippageBps) }}
 									onclick={() => {
 										customSlippageOpen = true;
-										customSlippageInput = (slippageBps / 100).toFixed(1);
+										customSlippageInput = slippageOptions.includes(slippageBps)
+											? ''
+											: parseFloat((slippageBps / 100).toFixed(2)).toString();
 									}}
 								>
-									{slippageOptions.includes(slippageBps) ? 'Custom' : `${(slippageBps / 100).toFixed(1)}%`}
+									{slippageOptions.includes(slippageBps) ? 'Custom' : `${parseFloat((slippageBps / 100).toFixed(2))}%`}
 								</button>
 							{/if}
 						</div>
-						{#if swapResult}
-							<button
-								class="fees-toggle-btn"
-								onclick={() => {
-									feesExpanded = !feesExpanded;
-								}}
-								aria-label="Toggle fee details"
-							>
-								{#if feesExpanded}
-									<ChevronUp size={16} />
-								{:else}
-									<ChevronDown size={16} />
-								{/if}
-							</button>
-						{/if}
 					</div>
 				</div>
 
-				<!-- Expandable fee details (HIVE↔HBD only for now) -->
-				{#if swapResult && feesExpanded}
+				<!-- Text warning for severe impact only (badge handles < 15%) -->
+				{#if priceImpactPct >= 10}
+					<div class="impact-warning" class:severe={priceImpactPct >= 15}>
+						<TriangleAlert size={14} />
+						<span>
+							{#if priceImpactPct >= 15}
+								Very high price impact — pool liquidity is low for this trade size. Try a smaller amount.
+							{:else}
+								High price impact — consider using a smaller amount for better rates.
+							{/if}
+						</span>
+					</div>
+				{/if}
+
+				<!-- Fee breakdown — always visible when a swap is calculated -->
+				{#if swapResult}
 					<div class="fee-details">
 						<div class="fee-row">
 							<span class="fee-label">Expected Output</span>
@@ -1164,21 +1238,9 @@
 								>{formatSmallUnits(swapResult.expectedOutput, toDec)} {toUnit}</span
 							>
 						</div>
-						<div class="fee-row">
-							<span class="fee-label">Base Fee (0.08%)</span>
-							<span class="fee-value"
-								>{formatSmallUnits(swapResult.baseFee, toDec)} {toUnit}</span
-							>
-						</div>
-						<div class="fee-row">
-							<span class="fee-label">CLP Fee</span>
-							<span class="fee-value"
-								>{formatSmallUnits(swapResult.clpFee, toDec)} {toUnit}</span
-							>
-						</div>
 						{#if swapResult.hop1Fee && hop1FeeCoin}
 							<div class="fee-row">
-								<span class="fee-label">Hop Fee ({coinDisplayLabel(hop1FeeCoin)})</span>
+								<span class="fee-label">Pool Fee ({fromUnit} → {coinDisplayLabel(hop1FeeCoin)})</span>
 								<span class="fee-value"
 									>{formatSmallUnits(
 										swapResult.hop1Fee.totalFee,
@@ -1186,20 +1248,30 @@
 									)} {coinDisplayLabel(hop1FeeCoin)}</span
 								>
 							</div>
+							<div class="fee-row">
+								<span class="fee-label">Pool Fee ({coinDisplayLabel(hop1FeeCoin)} → {toUnit})</span>
+								<span class="fee-value"
+									>{formatSmallUnits(swapResult.totalFee, toDec)} {toUnit}</span
+								>
+							</div>
+						{:else}
+							<div class="fee-row">
+								<span class="fee-label">Pool Fee</span>
+								<span class="fee-value"
+									>{formatSmallUnits(swapResult.totalFee, toDec)} {toUnit}</span
+								>
+							</div>
 						{/if}
 						<div class="fee-row highlight">
 							<span class="fee-label">Total Fee</span>
-							<span class="fee-value">
-								{#if swapResult.hop1Fee && hop1FeeCoin}
-									{formatSmallUnits(
-										swapResult.hop1Fee.totalFee,
-										hop1FeeCoin.decimalPlaces
-									)} {coinDisplayLabel(hop1FeeCoin)}
-									and {formatSmallUnits(swapResult.totalFee, toDec)} {toUnit}
-								{:else}
-									{formatSmallUnits(swapResult.totalFee, toDec)} {toUnit}
-								{/if}
-							</span>
+							{#if swapResult.hop1Fee && hop1FeeCoin}
+								<span class="fee-value fee-value-stack">
+									<span>{formatSmallUnits(swapResult.hop1Fee.totalFee, hop1FeeCoin.decimalPlaces)} {coinDisplayLabel(hop1FeeCoin)}</span>
+									<span>{formatSmallUnits(swapResult.totalFee, toDec)} {toUnit}</span>
+								</span>
+							{:else}
+								<span class="fee-value">{formatSmallUnits(swapResult.totalFee, toDec)} {toUnit}</span>
+							{/if}
 						</div>
 						<div class="fee-row">
 							<span class="fee-label">Min. Amount Out</span>
@@ -1580,29 +1652,13 @@
 		align-items: center;
 		gap: 0.5rem;
 		padding: 0.75rem 1rem;
+		flex-wrap: wrap;
 	}
 	.fees-header-right {
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;
-	}
-	.fees-toggle-btn {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		background: none;
-		border: none;
-		color: var(--dash-text-muted);
-		cursor: pointer;
-		padding: 0.25rem;
-		border-radius: 0.25rem;
-		transition:
-			color 0.15s ease,
-			background-color 0.15s ease;
-		&:hover {
-			color: var(--dash-text-primary);
-			background-color: var(--dash-card-border);
-		}
+		flex-wrap: wrap;
 	}
 	.fee-details {
 		display: flex;
@@ -1613,15 +1669,17 @@
 		padding-top: 0.75rem;
 	}
 	.fee-row {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
+		display: grid;
+		grid-template-columns: 1fr auto;
+		align-items: baseline;
+		gap: 0.75rem;
 		padding: 0.125rem 0;
 		&.highlight {
 			padding-top: 0.375rem;
 			margin-top: 0.125rem;
 			border-top: 1px solid var(--dash-card-border);
 			font-weight: 500;
+			align-items: start;
 		}
 	}
 	.fee-label {
@@ -1633,9 +1691,19 @@
 		font-weight: 400;
 		font-size: var(--text-sm);
 		color: var(--dash-text-primary);
+		text-align: right;
+		white-space: nowrap;
+	}
+	.fee-value-stack {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		gap: 0.125rem;
+		span { white-space: nowrap; }
 	}
 	.slippage-options {
 		display: flex;
+		flex-wrap: wrap;
 		gap: 0.25rem;
 		align-items: center;
 		button {
@@ -1663,30 +1731,35 @@
 	.custom-slippage {
 		display: flex;
 		align-items: center;
-		gap: 0.2rem;
+		gap: 0.25rem;
+		padding: 0.25rem 0.5rem;
 		border: 1px solid var(--dash-accent-purple);
 		border-radius: 12px;
-		padding: 0.15rem 0.4rem;
-		background: transparent;
+		background: rgba(111, 106, 248, 0.1);
+		transition: border-color 0.15s ease;
+		&.invalid {
+			border-color: var(--dash-accent-red);
+			background: rgba(239, 68, 68, 0.08);
+		}
 		input {
-			width: 3rem;
+			width: 2.5rem;
 			border: none;
 			background: transparent;
 			color: var(--dash-text-primary);
+			font: inherit;
 			font-size: var(--text-xs);
-			font-weight: 500;
+			font-weight: 600;
 			outline: none;
-			text-align: right;
+			text-align: center;
 			-moz-appearance: textfield;
+			&::placeholder { color: var(--dash-text-muted); font-weight: 400; }
 			&::-webkit-inner-spin-button,
-			&::-webkit-outer-spin-button {
-				-webkit-appearance: none;
-				margin: 0;
-			}
+			&::-webkit-outer-spin-button { -webkit-appearance: none; margin: 0; }
 		}
-		span {
+		.custom-slippage-unit {
 			font-size: var(--text-xs);
-			color: var(--dash-text-muted);
+			font-weight: 600;
+			color: var(--dash-accent-purple);
 		}
 	}
 
@@ -2140,6 +2213,42 @@
 		}
 	}
 
+	/* ── Price Impact Summary Row ── */
+	.fees-impact-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 0.625rem 1rem 0;
+	}
+	.impact-pct {
+		font-family: 'Noto Sans Mono Variable', monospace;
+		font-size: var(--text-sm);
+		font-weight: 600;
+		&.good   { color: var(--dash-accent-green); }
+		&.medium { color: #d97706; }
+		&.bad    { color: var(--dash-accent-red); }
+	}
+	.impact-pct-empty {
+		font-family: 'Noto Sans Mono Variable', monospace;
+		font-size: var(--text-sm);
+		color: var(--dash-text-muted);
+	}
+
+	/* ── Price Impact Warning ── */
+	.impact-warning {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.5rem 1rem;
+		border-top: 1px solid var(--dash-card-border);
+		color: #d97706; /* amber-600 */
+		font-size: var(--text-sm);
+		:global(svg) { flex-shrink: 0; }
+		&.severe {
+			color: var(--dash-accent-red);
+		}
+	}
+
 	/* ── Status & Waiting ── */
 	.status-wrapper {
 		max-width: 72rem;
@@ -2226,6 +2335,20 @@
 			margin-top: 15%;
 			margin-left: 1rem;
 			margin-right: 1rem;
+		}
+		/* Slippage: label on first line, pills on second line */
+		.fees-header {
+			flex-direction: column;
+			align-items: flex-start;
+			gap: 0.5rem;
+			padding: 0.625rem 0.875rem;
+		}
+		.fees-header-right {
+			width: 100%;
+		}
+		.slippage-options {
+			width: 100%;
+			justify-content: flex-start;
 		}
 	}
 </style>

--- a/src/lib/sendswap/stages/SwapOptions.svelte
+++ b/src/lib/sendswap/stages/SwapOptions.svelte
@@ -60,6 +60,7 @@
 	import { browser } from '$app/environment';
 	import { validate as validateBtcAddr, Network as BtcNetwork } from 'bitcoin-address-validation';
 	import { isVscTestnet } from '../../../client';
+	import { getAlteraFeePct } from '$lib/magiTransactions/hive/vscOperations/swap';
 
 	let {
 		editStage,
@@ -319,14 +320,27 @@
 		return amt * fromPriceUsdRaw;
 	});
 
-	/** Exchange fee: 0.25% (Altera) when selling HIVE/HBD for BTC, 0% on BTC→HIVE/HBD */
-	let exchangeFeePct = $derived.by(() => {
-		const assetOut = $SendTxDetails.toCoin?.coin.value;
-		const assetIn = $SendTxDetails.fromCoin?.coin.value;
-		if (!assetOut || !assetIn) return null;
-		if (assetOut === Coin.btc.value) return 0.25;
-		if (assetIn === Coin.btc.value) return 0;
-		return null; // HIVE↔HBD fee TBD
+	let exchangeFeePct = $derived(
+		getAlteraFeePct(
+			$SendTxDetails.fromCoin?.coin.value ?? '',
+			$SendTxDetails.toCoin?.coin.value ?? ''
+		)
+	);
+
+	/**
+	 * Total protocol fee across all hops in USD.
+	 * For two-hop routes (BTC↔HIVE), the intermediate hop fee is denominated in
+	 * HBD (≈ $1 pegged). Final-hop fee is in the output coin.
+	 */
+	let totalProtocolFeeUsd = $derived.by(() => {
+		const toCoinDef = $SendTxDetails.toCoin;
+		if (!swapResult || toPriceUsdRaw <= 0 || !toCoinDef) return null;
+		const finalHopUsd =
+			(Number(swapResult.baseFee) / 10 ** toCoinDef.coin.decimalPlaces) * toPriceUsdRaw;
+		if (!swapResult.hop1Fee) return finalHopUsd;
+		// hop1 intermediate is always HBD for BTC↔HIVE routes; HBD ≈ $1 pegged
+		const hop1Usd = Number(swapResult.hop1Fee.baseFee) / 10 ** Coin.hbd.decimalPlaces;
+		return hop1Usd + finalHopUsd;
 	});
 
 	const auth = $derived(getAuth()());
@@ -635,7 +649,6 @@
 	});
 
 	let fromInUsd = $state('');
-	let fromInTo = $state('');
 	let toInUsd = $state('');
 	let fromPriceUsdRaw = $state(0);
 	let toPriceUsdRaw = $state(0);
@@ -646,11 +659,6 @@
 				fromInUsd = amt.toPrettyMinFigs();
 				fromPriceUsdRaw = amt.toNumber();
 			});
-			if ($SendTxDetails.toCoin) {
-				oneFrom.convertTo($SendTxDetails.toCoin.coin, Network.lightning).then((amt) => {
-					fromInTo = amt.toPrettyMinFigs();
-				});
-			}
 		}
 		if ($SendTxDetails.toCoin) {
 			new CoinAmount(1, $SendTxDetails.toCoin.coin)
@@ -1311,20 +1319,19 @@
 								{/if}
 							</span>
 						</div>
-						<!-- Base fee: 0.08% per pool (0.16% total for two-hop routes) -->
+						<!-- Protocol fee: 0.08% per pool (0.16% total for two-hop routes) -->
 						<div class="fee-row">
 							<span class="fee-label">
-								Base Fee
+								Protocol Fee
 								<span class="fee-sublabel">({swapResult.hop1Fee ? '0.16%' : '0.08%'})</span>
 							</span>
-							{#if swapResult.hop1Fee && hop1FeeCoin}
-								<span class="fee-value fee-value-stack">
-									<span>{formatSmallUnits(swapResult.hop1Fee.baseFee, hop1FeeCoin.decimalPlaces)} {coinDisplayLabel(hop1FeeCoin)}</span>
-									<span>{formatSmallUnits(swapResult.baseFee, toDec)} {toUnit}</span>
-								</span>
-							{:else}
-								<span class="fee-value">{formatSmallUnits(swapResult.baseFee, toDec)} {toUnit}</span>
-							{/if}
+							<span class="fee-value">
+								{#if totalProtocolFeeUsd !== null}
+									≈ ${formatUsd(totalProtocolFeeUsd)}
+								{:else}
+									—
+								{/if}
+							</span>
 						</div>
 						{#if exchangeFeePct !== null}
 							<div class="fee-row">

--- a/src/lib/sendswap/stages/SwapOptions.svelte
+++ b/src/lib/sendswap/stages/SwapOptions.svelte
@@ -50,6 +50,7 @@
 		getOrderedDepthsFor,
 		calculateTwoHopSwap,
 		checkExceedsPoolDepth,
+		calculatePriceImpact,
 		type TypedPoolDepths,
 		calculateSwap,
 		type SwapCalcResult
@@ -307,6 +308,25 @@
 		const toCoinDef = $SendTxDetails.toCoin;
 		if (!swapResult || swapResult.minAmountOut <= 0n || toPriceUsdRaw <= 0 || !toCoinDef) return null;
 		return (Number(swapResult.minAmountOut) / 10 ** toCoinDef.coin.decimalPlaces) * toPriceUsdRaw;
+	});
+
+	let inputAmountUsd = $derived.by(() => {
+		const fromCoinDef = $SendTxDetails.fromCoin;
+		const fromAmount = $SendTxDetails.fromAmount;
+		if (!fromCoinDef || !fromAmount || fromAmount === '0' || fromPriceUsdRaw <= 0) return null;
+		const amt = new CoinAmount(fromAmount, fromCoinDef.coin).toNumber();
+		if (!Number.isFinite(amt) || amt <= 0) return null;
+		return amt * fromPriceUsdRaw;
+	});
+
+	/** Exchange fee: 0.25% (Altera) when selling HIVE/HBD for BTC, 0% on BTC→HIVE/HBD */
+	let exchangeFeePct = $derived.by(() => {
+		const assetOut = $SendTxDetails.toCoin?.coin.value;
+		const assetIn = $SendTxDetails.fromCoin?.coin.value;
+		if (!assetOut || !assetIn) return null;
+		if (assetOut === Coin.btc.value) return 0.25;
+		if (assetIn === Coin.btc.value) return 0;
+		return null; // HIVE↔HBD fee TBD
 	});
 
 	const auth = $derived(getAuth()());
@@ -827,22 +847,21 @@
 
 	let toCoin = $derived($SendTxDetails.toCoin?.coin ?? Coin.unk);
 
-	/** Estimated price impact in percent (0–100). Compares the USD value of
-	 *  `expectedOutput` against the USD value of the input using cached spot
-	 *  prices. Returns 0 when prices aren't loaded yet or no swap is active. */
 	let priceImpactPct = $derived.by(() => {
 		const fromCoinDef = $SendTxDetails.fromCoin;
 		const toCoinDef = $SendTxDetails.toCoin;
 		const fromAmount = $SendTxDetails.fromAmount;
-		if (!swapResult || swapResult.expectedOutput <= 0n) return 0;
 		if (!fromCoinDef || !toCoinDef || !fromAmount || fromAmount === '0') return 0;
-		if (fromPriceUsdRaw <= 0 || toPriceUsdRaw <= 0) return 0;
-		const inputAmt = new CoinAmount(fromAmount, fromCoinDef.coin).toNumber();
-		const inputUsd = inputAmt * fromPriceUsdRaw;
-		if (inputUsd <= 0) return 0;
-		const outputAmt = Number(swapResult.expectedOutput) / 10 ** toCoinDef.coin.decimalPlaces;
-		const outputUsd = outputAmt * toPriceUsdRaw;
-		return Math.max(0, ((inputUsd - outputUsd) / inputUsd) * 100);
+		if (!swapResult || swapResult.expectedOutput <= 0n) return 0;
+		const fromAmountInt = new CoinAmount(fromAmount, fromCoinDef.coin).amount;
+		if (!Number.isFinite(fromAmountInt) || fromAmountInt <= 0) return 0;
+		return calculatePriceImpact(
+			BigInt(fromAmountInt),
+			fromCoinDef.coin.value,
+			toCoinDef.coin.value,
+			hiveHbdPool,
+			btcHbdPool
+		);
 	});
 </script>
 
@@ -981,6 +1000,7 @@
 							{minAmount}
 							{maxAmount}
 							hideUnit
+							hideUsd
 						/>
 					</div>
 					<button class="token-selector-btn" onclick={() => openDialog('from')}>
@@ -997,6 +1017,9 @@
 						<ChevronDown size={14} />
 					</button>
 				</div>
+				{#if inputAmountUsd !== null}
+					<span class="section-usd-approx">≈ ${formatUsd(inputAmountUsd)}</span>
+				{/if}
 			</div>
 
 			<!-- Swap Arrow -->
@@ -1040,6 +1063,9 @@
 						<ChevronDown size={14} />
 					</button>
 				</div>
+				{#if expectedOutputUsd !== null}
+					<span class="section-usd-approx">≈ ${formatUsd(expectedOutputUsd)}</span>
+				{/if}
 			</div>
 
 			<!-- Route Info -->
@@ -1300,8 +1326,23 @@
 								<span class="fee-value">{formatSmallUnits(swapResult.baseFee, toDec)} {toUnit}</span>
 							{/if}
 						</div>
+						{#if exchangeFeePct !== null}
+							<div class="fee-row">
+								<span class="fee-label">
+									Exchange Fee
+									<span class="fee-sublabel">(Altera)</span>
+								</span>
+								<span
+									class="fee-value"
+									class:fee-free={exchangeFeePct === 0}
+									class:fee-cost={exchangeFeePct > 0}
+								>
+									{exchangeFeePct === 0 ? 'Free' : `${exchangeFeePct}%`}
+								</span>
+							</div>
+						{/if}
 						<div class="fee-row">
-							<span class="fee-label">Min. Amount Out</span>
+							<span class="fee-label">Min amount received</span>
 							<span class="fee-value fee-value-stack">
 								<span>{formatSmallUnits(swapResult.minAmountOut, toDec)} {toUnit}</span>
 								{#if minAmountOutUsd !== null}
@@ -1731,6 +1772,17 @@
 	.usd-approx {
 		font-size: var(--text-xs);
 		color: var(--dash-text-muted);
+	}
+	.section-usd-approx {
+		font-size: var(--text-xs);
+		color: var(--dash-text-muted);
+		font-family: 'Noto Sans Mono Variable', monospace;
+	}
+	.fee-free {
+		color: var(--dash-accent-green) !important;
+	}
+	.fee-cost {
+		color: #f59e0b !important;
 	}
 	.slippage-options {
 		display: flex;

--- a/src/lib/sendswap/stages/SwapOptions.svelte
+++ b/src/lib/sendswap/stages/SwapOptions.svelte
@@ -1238,30 +1238,30 @@
 								>{formatSmallUnits(swapResult.expectedOutput, toDec)} {toUnit}</span
 							>
 						</div>
-						{#if swapResult.hop1Fee && hop1FeeCoin}
-							<div class="fee-row">
-								<span class="fee-label">Pool Fee ({fromUnit} → {coinDisplayLabel(hop1FeeCoin)})</span>
-								<span class="fee-value"
-									>{formatSmallUnits(
-										swapResult.hop1Fee.totalFee,
-										hop1FeeCoin.decimalPlaces
-									)} {coinDisplayLabel(hop1FeeCoin)}</span
-								>
-							</div>
-							<div class="fee-row">
-								<span class="fee-label">Pool Fee ({coinDisplayLabel(hop1FeeCoin)} → {toUnit})</span>
-								<span class="fee-value"
-									>{formatSmallUnits(swapResult.totalFee, toDec)} {toUnit}</span
-								>
-							</div>
-						{:else}
-							<div class="fee-row">
-								<span class="fee-label">Pool Fee</span>
-								<span class="fee-value"
-									>{formatSmallUnits(swapResult.totalFee, toDec)} {toUnit}</span
-								>
-							</div>
-						{/if}
+						<!-- Base Fee (0.08% of gross output at each pool) -->
+						<div class="fee-row">
+							<span class="fee-label">Base Fee <span class="fee-sublabel">(0.08%)</span></span>
+							{#if swapResult.hop1Fee && hop1FeeCoin}
+								<span class="fee-value fee-value-stack">
+									<span>{formatSmallUnits(swapResult.hop1Fee.baseFee, hop1FeeCoin.decimalPlaces)} {coinDisplayLabel(hop1FeeCoin)}</span>
+									<span>{formatSmallUnits(swapResult.baseFee, toDec)} {toUnit}</span>
+								</span>
+							{:else}
+								<span class="fee-value">{formatSmallUnits(swapResult.baseFee, toDec)} {toUnit}</span>
+							{/if}
+						</div>
+						<!-- CLP Fee (quadratic, grows with trade size relative to pool depth) -->
+						<div class="fee-row">
+							<span class="fee-label">CLP Fee <span class="fee-sublabel">(liquidity)</span></span>
+							{#if swapResult.hop1Fee && hop1FeeCoin}
+								<span class="fee-value fee-value-stack">
+									<span>{formatSmallUnits(swapResult.hop1Fee.clpFee, hop1FeeCoin.decimalPlaces)} {coinDisplayLabel(hop1FeeCoin)}</span>
+									<span>{formatSmallUnits(swapResult.clpFee, toDec)} {toUnit}</span>
+								</span>
+							{:else}
+								<span class="fee-value">{formatSmallUnits(swapResult.clpFee, toDec)} {toUnit}</span>
+							{/if}
+						</div>
 						<div class="fee-row highlight">
 							<span class="fee-label">Total Fee</span>
 							{#if swapResult.hop1Fee && hop1FeeCoin}
@@ -1685,6 +1685,10 @@
 	.fee-label {
 		color: var(--dash-text-muted);
 		font-size: var(--text-sm);
+	}
+	.fee-sublabel {
+		font-size: var(--text-xs);
+		opacity: 0.7;
 	}
 	.fee-value {
 		font-family: 'Noto Sans Mono Variable', monospace;

--- a/src/lib/sendswap/stages/SwapOptions.svelte
+++ b/src/lib/sendswap/stages/SwapOptions.svelte
@@ -8,7 +8,7 @@
 		solveNetworkConstraints
 	} from '$lib/sendswap/utils/sendUtils';
 	import { assetCard, type AssetObject } from '$lib/sendswap/components/info/SendSnippets.svelte';
-	import { onDestroy, onMount, untrack } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import swapOptions, {
 		Coin,
 		Network,
@@ -18,10 +18,6 @@
 	import AmountInput from '$lib/currency/AmountInput.svelte';
 	import PillButton from '$lib/PillButton.svelte';
 	import {
-		ArrowDownRight,
-		ArrowLeft,
-		ArrowUpDown,
-		ArrowUpRight,
 		ChevronDown,
 		Search,
 		Send,
@@ -30,16 +26,6 @@
 		X
 	} from '@lucide/svelte';
 	import { CoinAmount } from '$lib/currency/CoinAmount';
-	import {
-		updateHistoricalData,
-		HistoricalCoinData,
-		type CoinMarketMapData,
-		loadHistoricalCoinData,
-		saveHistoricalCoinData
-	} from '$lib/currency/historical';
-	import LineChart, { type Point } from '$lib/LineChart.svelte';
-	import Card from '$lib/cards/Card.svelte';
-	import moment from 'moment';
 	import Dialog from '$lib/zag/Dialog.svelte';
 	import { accountBalance, getBalanceSmallestUnits } from '$lib/stores/currentBalance';
 	import type { AccountBalance } from '$lib/stores/currentBalance';
@@ -77,7 +63,6 @@
 	} = $props();
 
 	onMount(() => {
-		loadHistoricalCoinData();
 		// Resolve each swap-eligible pool dynamically so calls are
 		// network-aware (mainnet vs testnet). Both are loaded in
 		// parallel — the swap-calc effect picks whichever it needs
@@ -90,9 +75,6 @@
 			if (hiveHbd) hiveHbdPool = hiveHbd;
 			if (btcHbd) btcHbdPool = btcHbd;
 		})();
-	});
-	onDestroy(() => {
-		saveHistoricalCoinData();
 	});
 
 	// Pool depths and swap calculation state
@@ -222,15 +204,7 @@
 			}
 			const pool1 = assetIn === Coin.btc.value ? btcHbdPool : hiveHbdPool;
 			const pool2 = assetIn === Coin.btc.value ? hiveHbdPool : btcHbdPool;
-			result = calculateTwoHopSwap(
-				x,
-				pool1,
-				pool2,
-				assetIn,
-				Coin.hbd.value,
-				assetOut,
-				slippageBps
-			);
+			result = calculateTwoHopSwap(x, pool1, pool2, assetIn, Coin.hbd.value, assetOut, slippageBps);
 		}
 
 		if (!result) {
@@ -301,13 +275,29 @@
 
 	let expectedOutputUsd = $derived.by(() => {
 		const toCoinDef = $SendTxDetails.toCoin;
-		if (!swapResult || swapResult.expectedOutput <= 0n || toPriceUsdRaw <= 0 || !toCoinDef) return null;
+		if (!swapResult || swapResult.expectedOutput <= 0n || toPriceUsdRaw <= 0 || !toCoinDef)
+			return null;
 		return (Number(swapResult.expectedOutput) / 10 ** toCoinDef.coin.decimalPlaces) * toPriceUsdRaw;
+	});
+
+	/** "You Receive" display value — formatted with thousands separator, same locale as the rest of the UI */
+	let formattedToAmount = $derived.by(() => {
+		const raw = $SendTxDetails.toAmount;
+		const toCoinDef = $SendTxDetails.toCoin;
+		if (!raw || raw === '0' || !toCoinDef) return null;
+		const num = Number(raw);
+		if (!Number.isFinite(num)) return null;
+		return new Intl.NumberFormat(numberFormatLanguage, {
+			useGrouping: true,
+			minimumFractionDigits: 0,
+			maximumFractionDigits: toCoinDef.coin.decimalPlaces
+		}).format(num);
 	});
 
 	let minAmountOutUsd = $derived.by(() => {
 		const toCoinDef = $SendTxDetails.toCoin;
-		if (!swapResult || swapResult.minAmountOut <= 0n || toPriceUsdRaw <= 0 || !toCoinDef) return null;
+		if (!swapResult || swapResult.minAmountOut <= 0n || toPriceUsdRaw <= 0 || !toCoinDef)
+			return null;
 		return (Number(swapResult.minAmountOut) / 10 ** toCoinDef.coin.decimalPlaces) * toPriceUsdRaw;
 	});
 
@@ -463,7 +453,9 @@
 	// Combined: enable button when swap fields valid, destination valid, not same coin, and has balance
 	$effect(() => {
 		if (!isActive) return;
-		editStage(swapFieldsValid && destValid && !sameCoinError && !insufficientBalance && !exceedsPoolDepth);
+		editStage(
+			swapFieldsValid && destValid && !sameCoinError && !insufficientBalance && !exceedsPoolDepth
+		);
 	});
 
 	let { assetOptions, networkOptions } = $state<ReturnType<typeof solveNetworkConstraints>>({
@@ -648,77 +640,24 @@
 		}
 	});
 
-	let fromInUsd = $state('');
-	let toInUsd = $state('');
 	let fromPriceUsdRaw = $state(0);
 	let toPriceUsdRaw = $state(0);
 	$effect(() => {
 		if ($SendTxDetails.fromCoin) {
-			const oneFrom = new CoinAmount(1, $SendTxDetails.fromCoin.coin);
-			oneFrom.convertTo(Coin.usd, Network.lightning).then((amt) => {
-				fromInUsd = amt.toPrettyMinFigs();
-				fromPriceUsdRaw = amt.toNumber();
-			});
+			new CoinAmount(1, $SendTxDetails.fromCoin.coin)
+				.convertTo(Coin.usd, Network.lightning)
+				.then((amt) => {
+					fromPriceUsdRaw = amt.toNumber();
+				});
 		}
 		if ($SendTxDetails.toCoin) {
 			new CoinAmount(1, $SendTxDetails.toCoin.coin)
 				.convertTo(Coin.usd, Network.lightning)
 				.then((amt) => {
-					toInUsd = amt.toPrettyMinFigs();
 					toPriceUsdRaw = amt.toNumber();
 				});
 		}
 	});
-	// map of coin value (NOT ucid) fields to historical data
-	let graphsLoaded = $state(new Set<string>());
-	let fromData: CoinMarketMapData | undefined = $state();
-	let toData: CoinMarketMapData | undefined = $state();
-	let hoveredFromPoint: Point | undefined = $state();
-	let hoveredToPoint: Point | undefined = $state();
-	let lastDefined = $state.raw(new Set<string>());
-	$effect(() => {
-		let currentlyDefined = [$SendTxDetails.fromCoin?.coin, $SendTxDetails.toCoin?.coin].filter(
-			(coin) => coin !== undefined
-		);
-		untrack(() => {
-			const definedSet = new Set(currentlyDefined.map((coin) => coin.value));
-			if (definedSet.symmetricDifference(lastDefined).size === 0) return;
-			lastDefined = definedSet;
-			graphsLoaded = graphsLoaded.intersection(definedSet);
-
-			updateHistoricalData(currentlyDefined)
-				.then(() => {
-					if ($SendTxDetails.fromCoin && $SendTxDetails.fromCoin.coin.ucid) {
-						fromData = $HistoricalCoinData.get($SendTxDetails.fromCoin.coin.ucid);
-					}
-					if ($SendTxDetails.toCoin && $SendTxDetails.toCoin.coin.ucid) {
-						toData = $HistoricalCoinData.get($SendTxDetails.toCoin.coin.ucid);
-					}
-				})
-				.finally(() => (graphsLoaded = graphsLoaded.union(definedSet)));
-		});
-	});
-	function getPercentChange(points: Point[] | undefined, current?: number) {
-		if (!points || points.length === 0) return 0;
-		const first = points[0].value;
-		const last = points[points.length - 1].value;
-		return (last / first - 1) * 100;
-	}
-	function formatGraphValue(value: number) {
-		if (value > 10) {
-			return value.toLocaleString(numberFormatLanguage, {
-				useGrouping: true,
-				maximumFractionDigits: 2,
-				minimumFractionDigits: 2
-			});
-		} else {
-			return value.toLocaleString(numberFormatLanguage, {
-				useGrouping: true,
-				maximumFractionDigits: 4,
-				minimumFractionDigits: 2
-			});
-		}
-	}
 
 	let minAmount: CoinAmount<Coin> | undefined = $state();
 	$effect(() => {
@@ -754,7 +693,6 @@
 		if (bal == null || typeof bal !== 'number' || bal <= 0) return undefined;
 		return new CoinAmount(bal, from.coin, true);
 	});
-
 
 	let dialogOpen = $state(false);
 	let toggle = $state<(open?: boolean) => void>(() => {});
@@ -873,17 +811,6 @@
 	});
 </script>
 
-{#snippet percentArrow(percent: number)}
-	<span class={{ up: percent >= 0, down: percent < 0 }}>
-		{#if percent >= 0}
-			<ArrowUpRight size="16" />
-		{:else}
-			<ArrowDownRight size="16" />
-		{/if}
-		{percent.toFixed(2) + '%'}
-	</span>
-{/snippet}
-
 <Dialog bind:open={dialogOpen} bind:toggle back={dialogBack}>
 	{#snippet title()}Select a token{/snippet}
 	{#snippet content()}
@@ -921,11 +848,13 @@
 				</div>
 				<span class="dialog-section-label">ALL ASSETS</span>
 				<div class="network-cards">
-					{#each tempCoinOpt.networks.filter(n => n.value !== Network.lightning.value) as net (net.value)}
+					{#each tempCoinOpt.networks.filter((n) => n.value !== Network.lightning.value) as net (net.value)}
 						<button class="network-card" onclick={() => confirmFromSelection(tempCoinOpt!, net)}>
 							<img src={tempCoinOpt.coin.icon} alt="" class="network-card-icon" />
 							<div class="network-card-info">
-								<span class="network-card-name">{net.value === Network.magi.value ? 'Magi Network' : 'Mainnet'}</span>
+								<span class="network-card-name"
+									>{net.value === Network.magi.value ? 'Magi Network' : 'Mainnet'}</span
+								>
 							</div>
 							<div class="network-card-balance">
 								<span class="balance-amount"
@@ -941,62 +870,23 @@
 	{/snippet}
 </Dialog>
 
-<!-- ═══ Two-Column Layout ═══ -->
 <div class="swap-layout">
-	<!-- ── LEFT EAR: From Chart ── -->
-	<div class={['ear left-ear', { hide: !$SendTxDetails.fromCoin }]}>
-		{#if $SendTxDetails.fromCoin}
-			{@const coin = $SendTxDetails.fromCoin.coin}
-			<Card>
-				<div class="lc-wrapper">
-					<div class="lc-labels">
-						<div class="coin">
-							<img src={coin.icon} alt={coinDisplayLabel(coin)} />
-							<div class="label-network">
-								{coinDisplayLabel(coin)}
-								<span class="sm-caption">Native</span>
-							</div>
-						</div>
-						<div class="amount-percent">
-							{#if hoveredFromPoint}
-								<p>
-									{`${formatGraphValue(hoveredFromPoint.value)} ${Coin.usd.unit}`}
-								</p>
-								<p>{moment(hoveredFromPoint.date).format('MMM DD, HH:mm')}</p>
-							{:else}
-								{fromInUsd}
-								{@render percentArrow(getPercentChange(fromData?.quotes))}
-							{/if}
-						</div>
-					</div>
-					<LineChart
-						data={fromData?.quotes ?? []}
-						height={120}
-						isLoading={!graphsLoaded.has(coin.value)}
-						styleType="trend"
-						bind:hoveredPoint={hoveredFromPoint}
-					/>
-				</div>
-			</Card>
-		{/if}
-	</div>
-
-	<!-- ── CENTER LEFT: Swap Card ── -->
+	<!-- ── Swap Card ── -->
 	<div class="swap-col-left">
 		<div class="quick-swap-card">
 			<!-- From Section -->
 			<div class="swap-section">
 				<div class="section-header">
 					<span class="section-label">From</span>
-					<span class="section-info sm-caption">
-						{#if $SendTxDetails.fromCoin}
-							{#if $SendTxDetails.fromNetwork}
-								{$SendTxDetails.fromNetwork.label}
-							{/if}
-							{#if maxAmount}
-								&middot; Balance: {maxAmount.toPrettyAmountString()}
-								{coinDisplayLabel($SendTxDetails.fromCoin.coin)}
-							{/if}
+					<span class="section-header-center">
+						{#if $SendTxDetails.fromNetwork}
+							<span class="network-pill">{$SendTxDetails.fromNetwork.label}</span>
+						{/if}
+					</span>
+					<span class="section-balance sm-caption">
+						{#if $SendTxDetails.fromCoin && maxAmount}
+							Balance: {maxAmount.toPrettyAmountString()}
+							{coinDisplayLabel($SendTxDetails.fromCoin.coin)}
 						{/if}
 					</span>
 				</div>
@@ -1009,6 +899,7 @@
 							{maxAmount}
 							hideUnit
 							hideUsd
+							hideNetwork
 						/>
 					</div>
 					<button class="token-selector-btn" onclick={() => openDialog('from')}>
@@ -1025,9 +916,20 @@
 						<ChevronDown size={14} />
 					</button>
 				</div>
-				{#if inputAmountUsd !== null}
-					<span class="section-usd-approx">≈ ${formatUsd(inputAmountUsd)}</span>
-				{/if}
+				<div class="section-usd-row">
+					<span class="section-usd-approx">
+						{#if inputAmountUsd !== null}≈ ${formatUsd(inputAmountUsd)}{/if}
+					</span>
+					{#if sameCoinError}
+						<span class="section-error-inline">Select a different token</span>
+					{:else if insufficientBalance && $SendTxDetails.fromCoin}
+						<span class="section-error-inline"
+							>Insufficient {coinDisplayLabel($SendTxDetails.fromCoin.coin)} balance</span
+						>
+					{:else if exceedsPoolDepth}
+						<span class="section-error-inline">Amount exceeds pool depth</span>
+					{/if}
+				</div>
 			</div>
 
 			<!-- Swap Arrow -->
@@ -1041,7 +943,7 @@
 			<div class="swap-section">
 				<div class="section-header">
 					<span class="section-label">You Receive</span>
-					<span class="section-info sm-caption">
+					<span class="sm-caption" style="color: var(--dash-text-muted)">
 						{#if $SendTxDetails.toNetwork}
 							{$SendTxDetails.toNetwork.label}
 						{:else}
@@ -1051,8 +953,8 @@
 				</div>
 				<div class="section-input-row">
 					<div class="to-amount-display">
-						{#if $SendTxDetails.toAmount && $SendTxDetails.toAmount !== '0'}
-							<span class="to-amount-value">{$SendTxDetails.toAmount}</span>
+						{#if formattedToAmount}
+							<span class="to-amount-value">{formattedToAmount}</span>
 						{:else}
 							<span class="to-amount-placeholder">0</span>
 						{/if}
@@ -1071,9 +973,11 @@
 						<ChevronDown size={14} />
 					</button>
 				</div>
-				{#if expectedOutputUsd !== null}
-					<span class="section-usd-approx">≈ ${formatUsd(expectedOutputUsd)}</span>
-				{/if}
+				<div class="section-usd-row">
+					<span class="section-usd-approx">
+						{#if expectedOutputUsd !== null}≈ ${formatUsd(expectedOutputUsd)}{/if}
+					</span>
+				</div>
 			</div>
 
 			<!-- Route Info -->
@@ -1086,29 +990,7 @@
 					</span>
 				</div>
 			{/if}
-
-			<!-- Same coin error -->
-			{#if sameCoinError}
-				<div class="same-coin-error">
-					<span class="error">Cannot swap the same asset. Please select a different token to receive.</span>
-				</div>
-			{/if}
-
-			<!-- Insufficient balance error -->
-			{#if insufficientBalance && !sameCoinError && $SendTxDetails.fromCoin}
-				<div class="same-coin-error">
-					<span class="error">Insufficient {coinDisplayLabel($SendTxDetails.fromCoin.coin)} balance. You don't have enough funds for this swap.</span>
-				</div>
-			{/if}
-
-			<!-- Pool depth cap error -->
-			{#if exceedsPoolDepth && !sameCoinError && !insufficientBalance}
-				<div class="same-coin-error">
-					<span class="error">Amount exceeds 50% of pool depth — the swap will fail on-chain. Reduce the amount to continue.</span>
-				</div>
-			{/if}
 		</div>
-
 	</div>
 
 	<!-- ── CENTER RIGHT: Deliver To ── -->
@@ -1219,13 +1101,13 @@
 			{@const fromUnit = coinDisplayLabel($SendTxDetails.fromCoin.coin)}
 			{@const toUnit = coinDisplayLabel($SendTxDetails.toCoin.coin)}
 			{@const hop1FeeCoin = swapResult?.hop1Fee
-				? (swapResult.hop1Fee.asset === Coin.hbd.value
+				? swapResult.hop1Fee.asset === Coin.hbd.value
 					? Coin.hbd
 					: swapResult.hop1Fee.asset === Coin.hive.value
 						? Coin.hive
 						: swapResult.hop1Fee.asset === Coin.btc.value
 							? Coin.btc
-							: null)
+							: null
 				: null}
 			<div class="swap-fees">
 				<!-- Always visible: price impact summary row -->
@@ -1236,8 +1118,8 @@
 							class="impact-pct"
 							class:good={priceImpactPct < 2}
 							class:medium={priceImpactPct >= 2 && priceImpactPct < 10}
-							class:bad={priceImpactPct >= 10}
-						>{priceImpactPct.toFixed(2)}%</span>
+							class:bad={priceImpactPct >= 10}>{priceImpactPct.toFixed(2)}%</span
+						>
 					{:else}
 						<span class="impact-pct-empty">—</span>
 					{/if}
@@ -1251,7 +1133,10 @@
 							{#each slippageOptions as bps}
 								<button
 									class={{ active: slippageBps === bps && !customSlippageOpen }}
-									onclick={() => { slippageBps = bps; customSlippageOpen = false; }}
+									onclick={() => {
+										slippageBps = bps;
+										customSlippageOpen = false;
+									}}
 								>
 									{(bps / 100).toFixed(bps % 100 === 0 ? 0 : 1)}%
 								</button>
@@ -1270,8 +1155,13 @@
 										}}
 										onblur={applyCustomSlippage}
 										onkeydown={(e) => {
-											if (e.key === 'Enter') { applyCustomSlippage(); e.currentTarget.blur(); }
-											if (e.key === 'Escape') { customSlippageOpen = false; }
+											if (e.key === 'Enter') {
+												applyCustomSlippage();
+												e.currentTarget.blur();
+											}
+											if (e.key === 'Escape') {
+												customSlippageOpen = false;
+											}
 										}}
 									/>
 									<span class="custom-slippage-unit">%</span>
@@ -1286,26 +1176,33 @@
 											: parseFloat((slippageBps / 100).toFixed(2)).toString();
 									}}
 								>
-									{slippageOptions.includes(slippageBps) ? 'Custom' : `${parseFloat((slippageBps / 100).toFixed(2))}%`}
+									{slippageOptions.includes(slippageBps)
+										? 'Custom'
+										: `${parseFloat((slippageBps / 100).toFixed(2))}%`}
 								</button>
 							{/if}
 						</div>
 					</div>
 				</div>
 
-				<!-- Text warning for severe impact only (badge handles < 15%) -->
-				{#if priceImpactPct >= 10}
-					<div class="impact-warning" class:severe={priceImpactPct >= 15}>
-						<TriangleAlert size={14} />
-						<span>
-							{#if priceImpactPct >= 15}
-								Very high price impact — pool liquidity is low for this trade size. Try a smaller amount.
-							{:else}
-								High price impact — consider using a smaller amount for better rates.
-							{/if}
-						</span>
+				<!-- Text warning — always rendered to reserve space; visibility toggled via CSS -->
+				<div
+					class="impact-warning"
+					class:severe={priceImpactPct >= 15}
+					class:hidden={priceImpactPct < 10}
+				>
+					<TriangleAlert size={14} />
+					<!-- Both messages stacked in the same grid cell so height never changes -->
+					<div class="impact-text">
+						<span class="impact-severe"
+							>Very high price impact. Pool liquidity is low for this trade size. Try a smaller
+							amount.</span
+						>
+						<span class="impact-medium"
+							>High price impact. Consider using a smaller amount for better rates.</span
+						>
 					</div>
-				{/if}
+				</div>
 
 				<!-- Fee breakdown — always visible when a swap is calculated -->
 				{#if swapResult}
@@ -1361,46 +1258,8 @@
 				{/if}
 			</div>
 		{/if}
-
 	</div>
 
-	<!-- ── RIGHT EAR: To Chart ── -->
-	<div class={['ear right-ear', { hide: !$SendTxDetails.toCoin }]}>
-		{#if $SendTxDetails.toCoin}
-			{@const coin = $SendTxDetails.toCoin.coin}
-			<Card>
-				<div class="lc-wrapper">
-					<div class="lc-labels">
-						<div class="coin">
-							<img src={coin.icon} alt={coinDisplayLabel(coin)} />
-							<div class="label-network">
-								{coinDisplayLabel(coin)}
-								<span class="sm-caption">Native</span>
-							</div>
-						</div>
-						<div class="amount-percent">
-							{#if hoveredToPoint}
-								<p>
-									{`${formatGraphValue(hoveredToPoint.value)} ${Coin.usd.unit}`}
-								</p>
-								<p>{moment(hoveredToPoint.date).format('MMM DD, HH:mm')}</p>
-							{:else}
-								{toInUsd}
-								{@render percentArrow(getPercentChange(toData?.quotes))}
-							{/if}
-						</div>
-					</div>
-					<LineChart
-						data={toData?.quotes ?? []}
-						height={120}
-						isLoading={!graphsLoaded.has(coin.value)}
-						styleType="trend"
-						bind:hoveredPoint={hoveredToPoint}
-					/>
-				</div>
-			</Card>
-		{/if}
-	</div>
 </div>
 
 <!-- Status & Waiting Overlay -->
@@ -1433,80 +1292,31 @@
 {/if}
 
 <style lang="scss">
-	/* ═══ Two-Column Layout ═══ */
+	/* ═══ Layout ═══ */
 	.swap-layout {
-		display: grid;
-		grid-template-columns: minmax(0, 300px) minmax(0, 480px) minmax(0, 300px);
-		grid-template-rows: auto auto;
+		display: flex;
+		flex-direction: column;
 		gap: 10px;
-		max-width: 1140px;
+		max-width: 480px;
+		min-width: 320px;
 		width: 100%;
 		margin: 0 auto;
 		padding: 0.5rem;
 		box-sizing: border-box;
-		justify-content: center;
 	}
-	.ear {
-		min-width: 0;
-		padding-top: 0.5rem;
-		&.hide { visibility: hidden; }
-		.lc-wrapper {
-			height: 100%;
-			box-sizing: border-box;
-			margin: -0.5rem;
-			.lc-labels {
-				padding: 0.5rem;
-				display: flex;
-				justify-content: space-between;
-				.coin {
-					display: inline-flex;
-					align-items: center;
-					gap: 0.5rem;
-					img {
-						width: 1.75rem;
-						height: 1.75rem;
-					}
-					.label-network {
-						display: flex;
-						flex-direction: column;
-						gap: 0.125rem;
-						color: var(--dash-text-primary);
-						font-size: 0.85rem;
-					}
-				}
-				.amount-percent {
-					display: flex;
-					flex-direction: column;
-					align-items: flex-end;
-					gap: 0.125rem;
-					color: var(--dash-text-primary);
-					font-size: 0.85rem;
-				}
-			}
+	/* On wide screens (sidebar visible) give the card a bit more room */
+	@media screen and (min-width: 860px) {
+		.swap-layout {
+			max-width: 560px;
 		}
-		.up,
-		.down {
-			display: inline-flex;
-			align-items: center;
-			font-family: 'Noto Sans Mono Variable', monospace;
-			width: fit-content;
-		}
-		.up { color: var(--dash-accent-green); }
-		.down { color: var(--dash-accent-red); }
 	}
-	.left-ear { grid-column: 1; grid-row: 1; align-self: start; }
-	.right-ear { grid-column: 3; grid-row: 1; align-self: start; }
 	.swap-col-left {
-		grid-column: 2;
-		grid-row: 1;
 		display: flex;
 		flex-direction: column;
 		gap: 0;
 		min-width: 0;
 	}
 	.swap-col-right {
-		grid-column: 2;
-		grid-row: 2;
 		display: flex;
 		flex-direction: column;
 		gap: 16px;
@@ -1544,15 +1354,35 @@
 		align-items: baseline;
 	}
 	.section-label {
+		flex: 1;
 		font-size: 0.8rem;
 		color: var(--dash-text-muted);
 		font-weight: 600;
 		text-transform: uppercase;
 		letter-spacing: 0.03em;
 	}
-	.section-info {
+	.section-header-center {
+		flex: 1;
+		display: flex;
+		justify-content: center;
+	}
+	.section-balance {
+		flex: 1;
+		text-align: right;
 		font-size: var(--text-xs);
 		color: var(--dash-text-muted);
+	}
+	.network-pill {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.1rem 0.45rem;
+		border-radius: 1rem;
+		border: 1px solid var(--dash-accent-purple);
+		font-size: 0.7rem;
+		font-weight: 600;
+		color: var(--dash-accent-purple);
+		letter-spacing: 0.02em;
+		text-transform: uppercase;
 	}
 	.section-input-row {
 		display: flex;
@@ -1563,6 +1393,7 @@
 	.input-field {
 		flex: 1;
 		min-width: 0;
+		--number-input-padding-right: 0;
 	}
 	.input-field :global(.normal-wrapper label) {
 		display: none;
@@ -1570,29 +1401,36 @@
 	.input-field :global(.normal-wrapper .amount-input) {
 		border: none;
 		background: transparent;
+		padding: 0;
+		gap: 0;
 	}
 	.input-field :global(.normal-wrapper .amount-input > .icons),
 	.input-field :global(.normal-wrapper .amount-input > svg) {
 		display: none;
 	}
-	.input-field :global(.normal-wrapper .amount-input input) {
+	.input-field :global(.normal-wrapper .amount-input [data-part='input']) {
 		font-size: 1.5rem;
 		font-family: 'Nunito Sans', sans-serif;
 		font-weight: 500;
+		height: auto;
+		border: none;
+		border-radius: 0;
+		padding: 0.5rem 0;
 	}
 	.input-field :global(.normal-wrapper .amount-input:has(input:focus-visible)) {
 		box-shadow: none;
 		border-bottom-color: transparent;
 		border-radius: 0;
 	}
+	/* Hide AmountInput's internal validation error — errors are shown inline
+	   in the section-usd-row instead, which doesn't shift the layout. */
 	.input-field :global(.normal-wrapper .bottom-info) {
-		position: static;
-		padding-top: 0;
+		display: none;
 	}
 	.to-amount-display {
 		flex: 1;
 		min-width: 0;
-		padding: 0.5rem 0;
+		padding: 0.5rem 0.8rem;
 		font-size: 1.5rem;
 		font-family: 'Nunito Sans', sans-serif;
 		font-weight: 500;
@@ -1661,19 +1499,6 @@
 	}
 
 	/* ── Same Coin Error ── */
-	.same-coin-error {
-		margin-top: 0.5rem;
-		padding: 0.5rem 0.75rem;
-		border-radius: 12px;
-		background-color: rgba(239, 68, 68, 0.08);
-		border: 1px solid rgba(239, 68, 68, 0.2);
-		.error {
-			color: var(--dash-accent-red);
-			font-size: var(--text-sm);
-			font-weight: 500;
-		}
-	}
-
 	/* ── Route Info ── */
 	.route-info {
 		display: flex;
@@ -1682,13 +1507,6 @@
 		gap: 0.5rem;
 		padding: 0.375rem 0 0.125rem;
 		font-size: 0.75rem;
-	}
-	.route-path {
-		color: var(--dash-text-muted);
-	}
-	.route-rate {
-		color: var(--dash-text-secondary);
-		font-family: 'Noto Sans Mono Variable', monospace;
 	}
 	.route-tags {
 		display: flex;
@@ -1774,16 +1592,33 @@
 		flex-direction: column;
 		align-items: flex-end;
 		gap: 0.125rem;
-		span { white-space: nowrap; }
+		span {
+			white-space: nowrap;
+		}
 	}
 	.usd-approx {
 		font-size: var(--text-xs);
 		color: var(--dash-text-muted);
 	}
+	.section-usd-row {
+		display: flex;
+		flex-wrap: wrap-reverse;
+		justify-content: space-between;
+		align-items: center;
+		min-height: 1.4em;
+		gap: 0.125rem 0.5rem;
+	}
 	.section-usd-approx {
 		font-size: var(--text-xs);
 		color: var(--dash-text-muted);
 		font-family: 'Noto Sans Mono Variable', monospace;
+	}
+	.section-error-inline {
+		font-size: var(--text-xs);
+		color: var(--negative-text, #f87171);
+		font-family: 'Nunito Sans', sans-serif;
+		font-weight: 500;
+		margin-left: auto;
 	}
 	.fee-free {
 		color: var(--dash-accent-green) !important;
@@ -1842,9 +1677,15 @@
 			outline: none;
 			text-align: center;
 			-moz-appearance: textfield;
-			&::placeholder { color: var(--dash-text-muted); font-weight: 400; }
+			&::placeholder {
+				color: var(--dash-text-muted);
+				font-weight: 400;
+			}
 			&::-webkit-inner-spin-button,
-			&::-webkit-outer-spin-button { -webkit-appearance: none; margin: 0; }
+			&::-webkit-outer-spin-button {
+				-webkit-appearance: none;
+				margin: 0;
+			}
 		}
 		.custom-slippage-unit {
 			font-size: var(--text-xs);
@@ -2059,117 +1900,7 @@
 		color: var(--dash-text-muted);
 	}
 
-	/* ── Charts Section ── */
-	.graphs {
-		&.hide {
-			display: none;
-		}
-		display: grid;
-		grid-template-columns: 1fr 1fr;
-		grid-template-rows: auto;
-		grid-template-areas: 'from to';
-		gap: 1rem;
-		width: 100%;
-		box-sizing: border-box;
-		.lc-wrapper {
-			height: 100%;
-			box-sizing: border-box;
-			margin: -0.5rem;
-			.lc-labels {
-				padding: 0.5rem;
-				display: flex;
-				justify-content: space-between;
-				.coin {
-					display: inline-flex;
-					align-items: center;
-					gap: 0.5rem;
-					img {
-						width: 1.75rem;
-						height: 1.75rem;
-					}
-					.label-network {
-						display: flex;
-						flex-direction: column;
-						gap: 0.125rem;
-						color: var(--dash-text-primary);
-						font-size: 0.85rem;
-					}
-				}
-				.amount-percent {
-					display: flex;
-					flex-direction: column;
-					align-items: flex-end;
-					gap: 0.125rem;
-					color: var(--dash-text-primary);
-					font-size: 0.85rem;
-				}
-			}
-		}
-		.up,
-		.down {
-			display: inline-flex;
-			align-items: center;
-			font-family: 'Noto Sans Mono Variable', monospace;
-			width: fit-content;
-		}
-		.up {
-			color: var(--dash-accent-green);
-		}
-		.down {
-			color: var(--dash-accent-red);
-		}
-	}
-
 	/* ── Dialog: Token Grid ── */
-	.dialog-title-row {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		margin-bottom: 1rem;
-		h5 {
-			flex: 1;
-			margin: 0;
-			font-size: var(--text-3xl);
-			font-weight: 600;
-			color: var(--dash-text-primary);
-		}
-	}
-	.dialog-close-btn {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		background: none;
-		border: none;
-		color: var(--dash-text-muted);
-		cursor: pointer;
-		padding: 0.25rem;
-		border-radius: 50%;
-		transition: color 0.15s ease;
-		&:hover {
-			color: var(--dash-text-primary);
-		}
-	}
-	.dialog-back-btn {
-		display: flex;
-		align-items: center;
-		gap: 0.25rem;
-		background: none;
-		border: none;
-		color: var(--dash-text-muted);
-		cursor: pointer;
-		font: inherit;
-		font-size: var(--text-sm);
-		padding: 0.25rem 0.5rem 0.25rem 0;
-		transition: color 0.15s ease;
-		&:hover {
-			color: var(--dash-text-primary);
-		}
-	}
-	.dialog-title-icon {
-		width: 1.5rem;
-		height: 1.5rem;
-		border-radius: 50%;
-	}
 	.token-search-wrapper {
 		position: relative;
 		margin-bottom: 1rem;
@@ -2314,9 +2045,15 @@
 		font-family: 'Noto Sans Mono Variable', monospace;
 		font-size: var(--text-sm);
 		font-weight: 600;
-		&.good   { color: var(--dash-accent-green); }
-		&.medium { color: #d97706; }
-		&.bad    { color: var(--dash-accent-red); }
+		&.good {
+			color: var(--dash-accent-green);
+		}
+		&.medium {
+			color: #d97706;
+		}
+		&.bad {
+			color: var(--dash-accent-red);
+		}
 	}
 	.impact-pct-empty {
 		font-family: 'Noto Sans Mono Variable', monospace;
@@ -2327,16 +2064,38 @@
 	/* ── Price Impact Warning ── */
 	.impact-warning {
 		display: flex;
-		align-items: center;
+		align-items: start;
 		gap: 0.5rem;
-		padding: 0.5rem 1rem;
+		padding: 0.375rem 1rem;
 		border-top: 1px solid var(--dash-card-border);
 		color: #d97706; /* amber-600 */
 		font-size: var(--text-sm);
-		:global(svg) { flex-shrink: 0; }
+		:global(svg) {
+			flex-shrink: 0;
+		}
 		&.severe {
 			color: var(--dash-accent-red);
 		}
+		/* Hidden state — keeps layout space, just invisible */
+		&.hidden {
+			visibility: hidden;
+		}
+	}
+	/* Both message variants stacked in one grid cell — container height is
+	   always the taller of the two, so nothing shifts when the text changes. */
+	.impact-text {
+		display: grid;
+		.impact-severe,
+		.impact-medium {
+			grid-area: 1 / 1;
+			visibility: hidden;
+		}
+	}
+	.impact-warning.severe .impact-severe {
+		visibility: visible;
+	}
+	.impact-warning:not(.severe):not(.hidden) .impact-medium {
+		visibility: visible;
 	}
 
 	/* ── Status & Waiting ── */
@@ -2387,19 +2146,7 @@
 		}
 	}
 
-	/* ── Responsive: Stack on smaller screens ── */
-	@media screen and (max-width: 56rem) {
-		.swap-layout {
-			grid-template-columns: 1fr;
-			padding: 0.5rem;
-		}
-		.ear { display: none; }
-		.swap-col-left, .swap-col-right { grid-column: 1; }
-	}
 	@media screen and (max-width: 36rem) {
-		.swap-layout {
-			padding: 0.5rem;
-		}
 		.quick-swap-card {
 			padding: 1rem;
 		}
@@ -2416,10 +2163,6 @@
 		.dest-network-toggle button {
 			padding: 0.375rem 0.5rem;
 			font-size: var(--text-xs);
-		}
-		.graphs {
-			display: flex;
-			flex-direction: column;
 		}
 		.waiting-overlay .waiting-card {
 			margin-top: 15%;

--- a/src/lib/sendswap/stages/SwapOptions.svelte
+++ b/src/lib/sendswap/stages/SwapOptions.svelte
@@ -17,14 +17,7 @@
 	} from '$lib/sendswap/utils/sendOptions';
 	import AmountInput from '$lib/currency/AmountInput.svelte';
 	import PillButton from '$lib/PillButton.svelte';
-	import {
-		ChevronDown,
-		Search,
-		Send,
-		TriangleAlert,
-		Wallet,
-		X
-	} from '@lucide/svelte';
+	import { ChevronDown, Search, Send, TriangleAlert, Wallet, X } from '@lucide/svelte';
 	import { CoinAmount } from '$lib/currency/CoinAmount';
 	import Dialog from '$lib/zag/Dialog.svelte';
 	import { accountBalance, getBalanceSmallestUnits } from '$lib/stores/currentBalance';
@@ -1259,7 +1252,6 @@
 			</div>
 		{/if}
 	</div>
-
 </div>
 
 <!-- Status & Waiting Overlay -->
@@ -1668,6 +1660,7 @@
 		}
 		input {
 			width: 2.5rem;
+			height: auto;
 			border: none;
 			background: transparent;
 			color: var(--dash-text-primary);

--- a/src/lib/zag/NumberInput.svelte
+++ b/src/lib/zag/NumberInput.svelte
@@ -61,6 +61,7 @@
 	const service = useMachine(numberInput.machine, {
 		id,
 		min: 0,
+		locale: 'en-US',
 		get disabled() {
 			return disabled;
 		},
@@ -71,7 +72,7 @@
 		get formatOptions() {
 			return {
 				style: 'decimal' as const,
-				useGrouping: true,
+				useGrouping: false,
 				minimumFractionDigits: 0,
 				maximumFractionDigits: decimals
 			};
@@ -125,6 +126,12 @@
 				e.preventDefault();
 				e.stopPropagation();
 			}
+			// Treat comma as decimal separator — prevent the comma and
+			// insert a dot so Zag processes it as the decimal point.
+			if (e.key === ',') {
+				e.preventDefault();
+				document.execCommand('insertText', false, '.');
+			}
 		}}
 	/>
 	<!-- <div class="triggers">
@@ -155,7 +162,7 @@
 		max-width: 100%;
 		min-width: 0;
 		flex-grow: 1;
-		padding-right: 2rem;
+		padding-right: var(--number-input-padding-right, 2rem);
 		font-family: 'Nunito Sans', sans-serif;
 		color: var(--dash-text-primary);
 		background: transparent;

--- a/src/routes/(authed)/+layout.svelte
+++ b/src/routes/(authed)/+layout.svelte
@@ -131,15 +131,21 @@
 		color: var(--dash-text-accent);
 	}
 
-	@media screen and (max-width: 620px) {
+	/* Sidebar overlay dimming — any width where sidebar isn't sticky */
+	@media screen and (max-width: 860px) {
 		.main-area {
-			padding: 0 1rem;
 			opacity: 1;
 			transition: opacity 0.2s;
 		}
 		.showSidebar .main-area {
 			pointer-events: none;
 			opacity: 0.2;
+		}
+	}
+	/* True mobile: tighten horizontal padding */
+	@media screen and (max-width: 620px) {
+		.main-area {
+			padding: 0 1rem;
 		}
 	}
 </style>

--- a/src/routes/[...path]/+page.ts
+++ b/src/routes/[...path]/+page.ts
@@ -1,5 +1,7 @@
 import { error } from '@sveltejs/kit';
 
+export const prerender = false;
+
 export function load() {
 	error(404, 'Page not found');
 }

--- a/src/routes/[...path]/+page.ts
+++ b/src/routes/[...path]/+page.ts
@@ -1,0 +1,5 @@
+import { error } from '@sveltejs/kit';
+
+export function load() {
+	error(404, 'Page not found');
+}


### PR DESCRIPTION
## Summary

### Bug fixes
- Swap amounts displaying 1000x too large — fixed double-shifting of pre-shifted integer strings by `CoinAmount`
- Unknown routes now return a branded 404 instead of a 500 (catch-all route added)
- Rate display in QuickSwap showing duplicate unit ("BTC BTC") and scientific notation (`7.9e-7 BTC`) — fixed
- Typing `,` in the amount field treated as thousands separator instead of decimal — now both `,` and `.` work as decimal delimiter; thousands grouping removed from display

### Swap UI — fee transparency & price impact
- Protocol fee now shown as USD (`≈ $0.05`) instead of raw coin amounts — no more `0.00000001 BTC`
- Exchange fee row added to all three surfaces (SwapOptions, ReviewSwap, QuickSwap): shows **Free** (green) now; one constant flip (`ALTERA_FEE_ACTIVE`) to show **0.25%** (amber) when re-enabled
- Price impact % shown inline, colored green/yellow/red with a warning at ≥10% — uses correct AMM formula `x/(X+x)` (fixes 5% impact on $0.06 trades)
- Warning banner renders at a fixed height (no layout shift when it appears/disappears)
- USD value shown under both From and To input bars
- "Min amount received" label used consistently everywhere; Market Rate row removed from ReviewSwap
- Applied consistently to both `/swap` page (SwapOptions + ReviewSwap) and dashboard QuickSwap card

### Fee architecture — single source of truth
- `getAlteraFeePct(assetIn, assetOut)` exported from `swap.ts`; all three UI components call it — no duplication
- `ALTERA_FEE_ACTIVE = false` is the single toggle: flip it to enable the amber badge and `ref_bps` payload field everywhere simultaneously
- Fee disabled correctly by omitting the field (contract treats `ref_bps: 0` differently from omitting it)

### Pool depth guard
- Swaps exceeding 50% of pool reserve blocked with error banner and disabled button
- Pure `checkExceedsPoolDepth()` extracted to `swapCalc.ts` (unit tested)
- Two-hop routes (BTC↔HIVE) check both pools in sequence

### Slippage UX
- Custom slippage input auto-focuses, validates on blur/Enter, cancels on Escape
- Collapses back to pill selection after entry

### Responsive layout
- Swap card is now a single centered column: 320px min, 480px max on mobile/tablet, 560px on large screens
- Sidebar hides below 860px so it never competes with the swap card; hamburger and overlay dimming updated to match
- Left/right line-chart panels removed entirely

### Dashboard
- Live sHBD APR and real earning estimates
- Branded 404/error page

### Tests
- 46 unit tests covering all swap math, pool depth checks, two-hop routing, and price impact calculations (including regression: small HIVE amounts correctly show <0.05% impact)