### PR TITLE
refactor(sendswap): per-flow isolated $state, split SendDetails into union type

### DIFF
--- a/src/lib/cards/QuickSwap.svelte
+++ b/src/lib/cards/QuickSwap.svelte
@@ -1,11 +1,7 @@
 <script lang="ts">
 	import { getAuth } from '$lib/auth/store';
-	import {
-		blankDetails,
-		SendTxDetails,
-		solveNetworkConstraints,
-		optionsEqual
-	} from '$lib/sendswap/utils/sendUtils';
+	import { solveNetworkConstraints, optionsEqual } from '$lib/sendswap/utils/sendUtils';
+	import { SwapTxState, provideTxState } from '$lib/sendswap/utils/txState.svelte';
 	import swapOptions, {
 		Coin,
 		Network,
@@ -94,17 +90,16 @@
 		return native ?? Network.hiveMainnet;
 	}
 
-	function startDetails() {
+	const txState = new SwapTxState();
+	provideTxState(txState);
+
+	function applyStartDetails() {
 		const stored = loadSwapSelection(SWAP_QUICK_PREF_KEY);
 		const btcFromOption = swapOptions.from.coins.find((c) => c.coin.value === Coin.btc.value);
 		const hiveFromOption = swapOptions.from.coins.find((c) => c.coin.value === Coin.hive.value);
 		const btcToOption = swapOptions.to.coins.find((c) => c.coin.value === Coin.btc.value);
 		const hiveToOption = swapOptions.to.coins.find((c) => c.coin.value === Coin.hive.value);
 
-		// Defaults depend on the connected wallet type:
-		// - Reown BTC wallet → from BTC, to HIVE (only valid FROM is BTC)
-		// - Hive wallet (aioha) → from HIVE, to BTC
-		// Persisted selection overrides for non-forced wallets.
 		const isReownBtc =
 			auth.value?.provider === 'reown' && auth.value.did?.startsWith('did:pkh:bip122:');
 		const isHive = auth.value?.provider === 'aioha';
@@ -114,25 +109,21 @@
 
 		const fromOpt = isReownBtc ? btcFromOption : (findFromOpt(stored?.fromCoin) ?? defaultFrom);
 		const toOpt = isReownBtc ? hiveToOption : (findToOpt(stored?.toCoin) ?? defaultTo);
-		// Always derive the network from the coin's native mainnet — ignore
-		// any persisted `magi` value left over from earlier code.
 		const fromNet = fromOpt ? nativeNetworkFor(fromOpt.coin.value) : undefined;
 		const toNet = toOpt ? nativeNetworkFor(toOpt.coin.value) : undefined;
-		return {
-			...blankDetails(),
-			method: TransferMethod.lightningTransfer,
-			fromCoin: fromOpt ?? undefined,
-			fromNetwork: fromNet,
-			toCoin: toOpt ?? undefined,
-			toNetwork: toNet
-		};
+
+		txState.method = TransferMethod.lightningTransfer;
+		txState.fromCoin = fromOpt ?? undefined;
+		txState.fromNetwork = fromNet;
+		txState.toCoin = toOpt ?? undefined;
+		txState.toNetwork = toNet;
 	}
 
 	let swapDetailsInitialized = $state(false);
 	$effect(() => {
 		if (!auth.value || swapDetailsInitialized) return;
 		swapDetailsInitialized = true;
-		SendTxDetails.set(startDetails());
+		applyStartDetails();
 	});
 
 	// Persist the user's QuickSwap source/target selection (own key — does
@@ -142,10 +133,10 @@
 	// as dependencies on the first (gated) effect run — otherwise this
 	// effect would never re-fire when the user changes a selection.
 	$effect(() => {
-		const fromCoin = $SendTxDetails.fromCoin?.coin.value;
-		const fromNetwork = $SendTxDetails.fromNetwork?.value;
-		const toCoin = $SendTxDetails.toCoin?.coin.value;
-		const toNetwork = $SendTxDetails.toNetwork?.value;
+		const fromCoin = txState.fromCoin?.coin.value;
+		const fromNetwork = txState.fromNetwork?.value;
+		const toCoin = txState.toCoin?.coin.value;
+		const toNetwork = txState.toNetwork?.value;
 		if (!swapDetailsInitialized) return;
 		if (fromCoin || toCoin) {
 			saveSwapSelection(SWAP_QUICK_PREF_KEY, { fromCoin, fromNetwork, toCoin, toNetwork });
@@ -164,7 +155,7 @@
 	$effect(() => {
 		if (!auth.value) return;
 		const provider = auth.value.provider;
-		const toValue = $SendTxDetails.toCoin?.coin.value;
+		const toValue = txState.toCoin?.coin.value;
 
 		const walletMatchesTo =
 			(provider === 'aioha' && (toValue === Coin.hive.value || toValue === Coin.hbd.value)) ||
@@ -175,16 +166,16 @@
 		// Reads of and writes to toUsername must stay untracked — otherwise
 		// writing re-fires the effect and we hit effect_update_depth_exceeded.
 		untrack(() => {
-			const current = $SendTxDetails.toUsername;
+			const current = txState.toUsername;
 			if (walletMatchesTo && walletReceiver) {
 				if (!current || current === lastAutofilledReceiver) {
 					if (current !== walletReceiver) {
-						$SendTxDetails.toUsername = walletReceiver;
+						txState.toUsername = walletReceiver;
 					}
 					lastAutofilledReceiver = walletReceiver;
 				}
 			} else if (current === lastAutofilledReceiver && current) {
-				$SendTxDetails.toUsername = '';
+				txState.toUsername = '';
 				lastAutofilledReceiver = null;
 			}
 		});
@@ -196,11 +187,11 @@
 	});
 	$effect(() => {
 		const result = solveNetworkConstraints(
-			$SendTxDetails.method,
-			$SendTxDetails.fromCoin,
-			$SendTxDetails.toNetwork,
+			txState.method,
+			txState.fromCoin,
+			txState.toNetwork,
 			auth.value?.did,
-			$SendTxDetails.fromNetwork,
+			txState.fromNetwork,
 			true
 		);
 		if (!optionsEqual(result.assetOptions, assetOptions)) assetOptions = result.assetOptions;
@@ -235,11 +226,11 @@
 
 	let possibleCoins: CoinOnNetwork[] = $derived.by(() => {
 		const result: CoinOnNetwork[] = [];
-		if ($SendTxDetails.fromCoin && $SendTxDetails.fromNetwork) {
-			result.push({ coin: $SendTxDetails.fromCoin.coin, network: $SendTxDetails.fromNetwork });
+		if (txState.fromCoin && txState.fromNetwork) {
+			result.push({ coin: txState.fromCoin.coin, network: txState.fromNetwork });
 		}
-		if ($SendTxDetails.toCoin && $SendTxDetails.toNetwork) {
-			result.push({ coin: $SendTxDetails.toCoin.coin, network: $SendTxDetails.toNetwork });
+		if (txState.toCoin && txState.toNetwork) {
+			result.push({ coin: txState.toCoin.coin, network: txState.toNetwork });
 		}
 		const btcIndex = result.findIndex((c) => c.coin.value === Coin.btc.value);
 		if (btcIndex !== -1) {
@@ -250,40 +241,40 @@
 
 	// Single-option list for From amount input so AmountInput does not show internal dropdown
 	const fromOnlyCoinOpts: CoinOnNetwork[] = $derived.by(() => {
-		if (!$SendTxDetails.fromCoin || !$SendTxDetails.fromNetwork) return [];
-		return [{ coin: $SendTxDetails.fromCoin.coin, network: $SendTxDetails.fromNetwork }];
+		if (!txState.fromCoin || !txState.fromNetwork) return [];
+		return [{ coin: txState.fromCoin.coin, network: txState.fromNetwork }];
 	});
 
 	// Single-option list for To amount input
 	const toOnlyCoinOpts: CoinOnNetwork[] = $derived.by(() => {
-		if (!$SendTxDetails.toCoin || !$SendTxDetails.toNetwork) return [];
-		return [{ coin: $SendTxDetails.toCoin.coin, network: $SendTxDetails.toNetwork }];
+		if (!txState.toCoin || !txState.toNetwork) return [];
+		return [{ coin: txState.toCoin.coin, network: txState.toNetwork }];
 	});
 
 	let inputAmount = $state(new CoinAmount(0, Coin.unk));
 	let toInputAmount = $state(new CoinAmount(0, Coin.unk));
 	$effect(() => {
-		if (!$SendTxDetails.fromCoin) return;
-		if (inputAmount.coin.value === $SendTxDetails.fromCoin.coin.value) {
+		if (!txState.fromCoin) return;
+		if (inputAmount.coin.value === txState.fromCoin.coin.value) {
 			const amt = inputAmount.toAmountString();
-			if (amt !== $SendTxDetails.fromAmount) $SendTxDetails.fromAmount = amt;
+			if (amt !== txState.fromAmount) txState.fromAmount = amt;
 		} else {
-			inputAmount.convertTo($SendTxDetails.fromCoin.coin, Network.lightning).then((amt) => {
-				if ($SendTxDetails.fromAmount !== amt.toAmountString()) {
-					$SendTxDetails.fromAmount = amt.toAmountString();
+			inputAmount.convertTo(txState.fromCoin.coin, Network.lightning).then((amt) => {
+				if (txState.fromAmount !== amt.toAmountString()) {
+					txState.fromAmount = amt.toAmountString();
 				}
 			});
 		}
 	});
 	$effect(() => {
-		if (!$SendTxDetails.toCoin) return;
-		if (toInputAmount.coin.value === $SendTxDetails.toCoin.coin.value) {
+		if (!txState.toCoin) return;
+		if (toInputAmount.coin.value === txState.toCoin.coin.value) {
 			const amt = toInputAmount.toAmountString();
-			if (amt !== $SendTxDetails.toAmount) $SendTxDetails.toAmount = amt;
+			if (amt !== txState.toAmount) txState.toAmount = amt;
 		} else {
-			toInputAmount.convertTo($SendTxDetails.toCoin.coin, Network.lightning).then((amt) => {
-				if ($SendTxDetails.toAmount !== amt.toAmountString()) {
-					$SendTxDetails.toAmount = amt.toAmountString();
+			toInputAmount.convertTo(txState.toCoin.coin, Network.lightning).then((amt) => {
+				if (txState.toAmount !== amt.toAmountString()) {
+					txState.toAmount = amt.toAmountString();
 				}
 			});
 		}
@@ -291,9 +282,9 @@
 
 	let fromInTo = $state('');
 	$effect(() => {
-		if ($SendTxDetails.fromCoin && $SendTxDetails.toCoin) {
-			new CoinAmount(1, $SendTxDetails.fromCoin.coin)
-				.convertTo($SendTxDetails.toCoin.coin, Network.lightning)
+		if (txState.fromCoin && txState.toCoin) {
+			new CoinAmount(1, txState.fromCoin.coin)
+				.convertTo(txState.toCoin.coin, Network.lightning)
 				.then((amt) => {
 					fromInTo = formatRateAmount(amt);
 				});
@@ -302,19 +293,17 @@
 
 	let toPriceUsdRaw = $state(0);
 	$effect(() => {
-		if ($SendTxDetails.toCoin) {
-			new CoinAmount(1, $SendTxDetails.toCoin.coin)
-				.convertTo(Coin.usd, Network.lightning)
-				.then((amt) => {
-					toPriceUsdRaw = amt.toNumber();
-				});
+		if (txState.toCoin) {
+			new CoinAmount(1, txState.toCoin.coin).convertTo(Coin.usd, Network.lightning).then((amt) => {
+				toPriceUsdRaw = amt.toNumber();
+			});
 		}
 	});
 
 	let priceImpactPct = $derived.by(() => {
-		const fromCoinDef = $SendTxDetails.fromCoin;
-		const toCoinDef = $SendTxDetails.toCoin;
-		const fromAmount = $SendTxDetails.fromAmount;
+		const fromCoinDef = txState.fromCoin;
+		const toCoinDef = txState.toCoin;
+		const fromAmount = txState.fromAmount;
 		if (!fromCoinDef || !toCoinDef || !fromAmount || fromAmount === '0') return 0;
 		if (!swapResult || swapResult.expectedOutput <= 0n) return 0;
 		const fromAmountInt = new CoinAmount(fromAmount, fromCoinDef.coin).amount;
@@ -357,10 +346,7 @@
 	}
 
 	let exchangeFeePct = $derived(
-		getAlteraFeePct(
-			$SendTxDetails.fromCoin?.coin.value ?? '',
-			$SendTxDetails.toCoin?.coin.value ?? ''
-		)
+		getAlteraFeePct(txState.fromCoin?.coin.value ?? '', txState.toCoin?.coin.value ?? '')
 	);
 
 	/**
@@ -369,7 +355,7 @@
 	 * HBD (≈ $1 pegged). Final-hop fee is in the output coin.
 	 */
 	let totalProtocolFeeUsd = $derived.by(() => {
-		const toCoinDef = $SendTxDetails.toCoin;
+		const toCoinDef = txState.toCoin;
 		if (!swapResult || toPriceUsdRaw <= 0 || !toCoinDef) return null;
 		const finalHopUsd =
 			(Number(swapResult.baseFee) / 10 ** toCoinDef.coin.decimalPlaces) * toPriceUsdRaw;
@@ -397,9 +383,9 @@
 	})();
 
 	$effect(() => {
-		const fromCoin = $SendTxDetails.fromCoin;
-		const toCoin = $SendTxDetails.toCoin;
-		const fromAmount = $SendTxDetails.fromAmount;
+		const fromCoin = txState.fromCoin;
+		const toCoin = txState.toCoin;
+		const fromAmount = txState.fromAmount;
 		if (!fromCoin || !toCoin || !fromAmount || fromAmount === '0') {
 			swapResult = null;
 			return;
@@ -468,7 +454,7 @@
 		}
 		swapResult = result;
 
-		// Mirror the swap calc into $SendTxDetails so ReviewSwap can read
+		// Mirror the swap calc into txState so ReviewSwap can read
 		// the same numbers (fee, slippage, expected output) without
 		// recomputing or showing a "loading…" placeholder. Also drive
 		// the TO amount input from the pool result.
@@ -479,21 +465,20 @@
 			const swapBaseFee = result.baseFee.toString();
 			const swapClpFee = result.clpFee.toString();
 			const swapTotalFee = result.totalFee.toString();
-			if ($SendTxDetails.expectedOutput !== expectedOutput)
-				$SendTxDetails.expectedOutput = expectedOutput;
-			if ($SendTxDetails.slippageBps !== slippageBps) $SendTxDetails.slippageBps = slippageBps;
-			if ($SendTxDetails.minAmountOut !== minAmountOut) $SendTxDetails.minAmountOut = minAmountOut;
-			if ($SendTxDetails.swapBaseFee !== swapBaseFee) $SendTxDetails.swapBaseFee = swapBaseFee;
-			if ($SendTxDetails.swapClpFee !== swapClpFee) $SendTxDetails.swapClpFee = swapClpFee;
-			if ($SendTxDetails.swapTotalFee !== swapTotalFee) $SendTxDetails.swapTotalFee = swapTotalFee;
+			if (txState.expectedOutput !== expectedOutput) txState.expectedOutput = expectedOutput;
+			if (txState.slippageBps !== slippageBps) txState.slippageBps = slippageBps;
+			if (txState.minAmountOut !== minAmountOut) txState.minAmountOut = minAmountOut;
+			if (txState.swapBaseFee !== swapBaseFee) txState.swapBaseFee = swapBaseFee;
+			if (txState.swapClpFee !== swapClpFee) txState.swapClpFee = swapClpFee;
+			if (txState.swapTotalFee !== swapTotalFee) txState.swapTotalFee = swapTotalFee;
 			const hop1 = result.hop1Fee
 				? { asset: result.hop1Fee.asset, totalFee: result.hop1Fee.totalFee.toString() }
 				: undefined;
-			const prevHop1 = $SendTxDetails.swapHop1Fee;
+			const prevHop1 = txState.swapHop1Fee;
 			const hop1Changed = hop1
 				? !prevHop1 || prevHop1.asset !== hop1.asset || prevHop1.totalFee !== hop1.totalFee
 				: !!prevHop1;
-			if (hop1Changed) $SendTxDetails.swapHop1Fee = hop1;
+			if (hop1Changed) txState.swapHop1Fee = hop1;
 
 			// Drive the TO amount input. Wrapped in untrack so reading
 			// toInputAmount here doesn't turn this effect into a loop;
@@ -513,8 +498,8 @@
 	// Clear the TO field when there's no valid swap result, e.g. the
 	// user deleted the FROM amount or picked incompatible coins.
 	$effect(() => {
-		const expectedRaw = $SendTxDetails.expectedOutput;
-		const coin = $SendTxDetails.toCoin?.coin;
+		const expectedRaw = txState.expectedOutput;
+		const coin = txState.toCoin?.coin;
 		if (!coin) return;
 		if (expectedRaw && expectedRaw !== '0') return;
 		untrack(() => {
@@ -551,8 +536,8 @@
 	// Hive (from the L1 account) and BTC (from mempool.space via the
 	// reown BitcoinAdapter address).
 	const maxAmount = $derived.by(() => {
-		const coin = $SendTxDetails.fromCoin?.coin;
-		const network = $SendTxDetails.fromNetwork;
+		const coin = txState.fromCoin?.coin;
+		const network = txState.fromNetwork;
 		if (!coin || !network) return undefined;
 		const raw = getBalanceSmallestUnits($accountBalance, coin, network);
 		if (raw <= 0) return undefined;
@@ -636,7 +621,7 @@
 	 * anyway, but disabling it at pick time is clearer to the user.)
 	 */
 	function isToTokenAllowed(value: string): boolean {
-		const fromValue = $SendTxDetails.fromCoin?.coin.value;
+		const fromValue = txState.fromCoin?.coin.value;
 		return !fromValue || value !== fromValue;
 	}
 
@@ -653,9 +638,11 @@
 		// HIVE/HBD), never Magi.
 		const net = nativeNetworkFor(coinOpt.coin.value);
 		if (currentlyOpen === 'from') {
-			SendTxDetails.update((d) => ({ ...d, fromCoin: coinOpt, fromNetwork: net }));
+			txState.fromCoin = coinOpt;
+			txState.fromNetwork = net;
 		} else {
-			SendTxDetails.update((d) => ({ ...d, toCoin: coinOpt, toNetwork: net }));
+			txState.toCoin = coinOpt;
+			txState.toNetwork = net;
 		}
 		closeDialog();
 	}
@@ -681,7 +668,7 @@
 	let btcDepositQr = $state<string | null>(null);
 	$effect(() => {
 		const addr = btcDepositAddress;
-		const amountStr = $SendTxDetails.fromAmount ?? '0';
+		const amountStr = txState.fromAmount ?? '0';
 		if (!addr) {
 			btcDepositQr = null;
 			return;
@@ -704,17 +691,17 @@
 	});
 	const reviewStatus = $derived({ message: swapStatus, isError: swapError });
 	const hasAmount = $derived(
-		!!$SendTxDetails.fromAmount && $SendTxDetails.fromAmount !== '0' && inputAmount.amount > 0
+		!!txState.fromAmount && txState.fromAmount !== '0' && inputAmount.amount > 0
 	);
 	const sameCoinSelected = $derived(
-		!!$SendTxDetails.fromCoin &&
-			!!$SendTxDetails.toCoin &&
-			$SendTxDetails.fromCoin.coin.value === $SendTxDetails.toCoin.coin.value
+		!!txState.fromCoin &&
+			!!txState.toCoin &&
+			txState.fromCoin.coin.value === txState.toCoin.coin.value
 	);
-	const missingReceiver = $derived(!$SendTxDetails.toUsername?.trim());
+	const missingReceiver = $derived(!txState.toUsername?.trim());
 	const exceedsBalance = $derived.by(() => {
-		const coin = $SendTxDetails.fromCoin?.coin;
-		const network = $SendTxDetails.fromNetwork;
+		const coin = txState.fromCoin?.coin;
+		const network = txState.fromNetwork;
 		if (!coin || !network) return false;
 		const entered = inputAmount.amount;
 		if (!Number.isFinite(entered) || entered <= 0) return false;
@@ -724,9 +711,9 @@
 	});
 
 	const exceedsPoolDepth = $derived.by(() => {
-		const fromCoin = $SendTxDetails.fromCoin;
-		const toCoin = $SendTxDetails.toCoin;
-		const fromAmount = $SendTxDetails.fromAmount;
+		const fromCoin = txState.fromCoin;
+		const toCoin = txState.toCoin;
+		const fromAmount = txState.fromAmount;
 		if (!fromCoin || !toCoin || !fromAmount || fromAmount === '0') return false;
 		const fromAmountInt = new CoinAmount(fromAmount, fromCoin.coin).amount;
 		if (!Number.isFinite(fromAmountInt) || fromAmountInt <= 0) return false;
@@ -784,7 +771,7 @@
 			setError('Connect your wallet first');
 			return false;
 		}
-		if (!$SendTxDetails.fromCoin || !$SendTxDetails.toCoin) {
+		if (!txState.fromCoin || !txState.toCoin) {
 			setError('Select both tokens');
 			return false;
 		}
@@ -792,7 +779,7 @@
 			setError('From and To assets must be different');
 			return false;
 		}
-		if (!$SendTxDetails.fromAmount || $SendTxDetails.fromAmount === '0') {
+		if (!txState.fromAmount || txState.fromAmount === '0') {
 			setError('Enter an amount');
 			return false;
 		}
@@ -803,8 +790,8 @@
 		// BTC target: receiver must be a valid Bitcoin address on the
 		// appropriate network. Reject early so we never send a swap
 		// instruction with a malformed/non-BTC recipient.
-		if ($SendTxDetails.toCoin?.coin.value === Coin.btc.value) {
-			const addr = $SendTxDetails.toUsername?.trim() ?? '';
+		if (txState.toCoin?.coin.value === Coin.btc.value) {
+			const addr = txState.toUsername?.trim() ?? '';
 			const net = isVscTestnet() ? BtcNetwork.testnet : BtcNetwork.mainnet;
 			if (!validateBtcAddr(addr, net)) {
 				setError(
@@ -824,7 +811,7 @@
 			return false;
 		}
 
-		const fromCoinDef = $SendTxDetails.fromCoin.coin;
+		const fromCoinDef = txState.fromCoin.coin;
 		const provider = auth.value.provider;
 		const did = auth.value.did ?? '';
 		const isHiveAsset =
@@ -858,20 +845,20 @@
 		if (
 			auth.value?.provider === 'reown' &&
 			auth.value.did?.startsWith('did:pkh:bip122:') &&
-			$SendTxDetails.fromCoin?.coin.value === Coin.btc.value
+			txState.fromCoin?.coin.value === Coin.btc.value
 		) {
 			btcDepositAddress = null;
 			btcDepositError = null;
 			btcDepositToggle(true);
 			btcDepositLoading = true;
 			try {
-				const rawReceiver = $SendTxDetails.toUsername?.trim() ?? '';
+				const rawReceiver = txState.toUsername?.trim() ?? '';
 				const normalizedReceiver = rawReceiver.startsWith('hive:')
 					? rawReceiver
 					: rawReceiver.startsWith('@')
 						? `hive:${rawReceiver.slice(1)}`
 						: `hive:${rawReceiver}`;
-				const toAsset = $SendTxDetails.toCoin!.coin.value;
+				const toAsset = txState.toCoin!.coin.value;
 				// Map the target coin to the chain the DEX router should
 				// settle on. Without this the swapped funds stay in Magi
 				// instead of being withdrawn to the user's mainnet wallet.
@@ -926,7 +913,7 @@
 		try {
 			const { sendBtcFromConnectedWallet } =
 				await import('$lib/magiTransactions/bitcoin/walletSend');
-			const satsAmount = new CoinAmount($SendTxDetails.fromAmount ?? '0', Coin.btc).amount;
+			const satsAmount = new CoinAmount(txState.fromAmount ?? '0', Coin.btc).amount;
 			const txHash = await sendBtcFromConnectedWallet({
 				amountSats: satsAmount,
 				recipient: btcDepositAddress,
@@ -947,11 +934,11 @@
 	}
 
 	async function confirmSwap() {
-		if (!auth.value || !$SendTxDetails.fromCoin || !$SendTxDetails.toCoin) return;
+		if (!auth.value || !txState.fromCoin || !txState.toCoin) return;
 
-		const fromCoinDef = $SendTxDetails.fromCoin.coin;
-		const toCoinDef = $SendTxDetails.toCoin.coin;
-		const amount = new CoinAmount($SendTxDetails.fromAmount, fromCoinDef);
+		const fromCoinDef = txState.fromCoin.coin;
+		const toCoinDef = txState.toCoin.coin;
+		const amount = new CoinAmount(txState.fromAmount, fromCoinDef);
 		const caller = auth.value.did;
 
 		// QuickSwap is mainnet→mainnet: the DEX router must settle
@@ -963,7 +950,7 @@
 			btc: 'BTC'
 		};
 		const destinationChain = destChainMap[toCoinDef.value] ?? '';
-		const swapReceiver = $SendTxDetails.toUsername?.trim() ?? '';
+		const swapReceiver = txState.toUsername?.trim() ?? '';
 		// For Hive targets, prefix with "hive:" if not already
 		const routerRecipient =
 			destinationChain === 'HIVE' && !swapReceiver.startsWith('hive:')
@@ -1006,9 +993,7 @@
 						)
 					);
 				}
-				const minOut = $SendTxDetails.minAmountOut
-					? Number($SendTxDetails.minAmountOut)
-					: undefined;
+				const minOut = txState.minAmountOut ? Number(txState.minAmountOut) : undefined;
 				ops.push(
 					await getHiveSwapOp(
 						username,
@@ -1035,7 +1020,7 @@
 						toCoinDef as typeof Coin.hive | typeof Coin.hbd | typeof Coin.btc,
 						destinationChain || undefined
 					));
-				const storeMin = $SendTxDetails.minAmountOut;
+				const storeMin = txState.minAmountOut;
 				// Contract validates min_amount_out AFTER altera deduction,
 				// so scale the store's pre-fee min down by the same bps.
 				const finalMin =
@@ -1097,7 +1082,7 @@
 				ops: [
 					{
 						data: {
-							amount: new CoinAmount($SendTxDetails.toAmount || '0', toCoinDef).toAmountString(),
+							amount: new CoinAmount(txState.toAmount || '0', toCoinDef).toAmountString(),
 							asset: toCoinDef.unit.toLowerCase(),
 							from: caller,
 							to: caller,
@@ -1150,9 +1135,9 @@
 					openDialog('from');
 				}}
 			>
-				{#if $SendTxDetails.fromCoin}
-					<img src={$SendTxDetails.fromCoin.coin.icon} alt="" class="token-img" />
-					<span class="token-name">{$SendTxDetails.fromCoin.coin.label}</span>
+				{#if txState.fromCoin}
+					<img src={txState.fromCoin.coin.icon} alt="" class="token-img" />
+					<span class="token-name">{txState.fromCoin.coin.label}</span>
 				{:else}
 					<span class="token-name muted">Select token</span>
 				{/if}
@@ -1174,7 +1159,7 @@
 			<div class="balance-row">
 				<span class="balance-label"
 					>Balance: {maxAmount.toPrettyAmountString()}
-					{$SendTxDetails.fromCoin?.coin.label ?? ''}</span
+					{txState.fromCoin?.coin.label ?? ''}</span
 				>
 				<button type="button" class="max-btn" onclick={() => (inputAmount = maxAmount!)}>
 					Max
@@ -1196,9 +1181,9 @@
 			<span class="field-label">To:</span>
 			<span class="network-tag">mainnet</span>
 			<button type="button" class="token-select" onclick={() => openDialog('to')}>
-				{#if $SendTxDetails.toCoin}
-					<img src={$SendTxDetails.toCoin.coin.icon} alt="" class="token-img" />
-					<span class="token-name">{$SendTxDetails.toCoin.coin.label}</span>
+				{#if txState.toCoin}
+					<img src={txState.toCoin.coin.icon} alt="" class="token-img" />
+					<span class="token-name">{txState.toCoin.coin.label}</span>
 				{:else}
 					<span class="token-name muted">Select token</span>
 				{/if}
@@ -1224,7 +1209,7 @@
 				id="quickswap-receiver"
 				type="text"
 				required
-				bind:value={$SendTxDetails.toUsername}
+				bind:value={txState.toUsername}
 				placeholder="username or address"
 				autocomplete="off"
 				spellcheck="false"
@@ -1292,12 +1277,12 @@
 	</div>
 
 	<!-- Swap Details -->
-	{#if $SendTxDetails.fromCoin && $SendTxDetails.toCoin}
+	{#if txState.fromCoin && txState.toCoin}
 		<div class="swap-details">
 			<div class="detail-row">
 				<span class="detail-label">Rate</span>
 				<span class="detail-value"
-					>{fromInTo ? `1 ${$SendTxDetails.fromCoin.coin.label} ≈ ${fromInTo}` : '—'}</span
+					>{fromInTo ? `1 ${txState.fromCoin.coin.label} ≈ ${fromInTo}` : '—'}</span
 				>
 			</div>
 			<div class="detail-row">
@@ -1330,16 +1315,16 @@
 			<div class="detail-row">
 				<span class="detail-label">Route</span>
 				<span class="detail-value route">
-					{$SendTxDetails.fromCoin.coin.label}
+					{txState.fromCoin.coin.label}
 					→
-					{#if $SendTxDetails.fromCoin.coin.value !== 'hbd' && $SendTxDetails.toCoin.coin.value !== 'hbd'}
+					{#if txState.fromCoin.coin.value !== 'hbd' && txState.toCoin.coin.value !== 'hbd'}
 						HBD →
 					{/if}
-					{$SendTxDetails.toCoin.coin.label}
+					{txState.toCoin.coin.label}
 				</span>
 			</div>
-			{#if swapResult && swapResult.minAmountOut > 0n && $SendTxDetails.toCoin}
-				{@const toCoinDef = $SendTxDetails.toCoin.coin}
+			{#if swapResult && swapResult.minAmountOut > 0n && txState.toCoin}
+				{@const toCoinDef = txState.toCoin.coin}
 				{@const minOut = formatFee(swapResult.minAmountOut, toCoinDef.decimalPlaces)}
 				<div class="detail-row">
 					<span class="detail-label">Min amount received</span>
@@ -1413,8 +1398,8 @@
 		<div class="btc-deposit">
 			<p class="btc-deposit-intro">
 				Send exactly the amount below to the address shown. The mapping bot observes the transaction
-				and forwards the swap to <strong>{$SendTxDetails.toUsername ?? ''}</strong> as {$SendTxDetails
-					.toCoin?.coin.label ?? ''} on Magi.
+				and forwards the swap to <strong>{txState.toUsername ?? ''}</strong> as {txState.toCoin
+					?.coin.label ?? ''} on Magi.
 			</p>
 
 			{#if btcDepositLoading}
@@ -1433,7 +1418,7 @@
 				<div class="btc-deposit-field">
 					<span class="btc-deposit-label">Amount</span>
 					<Clipboard
-						value={new CoinAmount($SendTxDetails.fromAmount ?? '0', Coin.btc).toAmountString()}
+						value={new CoinAmount(txState.fromAmount ?? '0', Coin.btc).toAmountString()}
 						label="Amount (BTC)"
 						disabled={false}
 					/>

--- a/src/lib/sendswap/Deposit.svelte
+++ b/src/lib/sendswap/Deposit.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
 	import Dialog from '$lib/zag/Dialog.svelte';
 	import DepositOptions from './stages/deposit/DepositOptions.svelte';
-	import { Coin, Network, type SendDetails } from './utils/sendOptions';
+	import { Coin, Network } from './utils/sendOptions';
 	import { CoinAmount } from '$lib/currency/CoinAmount';
-	import { blankDetails, SendTxDetails } from './utils/sendUtils';
+	import { DepositTxState, provideTxState } from './utils/txState.svelte';
 	import Complete from './stages/Complete.svelte';
 	import ReviewSwap from './stages/ReviewSwap.svelte';
 	import StepsMachine, { type MixedStepsArray } from './StepsMachine.svelte';
 	import { getAuth } from '$lib/auth/store';
 	import { getUsernameFromAuth } from '$lib/getAccountName';
-	import { get } from 'svelte/store';
 	import Card from '$lib/cards/Card.svelte';
 	import Clipboard from '$lib/zag/Clipboard.svelte';
 	import PillButton from '$lib/PillButton.svelte';
@@ -27,41 +26,32 @@
 
 	const auth = $derived(getAuth()());
 
-	function depositDetails(): SendDetails {
-		return {
-			...blankDetails(),
-			toNetwork: Network.magi,
-			toUsername: getUsernameFromAuth(auth) ?? '',
-			slippageBps: undefined
-		};
+	const txState = new DepositTxState();
+	provideTxState(txState);
+
+	function applyDepositDetails() {
+		txState.toNetwork = Network.magi;
+		txState.toUsername = getUsernameFromAuth(auth) ?? '';
+		txState.fromCoin = undefined;
+		txState.fromNetwork = undefined;
+		txState.toCoin = undefined;
+		txState.fromAmount = '0';
+		txState.toAmount = '0';
+		txState.enteredAmount = '0';
+		txState.fee = undefined;
+		txState.account = undefined;
 	}
 
-	// Snapshot whatever SendTxDetails was before the deposit dialog
-	// opened, then restore it on close. The whole dashboard shares a
-	// single global `SendTxDetails` store (QuickSwap, Deposit,
-	// Withdraw, Send all write to it), so seeding deposit defaults
-	// wipes whatever QuickSwap had selected. Without this restore the
-	// user opens Deposit → backs out → QuickSwap is blank.
-	let snapshotBeforeDeposit: SendDetails | null = null;
 	$effect(() => {
-		if (dialogOpen) {
-			// Opening — snapshot the current state BEFORE clobbering.
-			if (!snapshotBeforeDeposit) {
-				snapshotBeforeDeposit = { ...get(SendTxDetails) };
-			}
-			sessionId;
-			SendTxDetails.set(depositDetails());
-		} else if (snapshotBeforeDeposit) {
-			// Closing — restore QuickSwap / previous-card state.
-			SendTxDetails.set(snapshotBeforeDeposit);
-			snapshotBeforeDeposit = null;
-		}
+		if (!dialogOpen) return;
+		sessionId;
+		applyDepositDetails();
 	});
 	$effect(() => {
 		if (!auth || !dialogOpen) return;
 		const username = getUsernameFromAuth(auth);
-		if (username && username !== $SendTxDetails.toUsername) {
-			$SendTxDetails.toUsername = username;
+		if (username && username !== txState.toUsername) {
+			txState.toUsername = username;
 		}
 	});
 
@@ -129,7 +119,7 @@
 			<StepsMachine
 				size="dialog"
 				txType="deposit"
-				resetDetails={depositDetails}
+				resetState={applyDepositDetails}
 				{stepsData}
 				{extraProps}
 				minHeight={512}

--- a/src/lib/sendswap/QuickSend.svelte
+++ b/src/lib/sendswap/QuickSend.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import Dialog from '$lib/zag/Dialog.svelte';
-	import { blankDetails, scanForBalance, SendTxDetails } from './utils/sendUtils';
+	import { scanForBalance } from './utils/sendUtils';
 	import Complete from './stages/Complete.svelte';
 	import ReviewTransfer from './stages/ReviewTransfer.svelte';
 	import swapOptions, { Coin, Network, TransferMethod } from './utils/sendOptions';
 	import QuickTransferOptions from './stages/QuickSendOptions.svelte';
 	import StepsMachine, { type MixedStepsArray } from './StepsMachine.svelte';
+	import { TransferTxState, provideTxState } from './utils/txState.svelte';
 
 	let {
 		dialogOpen = $bindable(),
@@ -17,7 +18,10 @@
 		sessionId: number;
 	} = $props();
 
-	function quickDetails() {
+	const txState = new TransferTxState();
+	provideTxState(txState);
+
+	function applyQuickDetails() {
 		const balOpt = scanForBalance(
 			[Coin.hive, Coin.hbd, Coin.shbd].map((c) => ({
 				coin: c,
@@ -25,23 +29,27 @@
 			}))
 		);
 		const coinOpt = swapOptions.from.coins.find((c) => c.coin.value === balOpt?.coin.value);
-		return {
-			...blankDetails(),
-			fromCoin: coinOpt,
-			fromNetwork: Network.magi,
-			toCoin: coinOpt,
-			toNetwork: Network.magi,
-			method: TransferMethod.magiTransfer
-		};
+		txState.fromCoin = coinOpt;
+		txState.fromNetwork = Network.magi;
+		txState.toCoin = coinOpt;
+		txState.toNetwork = Network.magi;
+		txState.method = TransferMethod.magiTransfer;
+		txState.toUsername = '';
+		txState.toDisplayName = '';
+		txState.memo = '';
+		txState.fromAmount = '0';
+		txState.toAmount = '0';
+		txState.enteredAmount = '0';
+		txState.fee = undefined;
+		txState.account = undefined;
 	}
 
-	// Only seed the SendTxDetails store when the QuickSend dialog actually
-	// opens — otherwise this effect fires on every mount/render and wipes
-	// out QuickSwap's persisted selection (both cards share the same store).
+	// Only seed when the dialog opens — QuickSwap's state is now a separate
+	// instance so there's no longer any cross-contamination.
 	$effect(() => {
 		if (!dialogOpen) return;
 		sessionId;
-		SendTxDetails.set(quickDetails());
+		applyQuickDetails();
 	});
 
 	// STEPS
@@ -64,7 +72,7 @@
 				size="dialog"
 				txType="send"
 				{stepsData}
-				resetDetails={quickDetails}
+				resetState={applyQuickDetails}
 				{extraProps}
 				minHeight={632}
 			/>

--- a/src/lib/sendswap/SendSwap.svelte
+++ b/src/lib/sendswap/SendSwap.svelte
@@ -1,12 +1,7 @@
 <script lang="ts">
 	import { getAuth } from '$lib/auth/store';
-	import swapOptions, {
-		Coin,
-		Network,
-		TransferMethod,
-		type SendDetails
-	} from '$lib/sendswap/utils/sendOptions';
-	import { blankDetails, scanForBalance, SendTxDetails } from '$lib/sendswap/utils/sendUtils';
+	import swapOptions, { Coin, Network, TransferMethod } from '$lib/sendswap/utils/sendOptions';
+	import { scanForBalance } from '$lib/sendswap/utils/sendUtils';
 	import {
 		SWAP_PAGE_PREF_KEY,
 		loadSwapSelection,
@@ -22,11 +17,20 @@
 	import ReviewTransfer from './stages/ReviewTransfer.svelte';
 	import ReviewSwap from './stages/ReviewSwap.svelte';
 	import StepsMachine, { type MixedStepsArray } from './StepsMachine.svelte';
+	import { SwapTxState, TransferTxState, provideTxState } from './utils/txState.svelte';
+	import { untrack } from 'svelte';
 
 	const { txType }: { txType: 'transfer' | 'swap' } = $props();
 
 	const auth = $derived(getAuth()());
-	function startDetails(): SendDetails {
+
+	// txType is a fixed string set by the parent route and never changes for the
+	// lifetime of this component; use untrack to suppress the "captures initial
+	// value" warning while still choosing the right state class at mount time.
+	const txState = untrack(() => txType === 'swap' ? new SwapTxState() : new TransferTxState());
+	provideTxState(txState);
+
+	function applyStartDetails() {
 		if (txType === 'swap') {
 			const stored = loadSwapSelection(SWAP_PAGE_PREF_KEY);
 			const fromOpt =
@@ -37,40 +41,31 @@
 				swapOptions.to.coins.find((c) => c.coin.value === Coin.hive.value);
 			const fromNet = findNetwork(stored?.fromNetwork) ?? Network.magi;
 			const toNet = findNetwork(stored?.toNetwork) ?? Network.magi;
-			return {
-				...blankDetails(),
-				toNetwork: toNet,
-				method: TransferMethod.lightningTransfer,
-				fromCoin: fromOpt,
-				fromNetwork: fromNet,
-				toCoin: toOpt
-			};
+			txState.toNetwork = toNet;
+			txState.method = TransferMethod.lightningTransfer;
+			txState.fromCoin = fromOpt;
+			txState.fromNetwork = fromNet;
+			txState.toCoin = toOpt;
 		} else {
 			const balOpt = scanForBalance(
-				[Coin.hive, Coin.hbd, Coin.shbd].map((c) => ({
-					coin: c,
-					network: Network.magi
-				}))
+				[Coin.hive, Coin.hbd, Coin.shbd].map((c) => ({ coin: c, network: Network.magi }))
 			);
 			const coinOpt = swapOptions.from.coins.find((c) => c.coin.value === balOpt?.coin.value);
-
-			return {
-				...blankDetails(),
-				toNetwork: Network.magi,
-				fromNetwork: Network.magi,
-				fromCoin: coinOpt,
-				toCoin: coinOpt
-			};
+			txState.toNetwork = Network.magi;
+			txState.fromNetwork = Network.magi;
+			txState.fromCoin = coinOpt;
+			txState.toCoin = coinOpt;
 		}
 	}
 
-	SendTxDetails.set(startDetails());
+	applyStartDetails();
+
 	$effect(() => {
 		// sets username for swap
 		if (txType !== 'swap') return;
 		if (auth.value) {
 			const username = getUsernameFromAuth(auth);
-			if (username) $SendTxDetails.toUsername = username;
+			if (username) txState.toUsername = username;
 		}
 	});
 
@@ -79,10 +74,10 @@
 	// stays independent.
 	$effect(() => {
 		if (txType !== 'swap') return;
-		const fromCoin = $SendTxDetails.fromCoin?.coin.value;
-		const fromNetwork = $SendTxDetails.fromNetwork?.value;
-		const toCoin = $SendTxDetails.toCoin?.coin.value;
-		const toNetwork = $SendTxDetails.toNetwork?.value;
+		const fromCoin = txState.fromCoin?.coin.value;
+		const fromNetwork = txState.fromNetwork?.value;
+		const toCoin = txState.toCoin?.coin.value;
+		const toNetwork = txState.toNetwork?.value;
 		// Only save once both sides are populated; partial state isn't useful.
 		if (fromCoin && toCoin) {
 			saveSwapSelection(SWAP_PAGE_PREF_KEY, { fromCoin, fromNetwork, toCoin, toNetwork });
@@ -105,7 +100,7 @@
 </script>
 
 <div class="send-internal-wrapper">
-	<StepsMachine size="page" {txType} resetDetails={startDetails} {stepsData} />
+	<StepsMachine size="page" {txType} resetState={applyStartDetails} {stepsData} />
 </div>
 
 <style lang="scss">

--- a/src/lib/sendswap/StepsMachine.svelte
+++ b/src/lib/sendswap/StepsMachine.svelte
@@ -2,7 +2,8 @@
 	import { getAuth } from '$lib/auth/store';
 	import { CoinAmount } from '$lib/currency/CoinAmount';
 	import { Coin, Network, type NecessarySendDetails } from '$lib/sendswap/utils/sendOptions';
-	import { blankDetails, getTxSessionId, send, SendTxDetails } from '$lib/sendswap/utils/sendUtils';
+	import { getTxSessionId, send } from '$lib/sendswap/utils/sendUtils';
+	import { useTxState } from '$lib/sendswap/utils/txState.svelte';
 	import V4VPopup from '$lib/sendswap/V4VPopup.svelte';
 	import { addLocalTransaction } from '$lib/stores/localStorageTxs';
 	import * as steps from '@zag-js/steps';
@@ -36,7 +37,8 @@
 		size: 'page' | 'dialog';
 		minHeight?: number;
 		txType: string;
-		resetDetails?: typeof blankDetails;
+		/** Called when the user resets back to step 0 from the complete screen. */
+		resetState?: () => void;
 		stepsData: MixedStepsArray;
 		extraProps?: { [key: string]: any };
 		onSubmit?: (
@@ -45,7 +47,9 @@
 		) => Promise<Error | { id: string }>;
 	};
 
-	let { size, minHeight, txType, resetDetails, stepsData, extraProps, onSubmit }: Props = $props();
+	let { size, minHeight, txType, resetState, stepsData, extraProps, onSubmit }: Props = $props();
+
+	const txState = useTxState();
 
 	const auth = $derived(getAuth()());
 	let sessionId = $state(getTxSessionId());
@@ -119,7 +123,7 @@
 		} else if (api.value === api.count) {
 			api.setStep(0);
 			sessionId = getTxSessionId();
-			SendTxDetails.set(resetDetails ? resetDetails() : blankDetails());
+			resetState?.();
 		} else {
 			api.goToPrevStep();
 			setStatus('');
@@ -168,20 +172,20 @@
 
 	// START TRANSACTION
 	function initSend() {
-		console.log('[initSend] store snapshot:', {
-			toAmount: $SendTxDetails.toAmount,
-			fromAmount: $SendTxDetails.fromAmount,
-			enteredAmount: $SendTxDetails.enteredAmount
-		});
-		const store = $SendTxDetails;
-		const fromCoin = store.fromCoin;
-		const fromNetwork = store.fromNetwork;
-		const rawToAmount = store.toAmount;
-		const toUsername = store.toUsername;
-		const memo = store.memo;
+		const fromCoin = txState.fromCoin;
+		const fromNetwork = txState.fromNetwork;
+		const rawToAmount = txState.toAmount;
+		const toUsername = txState.toUsername;
+		const memo = txState.kind === 'transfer' ? txState.memo : undefined;
 		// For deposit/withdraw: toCoin mirrors fromCoin; toNetwork defaults based on txType
-		const toCoin = store.toCoin ?? fromCoin;
-		const toNetwork = store.toNetwork ?? (txType === 'deposit' ? Network.magi : txType === 'withdraw' ? Network.hiveMainnet : undefined);
+		const toCoin = txState.toCoin ?? fromCoin;
+		const toNetwork =
+			txState.toNetwork ??
+			(txType === 'deposit'
+				? Network.magi
+				: txType === 'withdraw'
+					? Network.hiveMainnet
+					: undefined);
 
 		if (!fromCoin || !fromNetwork || !toCoin || !toNetwork) {
 			return new Error('Required field undefined.');
@@ -192,10 +196,10 @@
 		const amount =
 			rawToAmount && rawToAmount !== '0'
 				? rawToAmount
-				: $SendTxDetails.fromAmount && $SendTxDetails.fromAmount !== '0'
-					? $SendTxDetails.fromAmount
-					: $SendTxDetails.enteredAmount && $SendTxDetails.enteredAmount !== '0'
-						? $SendTxDetails.enteredAmount
+				: txState.fromAmount && txState.fromAmount !== '0'
+					? txState.fromAmount
+					: txState.enteredAmount && txState.enteredAmount !== '0'
+						? txState.enteredAmount
 						: rawToAmount;
 
 		const importantDetails: NecessarySendDetails = {
@@ -205,7 +209,11 @@
 			toCoin,
 			toNetwork,
 			toUsername,
-			memo
+			memo,
+			fromAmount: txState.fromAmount,
+			minAmountOut: txState.kind === 'swap' ? txState.minAmountOut : undefined,
+			btcDeductFee: txState.btcDeductFee || undefined,
+			btcMaxFee: txState.btcMaxFee
 		};
 
 		let intermediary = getIntermediaryNetwork(
@@ -300,17 +308,17 @@
 	</div>
 {/key}
 
-{#if showV4VModal && $SendTxDetails.toCoin && $SendTxDetails.toNetwork && $SendTxDetails.fromAmount}
-	{@const toCoin = $SendTxDetails.toCoin}
-	{@const toNetwork = $SendTxDetails.toNetwork}
-	{@const toAmount = $SendTxDetails.toAmount}
+{#if showV4VModal && txState.toCoin && txState.toNetwork && txState.fromAmount}
+	{@const toCoin = txState.toCoin}
+	{@const toNetwork = txState.toNetwork}
+	{@const toAmount = txState.toAmount}
 
 	<V4VPopup
 		from={{ coin: Coin.sats, network: Network.lightning }}
 		to={{ coin: toCoin.coin, network: toNetwork }}
 		{toAmount}
 		{auth}
-		toUsername={$SendTxDetails.toUsername}
+		toUsername={txState.toUsername}
 		onerror={(v) => {
 			if (v.includes('Bad request')) {
 				setStatus('An error occured, please try again.', true);
@@ -330,7 +338,7 @@
 							amount: new CoinAmount(toAmount, toCoin!.coin).toAmountString(),
 							asset: toCoin.coin.unit.toLowerCase(),
 							from: `v4vapp`,
-							to: $SendTxDetails.toUsername,
+							to: txState.toUsername,
 							memo: `altera_id=${id}`,
 							type: 'transfer'
 						},

--- a/src/lib/sendswap/StepsMachine.svelte
+++ b/src/lib/sendswap/StepsMachine.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { getAuth } from '$lib/auth/store';
 	import { CoinAmount } from '$lib/currency/CoinAmount';
-	import { Coin, Network, type NecessarySendDetails } from '$lib/sendswap/utils/sendOptions';
+	import { Coin, Network } from '$lib/sendswap/utils/sendOptions';
 	import { getTxSessionId, send } from '$lib/sendswap/utils/sendUtils';
 	import { useTxState } from '$lib/sendswap/utils/txState.svelte';
 	import V4VPopup from '$lib/sendswap/V4VPopup.svelte';
@@ -172,14 +172,10 @@
 
 	// START TRANSACTION
 	function initSend() {
-		const fromCoin = txState.fromCoin;
-		const fromNetwork = txState.fromNetwork;
-		const rawToAmount = txState.toAmount;
-		const toUsername = txState.toUsername;
-		const memo = txState.kind === 'transfer' ? txState.memo : undefined;
-		// For deposit/withdraw: toCoin mirrors fromCoin; toNetwork defaults based on txType
-		const toCoin = txState.toCoin ?? fromCoin;
-		const toNetwork =
+		// For deposit/withdraw: toCoin mirrors fromCoin; toNetwork defaults based on txType.
+		// Write resolved values back so send() can read them directly from txState.
+		txState.toCoin = txState.toCoin ?? txState.fromCoin;
+		txState.toNetwork =
 			txState.toNetwork ??
 			(txType === 'deposit'
 				? Network.magi
@@ -187,38 +183,13 @@
 					? Network.hiveMainnet
 					: undefined);
 
-		if (!fromCoin || !fromNetwork || !toCoin || !toNetwork) {
+		if (!txState.fromCoin || !txState.fromNetwork || !txState.toCoin || !txState.toNetwork) {
 			return new Error('Required field undefined.');
 		}
 
-		// Use toAmount, but fall back to fromAmount or enteredAmount if toAmount
-		// is stale '0' due to effect timing (e.g. deposit/withdraw sync race)
-		const amount =
-			rawToAmount && rawToAmount !== '0'
-				? rawToAmount
-				: txState.fromAmount && txState.fromAmount !== '0'
-					? txState.fromAmount
-					: txState.enteredAmount && txState.enteredAmount !== '0'
-						? txState.enteredAmount
-						: rawToAmount;
-
-		const importantDetails: NecessarySendDetails = {
-			fromCoin,
-			fromNetwork,
-			amount,
-			toCoin,
-			toNetwork,
-			toUsername,
-			memo,
-			fromAmount: txState.fromAmount,
-			minAmountOut: txState.kind === 'swap' ? txState.minAmountOut : undefined,
-			btcDeductFee: txState.btcDeductFee || undefined,
-			btcMaxFee: txState.btcMaxFee
-		};
-
 		let intermediary = getIntermediaryNetwork(
-			{ coin: fromCoin.coin, network: fromNetwork },
-			{ coin: toCoin.coin, network: toNetwork }
+			{ coin: txState.fromCoin.coin, network: txState.fromNetwork },
+			{ coin: txState.toCoin.coin, network: txState.toNetwork }
 		);
 
 		// console.log('found intermediary network:', intermediary.label);
@@ -231,7 +202,7 @@
 
 		waiting = true;
 		// console.log('waiting for signature');
-		send(importantDetails, auth, intermediary, setStatus, abortSend.signal).then((res) => {
+		send(txState, auth, intermediary, setStatus, abortSend.signal).then((res) => {
 			if (res instanceof Error) {
 				// log the error if it isn't caught
 				console.error(res.message);

--- a/src/lib/sendswap/Withdraw.svelte
+++ b/src/lib/sendswap/Withdraw.svelte
@@ -1,14 +1,10 @@
 <script lang="ts">
 	import Dialog from '$lib/zag/Dialog.svelte';
 	import WithdrawOptions from './stages/withdraw/WithdrawOptions.svelte';
-	import { Network } from './utils/sendOptions';
 	import { WithdrawTxState, provideTxState } from './utils/txState.svelte';
 	import Complete from './stages/Complete.svelte';
 	import ReviewSwap from './stages/ReviewSwap.svelte';
 	import StepsMachine, { type MixedStepsArray } from './StepsMachine.svelte';
-	import { getAuth } from '$lib/auth/store';
-	import { getUsernameFromAuth } from '$lib/getAccountName';
-
 	let {
 		dialogOpen = $bindable(),
 		toggle = $bindable(),
@@ -19,13 +15,11 @@
 		sessionId: number;
 	} = $props();
 
-	const auth = $derived(getAuth()());
-
 	const txState = new WithdrawTxState();
 	provideTxState(txState);
 
 	function applyWithdrawDetails() {
-		txState.toUsername = auth.value?.provider === 'aioha' ? (getUsernameFromAuth(auth) ?? '') : '';
+		txState.toUsername = '';
 		txState.fromCoin = undefined;
 		txState.fromNetwork = undefined;
 		txState.toCoin = undefined;
@@ -44,16 +38,6 @@
 		sessionId;
 		applyWithdrawDetails();
 	});
-	$effect(() => {
-		if (!auth || !dialogOpen) return;
-		if (auth.value?.provider !== 'aioha') return;
-		if (txState.toNetwork?.value === Network.btcMainnet.value) return;
-		const username = getUsernameFromAuth(auth);
-		if (username && username !== txState.toUsername) {
-			txState.toUsername = username;
-		}
-	});
-
 	// STEPS
 	const stepsData: MixedStepsArray = [
 		{ value: 'options', component: WithdrawOptions },

--- a/src/lib/sendswap/Withdraw.svelte
+++ b/src/lib/sendswap/Withdraw.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
 	import Dialog from '$lib/zag/Dialog.svelte';
 	import WithdrawOptions from './stages/withdraw/WithdrawOptions.svelte';
-	import { type SendDetails, Network } from './utils/sendOptions';
-	import { blankDetails, SendTxDetails } from './utils/sendUtils';
+	import { Network } from './utils/sendOptions';
+	import { WithdrawTxState, provideTxState } from './utils/txState.svelte';
 	import Complete from './stages/Complete.svelte';
 	import ReviewSwap from './stages/ReviewSwap.svelte';
 	import StepsMachine, { type MixedStepsArray } from './StepsMachine.svelte';
 	import { getAuth } from '$lib/auth/store';
 	import { getUsernameFromAuth } from '$lib/getAccountName';
-	import { get } from 'svelte/store';
 
 	let {
 		dialogOpen = $bindable(),
@@ -22,38 +21,36 @@
 
 	const auth = $derived(getAuth()());
 
-	function withdrawDetails(): SendDetails {
-		const username = auth.value?.provider === 'aioha' ? (getUsernameFromAuth(auth) ?? '') : '';
-		return {
-			...blankDetails(),
-			toUsername: username,
-			slippageBps: undefined
-		};
+	const txState = new WithdrawTxState();
+	provideTxState(txState);
+
+	function applyWithdrawDetails() {
+		txState.toUsername = auth.value?.provider === 'aioha' ? (getUsernameFromAuth(auth) ?? '') : '';
+		txState.fromCoin = undefined;
+		txState.fromNetwork = undefined;
+		txState.toCoin = undefined;
+		txState.toNetwork = undefined;
+		txState.fromAmount = '0';
+		txState.toAmount = '0';
+		txState.enteredAmount = '0';
+		txState.fee = undefined;
+		txState.account = undefined;
+		txState.btcDeductFee = false;
+		txState.btcMaxFee = undefined;
 	}
 
-	// Snapshot SendTxDetails on open and restore on close so the
-	// Withdraw dialog doesn't wipe QuickSwap's persisted selection
-	// (all dashboard cards share the same global store).
-	let snapshotBeforeWithdraw: SendDetails | null = null;
 	$effect(() => {
-		if (dialogOpen) {
-			if (!snapshotBeforeWithdraw) {
-				snapshotBeforeWithdraw = { ...get(SendTxDetails) };
-			}
-			sessionId;
-			SendTxDetails.set(withdrawDetails());
-		} else if (snapshotBeforeWithdraw) {
-			SendTxDetails.set(snapshotBeforeWithdraw);
-			snapshotBeforeWithdraw = null;
-		}
+		if (!dialogOpen) return;
+		sessionId;
+		applyWithdrawDetails();
 	});
 	$effect(() => {
 		if (!auth || !dialogOpen) return;
 		if (auth.value?.provider !== 'aioha') return;
-		if ($SendTxDetails.toNetwork?.value === Network.btcMainnet.value) return;
+		if (txState.toNetwork?.value === Network.btcMainnet.value) return;
 		const username = getUsernameFromAuth(auth);
-		if (username && username !== $SendTxDetails.toUsername) {
-			$SendTxDetails.toUsername = username;
+		if (username && username !== txState.toUsername) {
+			txState.toUsername = username;
 		}
 	});
 
@@ -77,7 +74,7 @@
 			<StepsMachine
 				size="dialog"
 				txType="withdraw"
-				resetDetails={withdrawDetails}
+				resetState={applyWithdrawDetails}
 				{stepsData}
 				{extraProps}
 				minHeight={512}

--- a/src/lib/sendswap/components/Instructions.svelte
+++ b/src/lib/sendswap/components/Instructions.svelte
@@ -1,16 +1,18 @@
 <script lang="ts">
 	import BasicCopy from '$lib/components/BasicCopy.svelte';
 	import { getAccountNameFromAddress } from '$lib/getAccountName';
-	import { SendTxDetails } from '../utils/sendUtils';
+	import { useTxState } from '../utils/txState.svelte';
 	import { Network } from '../utils/sendOptions';
 	import Card from '$lib/cards/Card.svelte';
 	import { Info } from '@lucide/svelte';
 	import { vscGateway } from '$lib/constants';
 
+	const txState = useTxState();
+
 	let toAccount = $derived(
-		$SendTxDetails.toNetwork?.value === Network.magi.value
+		txState.toNetwork?.value === Network.magi.value
 			? vscGateway
-			: $SendTxDetails.toUsername
+			: txState.toUsername
 	);
 </script>
 
@@ -18,9 +20,9 @@
 	<div class="blurb">
 		<span><Info /></span>
 		<p>
-			Transfer {$SendTxDetails.toCoin?.coin.label} to the following Hive account with your favorite wallet
+			Transfer {txState.toCoin?.coin.label} to the following Hive account with your favorite wallet
 			or exchange.
-			{#if $SendTxDetails.toNetwork?.value === Network.magi.value}
+			{#if txState.toNetwork?.value === Network.magi.value}
 				The account {vscGateway} is a dedicated Hive account controlled by the decentralized VSC
 				consensus. Your funds remain within your wallet on VSC at all times. Please make sure to
 				specify the correct memo when sending Hive or HBD.
@@ -37,12 +39,12 @@
 			<td class="sm-caption label">Transfer To</td>
 			<td class="content"><BasicCopy value={vscGateway}><code>{toAccount}</code></BasicCopy></td>
 		</tr>
-		{#if Number($SendTxDetails.toAmount) > 0}
+		{#if Number(txState.toAmount) > 0}
 			<tr>
 				<td class="sm-caption label">Amount</td>
 				<td class="content"
-					><BasicCopy value={$SendTxDetails.toAmount}>
-						<code>{$SendTxDetails.toAmount}</code> {$SendTxDetails.fromCoin?.coin.label}</BasicCopy
+					><BasicCopy value={txState.toAmount}>
+						<code>{txState.toAmount}</code> {txState.fromCoin?.coin.label}</BasicCopy
 					></td
 				>
 			</tr>
@@ -50,8 +52,8 @@
 		<tr>
 			<td class="sm-caption label">Memo</td>
 			<td class="content"
-				><BasicCopy value={`to=${$SendTxDetails.toUsername}`}
-					><code>to={getAccountNameFromAddress($SendTxDetails.toUsername)}</code></BasicCopy
+				><BasicCopy value={`to=${txState.toUsername}`}
+					><code>to={getAccountNameFromAddress(txState.toUsername)}</code></BasicCopy
 				></td
 			>
 		</tr>

--- a/src/lib/sendswap/components/RecipientCard.svelte
+++ b/src/lib/sendswap/components/RecipientCard.svelte
@@ -4,9 +4,9 @@
 	import {
 		getLastPaidContact,
 		momentToLastPaidString,
-		SendTxDetails,
 		validateAddress
 	} from '$lib/sendswap/utils/sendUtils';
+	import { useTransferState } from '$lib/sendswap/utils/txState.svelte';
 	import { CircleUser, Plus } from '@lucide/svelte';
 	import ContactInfo from './info/ContactInfo.svelte';
 	import PillButton from '$lib/PillButton.svelte';
@@ -14,19 +14,21 @@
 	import ClickableCard from '$lib/cards/ClickableCard.svelte';
 	import { untrack } from 'svelte';
 
+	const txState = useTransferState();
+
 	let {
 		basic = false,
 		contact,
 		edit
 	}: { basic?: boolean; contact?: Contact; edit?: (isOpen?: boolean) => void } = $props();
 
-	const toDid = $derived(getDidFromUsername($SendTxDetails.toUsername));
+	const toDid = $derived(getDidFromUsername(txState.toUsername));
 	let lastPaid: string | undefined = $state();
 	let isValid = $state(false);
 	let loading = $state(false);
 	let debounedUsername = $state('');
 	$effect(() => {
-		const addr = $SendTxDetails.toUsername;
+		const addr = txState.toUsername;
 		untrack(() => {
 			if (!addr || addr === debounedUsername) return;
 			if (!contact) loading = true;
@@ -37,12 +39,12 @@
 					const newDisplayName = contact
 						? contact.label
 						: (result.displayName ?? getAccountNameFromAddress(addr));
-					if ($SendTxDetails.toDisplayName !== newDisplayName)
-						$SendTxDetails.toDisplayName = newDisplayName;
+					if (txState.toDisplayName !== newDisplayName)
+						txState.toDisplayName = newDisplayName;
 				} else {
 					const newDisplayName = contact ? contact.label : getAccountNameFromAddress(addr);
-					if ($SendTxDetails.toDisplayName !== newDisplayName)
-						$SendTxDetails.toDisplayName = newDisplayName;
+					if (txState.toDisplayName !== newDisplayName)
+						txState.toDisplayName = newDisplayName;
 					warningBody = result.error;
 				}
 				loading = false;
@@ -62,7 +64,7 @@
 	);
 
 	const isAddButton = $derived(
-		!(loading || $SendTxDetails.toUsername || contact) || ($SendTxDetails.toUsername && !contact)
+		!(loading || txState.toUsername || contact) || (txState.toUsername && !contact)
 	);
 </script>
 
@@ -78,7 +80,7 @@
 			</span>
 		{:else if contact}
 			<ContactInfo
-				did={$SendTxDetails.toUsername !== '' ? toDid : undefined}
+				did={txState.toUsername !== '' ? toDid : undefined}
 				name={contact.label}
 				icon={contact.image}
 				accounts={contact.addresses}
@@ -86,11 +88,11 @@
 				size={basic ? 'medium' : 'large'}
 				showSelected
 			/>
-		{:else if $SendTxDetails.toUsername}
+		{:else if txState.toUsername}
 			<ContactInfo
 				did={toDid}
-				name={$SendTxDetails.toDisplayName}
-				accounts={[{ address: $SendTxDetails.toUsername, label: 'Primary' }]}
+				name={txState.toDisplayName}
+				accounts={[{ address: txState.toUsername, label: 'Primary' }]}
 				showSelected
 				{lastPaid}
 				warning={warningMsg}

--- a/src/lib/sendswap/components/info/SendSnippets.svelte
+++ b/src/lib/sendswap/components/info/SendSnippets.svelte
@@ -1,14 +1,11 @@
 <script module lang="ts">
-	import { Coin, Network, SendAccount } from '$lib/sendswap/utils/sendOptions';
-	import AccountInfo from './AccountInfo.svelte';
+	import { Coin, Network } from '$lib/sendswap/utils/sendOptions';
 	import AssetInfo from './AssetInfo.svelte';
 	import {
-		SendTxDetails,
 		type CoinOptionParam,
 		type NetworkOptionParam,
 		type RecipientData
 	} from '$lib/sendswap/utils/sendUtils';
-	import { get } from 'svelte/store';
 	import NetworkInfo from './NetworkInfo.svelte';
 	import { type Contact } from '$lib/sendswap/contacts/contacts';
 	import ContactInfo from './ContactInfo.svelte';
@@ -29,7 +26,6 @@
 	}
 	export {
 		assetCardSnippet as assetCard,
-		accountCardSnippet as accountCard,
 		networkCardSnippet as networkCard,
 		contactCardSnippet as contactCard,
 		contactRecentCardSnippet as contactRecentCard,
@@ -51,15 +47,6 @@
 			disabledMemo={fromOpt.disabledMemo}
 			size={params.size}
 		/>
-	{/if}
-	<!-- </div> -->
-{/snippet}
-
-{#snippet accountCardSnippet(account: SendAccount | undefined)}
-	<!-- <div class="card-wrapper"> -->
-	{#if account}
-		{@const store = get(SendTxDetails)}
-		<AccountInfo {account} currentCoin={store.fromCoin?.coin} />
 	{/if}
 	<!-- </div> -->
 {/snippet}

--- a/src/lib/sendswap/contacts/SelectContact.svelte
+++ b/src/lib/sendswap/contacts/SelectContact.svelte
@@ -12,8 +12,10 @@
 	import CreateContact from './CreateContact.svelte';
 	import { contactCard, type ContactObj } from '../components/info/SendSnippets.svelte';
 	import { untrack } from 'svelte';
-	import { SendTxDetails } from '../utils/sendUtils';
+	import { useTxState } from '../utils/txState.svelte';
 	import Confirmation from '$lib/components/Confirmation.svelte';
+
+	const txState = useTxState();
 
 	let {
 		selectedContact = $bindable(),
@@ -120,7 +122,7 @@
 							return;
 						}
 						selectedContact = contact;
-						$SendTxDetails.toUsername = selectedContact.addresses[0].address;
+						txState.toUsername = selectedContact.addresses[0].address;
 						if (valCache) {
 							valCache = undefined;
 						} else {
@@ -131,7 +133,7 @@
 				}
 			}
 			selectedContact = undefined;
-			if (oldContact) $SendTxDetails.toUsername = '';
+			if (oldContact) txState.toUsername = '';
 		});
 	});
 </script>

--- a/src/lib/sendswap/stages/Complete.svelte
+++ b/src/lib/sendswap/stages/Complete.svelte
@@ -3,7 +3,7 @@
 	import { CoinAmount } from '$lib/currency/CoinAmount';
 	import { Coin, Network } from '$lib/sendswap/utils/sendOptions';
 	import moment from 'moment';
-	import { SendTxDetails } from '$lib/sendswap/utils/sendUtils';
+	import { useTxState } from '$lib/sendswap/utils/txState.svelte';
 	import { goto } from '$app/navigation';
 	import PieTimer from '$lib/components/PieTimer.svelte';
 	import PillButton from '$lib/PillButton.svelte';
@@ -18,6 +18,8 @@
 		ALTERA_FEE_BPS,
 		ALTERA_FEE_USD_THRESHOLD
 	} from '$lib/magiTransactions/hive/vscOperations/swap';
+
+	const txState = useTxState();
 
 	let timer = $state<PieTimer>();
 
@@ -65,10 +67,10 @@
 		}
 	});
 
-	const isSend = $derived($SendTxDetails.toUsername !== getUsernameFromAuth(getAuth()()));
+	const isSend = $derived(txState.toUsername !== getUsernameFromAuth(getAuth()()));
 
-	let fromCoin = $derived($SendTxDetails.fromCoin?.coin ?? coins.unk);
-	let toCoin = $derived($SendTxDetails.toCoin?.coin ?? coins.unk);
+	let fromCoin = $derived(txState.fromCoin?.coin ?? coins.unk);
+	let toCoin = $derived(txState.toCoin?.coin ?? coins.unk);
 	function prettyWithDisplayUnit(amt: CoinAmount<Coin>): string {
 		const isNegative = amt.amount < 0;
 		const n = Math.abs(amt.amount) / 10 ** amt.coin.decimalPlaces;
@@ -87,7 +89,7 @@
 	let inUsd = $state('');
 	let grossInUsdNum = $state(0);
 	$effect(() => {
-		new CoinAmount($SendTxDetails.fromAmount, fromCoin)
+		new CoinAmount(txState.fromAmount, fromCoin)
 			.convertTo(Coin.usd, Network.lightning)
 			.then((amount) => {
 				inUsd = amount.toMinFigs();
@@ -95,15 +97,15 @@
 			});
 	});
 	const alteraFeeApplies = $derived(
-		!!$SendTxDetails.toNetwork &&
-			$SendTxDetails.toNetwork.value !== Network.magi.value &&
+		!!txState.toNetwork &&
+			txState.toNetwork.value !== Network.magi.value &&
 			toCoin.value !== Coin.hive.value &&
 			toCoin.value !== Coin.hbd.value &&
 			grossInUsdNum >= ALTERA_FEE_USD_THRESHOLD
 	);
 	const alteraFeeAmount = $derived.by(() => {
 		if (!alteraFeeApplies) return undefined;
-		const out = new CoinAmount($SendTxDetails.toAmount, toCoin);
+		const out = new CoinAmount(txState.toAmount, toCoin);
 		const feeSmallest = Math.floor((out.amount * ALTERA_FEE_BPS) / 10000);
 		if (feeSmallest <= 0) return undefined;
 		return new CoinAmount(feeSmallest, toCoin, true);
@@ -153,18 +155,18 @@
 	<Card>
 		<div class="amount">
 			{#if isSend}
-				<span class="sm-caption">Payment to {$SendTxDetails.toDisplayName}</span>
+				<span class="sm-caption">Payment to {txState.kind === 'transfer' ? txState.toDisplayName : txState.toUsername}</span>
 				<h4>
-					{prettyWithDisplayUnit(new CoinAmount($SendTxDetails.fromAmount, fromCoin))}
+					{prettyWithDisplayUnit(new CoinAmount(txState.fromAmount, fromCoin))}
 					{`(\$US ${inUsd})`}
 				</h4>
-			{:else if $SendTxDetails.toNetwork && $SendTxDetails.fromNetwork}
+			{:else if txState.toNetwork && txState.fromNetwork}
 				<div class="swap-header">
 					<span class="from-icon">
-						<CoinNetworkIcon coin={fromCoin} network={$SendTxDetails.fromNetwork!} size={32} />
+						<CoinNetworkIcon coin={fromCoin} network={txState.fromNetwork!} size={32} />
 					</span>
 					<span class="from-amt">
-						{prettyWithDisplayUnit(new CoinAmount($SendTxDetails.fromAmount, fromCoin))}
+						{prettyWithDisplayUnit(new CoinAmount(txState.fromAmount, fromCoin))}
 						<EqualApproximately size="16" />
 						{`${inUsd} USD`}
 					</span>
@@ -173,10 +175,10 @@
 					</span>
 
 					<span class="to-icon">
-						<CoinNetworkIcon coin={toCoin} network={$SendTxDetails.toNetwork!} size={32} />
+						<CoinNetworkIcon coin={toCoin} network={txState.toNetwork!} size={32} />
 					</span>
 					<span class="to-amt">
-						{prettyWithDisplayUnit(new CoinAmount($SendTxDetails.toAmount, toCoin))}
+						{prettyWithDisplayUnit(new CoinAmount(txState.toAmount, toCoin))}
 					</span>
 				</div>
 			{/if}

--- a/src/lib/sendswap/stages/QuickSendOptions.svelte
+++ b/src/lib/sendswap/stages/QuickSendOptions.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	import { SendTxDetails } from '../utils/sendUtils';
-	import { get } from 'svelte/store';
+	import { useTransferState } from '../utils/txState.svelte';
 	import { getAuth } from '$lib/auth/store';
 	import { getUsernameFromAuth } from '$lib/getAccountName';
 	import AmountInput from '$lib/currency/AmountInput.svelte';
@@ -34,43 +33,42 @@
 		onHomePage: boolean;
 		editStage: (complete: boolean) => void;
 	} = $props();
+
+	const txState = useTransferState();
 	const auth = $derived(getAuth()());
 
 	// EDIT STAGE
 	let toSelf = $derived(
-		$SendTxDetails.toUsername === getUsernameFromAuth(auth) &&
-			$SendTxDetails.fromNetwork?.value === $SendTxDetails.toNetwork?.value
+		txState.toUsername === getUsernameFromAuth(auth) &&
+			txState.fromNetwork?.value === txState.toNetwork?.value
 	);
 	// AMOUNT SECTION
 	let coinAmount = $state(new CoinAmount(0, Coin.hive));
 
 	// EDIT STAGE
 	let stageComplete = $derived(
-		!!$SendTxDetails.fromCoin &&
-			!!$SendTxDetails.fromNetwork &&
+		!!txState.fromCoin &&
+			!!txState.fromNetwork &&
 			coinAmount.amount !== 0 &&
 			!toSelf &&
-			!!$SendTxDetails.toUsername &&
-			!!$SendTxDetails.toNetwork
+			!!txState.toUsername &&
+			!!txState.toNetwork
 	);
 	$effect(() => {
 		editStage(stageComplete);
 	});
 	$effect(() => {
 		const amtStr = coinAmount.toAmountString();
-		SendTxDetails.update((s) => {
-			if (s.fromAmount === amtStr && s.toAmount === amtStr && s.enteredAmount === amtStr) {
-				return s;
-			}
-			return { ...s, fromAmount: amtStr, toAmount: amtStr, enteredAmount: amtStr };
-		});
+		if (txState.fromAmount !== amtStr) txState.fromAmount = amtStr;
+		if (txState.toAmount !== amtStr) txState.toAmount = amtStr;
+		if (txState.enteredAmount !== amtStr) txState.enteredAmount = amtStr;
 	});
 
 	const fromAssetObjs: AssetObject[] = $derived(
 		swapOptions.from.coins.map((opt) => ({
 			...opt.coin,
 			snippet: assetCard,
-			snippetData: { fromOpt: opt, net: $SendTxDetails.toNetwork, size: 'medium' }
+			snippetData: { fromOpt: opt, net: txState.toNetwork, size: 'medium' }
 		}))
 	);
 
@@ -80,16 +78,16 @@
 	let lastMaxBalance = -1;
 	let lastMaxCoin = '';
 	$effect(() => {
-		if (!$SendTxDetails.fromCoin || !$SendTxDetails.fromNetwork) return;
-		if ($SendTxDetails.fromNetwork.value !== Network.magi.value) return;
+		if (!txState.fromCoin || !txState.fromNetwork) return;
+		if (txState.fromNetwork.value !== Network.magi.value) return;
 
-		const coinValue = $SendTxDetails.fromCoin.coin.value;
+		const coinValue = txState.fromCoin.coin.value;
 		if (coinValue in $accountBalance.bal) {
 			const balance = $accountBalance.bal[coinValue as keyof AccountBalance];
 			if (balance !== lastMaxBalance || coinValue !== lastMaxCoin) {
 				lastMaxBalance = balance;
 				lastMaxCoin = coinValue;
-				max = new CoinAmount(balance, $SendTxDetails.fromCoin.coin, true);
+				max = new CoinAmount(balance, txState.fromCoin.coin, true);
 			}
 		}
 	});
@@ -100,10 +98,9 @@
 	};
 
 	$effect(() => {
-		const fromCoin = $SendTxDetails.fromCoin;
-		const current = get(SendTxDetails);
-		if (current.toCoin?.coin.value !== fromCoin?.coin.value) {
-			SendTxDetails.set({ ...current, toCoin: fromCoin });
+		const fromCoin = txState.fromCoin;
+		if (txState.toCoin?.coin.value !== fromCoin?.coin.value) {
+			txState.toCoin = fromCoin;
 		}
 	});
 
@@ -121,7 +118,7 @@
 		contactOpen = open;
 	};
 	let createNew: string | undefined = $derived(
-		!contact && $SendTxDetails.toUsername ? $SendTxDetails.toUsername : undefined
+		!contact && txState.toUsername ? txState.toUsername : undefined
 	);
 	let openToCreate = $state(false);
 	function openContact(create = false) {
@@ -131,8 +128,8 @@
 	let inputId = $state('');
 
 	const inputCoinOpt: CoinOnNetwork[] = $derived(
-		$SendTxDetails.fromCoin && $SendTxDetails.fromNetwork
-			? [{ coin: $SendTxDetails.fromCoin.coin, network: $SendTxDetails.fromNetwork }]
+		txState.fromCoin && txState.fromNetwork
+			? [{ coin: txState.fromCoin.coin, network: txState.fromNetwork }]
 			: [{ coin: Coin.unk, network: Network.unknown }]
 	);
 
@@ -157,23 +154,19 @@
 		const balanceCount = coinsWithBalance.length;
 		if (balanceCount === 0) return;
 
-		const current = get(SendTxDetails);
 		const currentCoinHasBalance =
-			current.fromCoin &&
-			coinsWithBalance.some((item) => item.coin.value === current.fromCoin?.coin.value);
+			txState.fromCoin &&
+			coinsWithBalance.some((item) => item.coin.value === txState.fromCoin?.coin.value);
 		if (currentCoinHasBalance) return;
 
 		const hiveCoin = coinsWithBalance.find((item) => item.coin.value === Coin.hive.value);
 		const coinToSelect = hiveCoin || coinsWithBalance[0];
 
 		if (coinToSelect) {
-			SendTxDetails.set({
-				...current,
-				fromCoin: coinToSelect.coinOpt,
-				fromNetwork: Network.magi,
-				toCoin: coinToSelect.coinOpt,
-				toNetwork: Network.magi
-			});
+			txState.fromCoin = coinToSelect.coinOpt;
+			txState.fromNetwork = Network.magi;
+			txState.toCoin = coinToSelect.coinOpt;
+			txState.toNetwork = Network.magi;
 		}
 	});
 </script>
@@ -201,8 +194,8 @@
 	<SelectAssetFlattened
 		availableCoins={fromAssetObjs}
 		close={toggleAsset}
-		bind:coin={$SendTxDetails.fromCoin}
-		bind:network={$SendTxDetails.fromNetwork}
+		bind:coin={txState.fromCoin}
+		bind:network={txState.fromNetwork}
 		bind:max
 	/>
 {/if}
@@ -212,7 +205,7 @@
 	<div class="sections">
 		<div class="section to">
 			<ContactSearchBox
-				bind:value={$SendTxDetails.toUsername}
+				bind:value={txState.toUsername}
 				bind:selectedContact={contact}
 				placeholder="Enter address"
 			/>
@@ -239,14 +232,14 @@
 					<div class="error">
 						No balance found on your account. Please make a deposit to get started.
 					</div>
-				{:else if $SendTxDetails.fromCoin && $SendTxDetails.fromNetwork}
+				{:else if txState.fromCoin && txState.fromNetwork}
 					<BalanceInfo
-						coin={$SendTxDetails.fromCoin.coin}
-						network={$SendTxDetails.fromNetwork}
+						coin={txState.fromCoin.coin}
+						network={txState.fromNetwork}
 						size="large"
 						styleType="vertical"
 					/>
-					<!-- <AssetInfo coinOpt={$SendTxDetails.fromCoin} size="medium" /> -->
+					<!-- <AssetInfo coinOpt={txState.fromCoin} size="medium" /> -->
 				{:else}
 					<span class="user-icon-placeholder"><Coins size="40" absoluteStrokeWidth={true} /></span>
 					Select Asset
@@ -262,7 +255,7 @@
 					<AmountInput
 						bind:coinAmount
 						coinOpts={inputCoinOpt}
-						expressIn={$SendTxDetails.fromCoin?.coin}
+						expressIn={txState.fromCoin?.coin}
 						maxAmount={max}
 						bind:id={inputId}
 					/>
@@ -276,7 +269,7 @@
 				bind:value={memo}
 				maxlength="300"
 				onchange={() => {
-					$SendTxDetails.memo = memo;
+					txState.memo = memo;
 				}}
 				id="memo-input"
 			/>

--- a/src/lib/sendswap/stages/ReviewSwap.svelte
+++ b/src/lib/sendswap/stages/ReviewSwap.svelte
@@ -4,7 +4,7 @@
 	import { CoinAmount } from '$lib/currency/CoinAmount';
 	import { Coin, Network, TransferMethod } from '$lib/sendswap/utils/sendOptions';
 	import moment from 'moment';
-	import { SendTxDetails } from '$lib/sendswap/utils/sendUtils';
+	import { useTxState } from '$lib/sendswap/utils/txState.svelte';
 	import { Dot, EqualApproximately, X } from '@lucide/svelte';
 	import WaveLoading from '$lib/components/WaveLoading.svelte';
 	import PillButton from '$lib/PillButton.svelte';
@@ -47,6 +47,9 @@
 		popup?: boolean;
 	} = $props();
 
+	const txState = useTxState();
+	const asSwap = $derived(txState.kind === 'swap' ? txState : null);
+
 	// Mark the review stage as "complete" (user can proceed) as soon as it
 	// becomes the active stage. The user clicking the forward button is then
 	// what triggers the actual broadcast.
@@ -83,21 +86,21 @@
 		}
 	});
 
-	let toCoin = $derived($SendTxDetails.toCoin?.coin ?? Coin.unk);
-	let fromCoin = $derived($SendTxDetails.fromCoin?.coin ?? Coin.unk);
+	let toCoin = $derived(txState.toCoin?.coin ?? Coin.unk);
+	let fromCoin = $derived(txState.fromCoin?.coin ?? Coin.unk);
 	let effectiveFromAmount = $derived(
-		$SendTxDetails.fromAmount && $SendTxDetails.fromAmount !== '0'
-			? $SendTxDetails.fromAmount
-			: $SendTxDetails.enteredAmount
+		txState.fromAmount && txState.fromAmount !== '0'
+			? txState.fromAmount
+			: txState.enteredAmount
 	);
 	// Pool fees are now denominated in the OUTPUT asset: the full input
 	// enters the pool and fees are carved off the gross output. So the
 	// "amount in" the user commits is simply the gross entered amount.
 	let netSwapFromAmountCa = $derived(new CoinAmount(effectiveFromAmount, fromCoin));
 	let effectiveToAmount = $derived(
-		$SendTxDetails.toAmount && $SendTxDetails.toAmount !== '0'
-			? $SendTxDetails.toAmount
-			: $SendTxDetails.enteredAmount
+		txState.toAmount && txState.toAmount !== '0'
+			? txState.toAmount
+			: txState.enteredAmount
 	);
 	// When from/to coins differ, the enteredAmount fallback is in the wrong denomination.
 	// Compute the converted "to" amount reactively so it displays correctly.
@@ -109,18 +112,18 @@
 	// Min. row render higher than the To row.
 	let convertedToAmount = $state<CoinAmount<Coin> | undefined>();
 	$effect(() => {
-		const expectedRaw = $SendTxDetails.expectedOutput;
+		const expectedRaw = asSwap?.expectedOutput;
 		if (expectedRaw && expectedRaw !== '0') {
 			convertedToAmount = new CoinAmount(Number(expectedRaw), toCoin, true);
 			return;
 		}
-		const toAmt = $SendTxDetails.toAmount;
+		const toAmt = txState.toAmount;
 		if (toAmt && toAmt !== '0') {
 			convertedToAmount = new CoinAmount(toAmt, toCoin);
 			return;
 		}
 		// toAmount not yet available — convert from the entered amount
-		const entered = $SendTxDetails.enteredAmount;
+		const entered = txState.enteredAmount;
 		if (!entered || entered === '0' || fromCoin.value === toCoin.value) {
 			convertedToAmount = new CoinAmount(entered || '0', toCoin);
 			return;
@@ -128,7 +131,7 @@
 		// Different coins: convert fromCoin → toCoin
 		new CoinAmount(entered, fromCoin).convertTo(toCoin, Network.lightning).then((converted) => {
 			// Only use if toAmount still not set
-			const current = $SendTxDetails.toAmount;
+			const current = txState.toAmount;
 			if (!current || current === '0') {
 				convertedToAmount = converted;
 			}
@@ -195,8 +198,8 @@
 	// user sees what will be deducted from `expectedOutput` and `minAmountOut`.
 	let btcFeeEstimate = $state<BtcFeeEstimate | null>(null);
 	const isToBtcMainnet = $derived(
-		$SendTxDetails.toNetwork?.value === Network.btcMainnet.value &&
-			$SendTxDetails.toCoin?.coin.value === Coin.btc.value
+		txState.toNetwork?.value === Network.btcMainnet.value &&
+			txState.toCoin?.coin.value === Coin.btc.value
 	);
 	$effect(() => {
 		if (!isToBtcMainnet) {
@@ -228,18 +231,18 @@
 	let inUsd = $state<CoinAmount<Coin>>();
 	let feeInUsd = $state<CoinAmount<Coin>>();
 	let total = $derived(
-		!$SendTxDetails.fee
+		!txState.fee
 			? new CoinAmount(effectiveFromAmount, fromCoin)
-			: new CoinAmount(effectiveFromAmount, fromCoin).add($SendTxDetails.fee)
+			: new CoinAmount(effectiveFromAmount, fromCoin).add(txState.fee)
 	);
 	let fromInTo = $state<CoinAmount<Coin>>();
 	$effect(() => {
-		if (!$SendTxDetails.fromCoin || !$SendTxDetails.toCoin) return;
+		if (!txState.fromCoin || !txState.toCoin) return;
 
 		// Prefer the pool-math effective rate (expectedOutput / input)
 		// over the lightning off-chain reference rate. Fees are
 		// output-denominated, so the full entered amount goes into the pool.
-		const expectedRaw = $SendTxDetails.expectedOutput;
+		const expectedRaw = asSwap?.expectedOutput;
 		if (expectedRaw && expectedRaw !== '0') {
 			const expected = Number(expectedRaw);
 			const grossIn = new CoinAmount(effectiveFromAmount, fromCoin).amount;
@@ -250,15 +253,15 @@
 			}
 		}
 
-		new CoinAmount(1, $SendTxDetails.fromCoin.coin)
-			.convertTo($SendTxDetails.toCoin.coin, Network.lightning)
+		new CoinAmount(1, txState.fromCoin.coin)
+			.convertTo(txState.toCoin.coin, Network.lightning)
 			.then((amt) => {
 				fromInTo = amt;
 			});
 	});
 	let isInstructions = $derived(
 		auth.value?.provider === 'reown' &&
-			$SendTxDetails.fromNetwork?.value === Network.hiveMainnet.value
+			txState.fromNetwork?.value === Network.hiveMainnet.value
 	);
 	$effect(() => {
 		netSwapFromAmountCa.convertTo(Coin.usd, Network.lightning).then((amt) => {
@@ -266,7 +269,7 @@
 		});
 	});
 	$effect(() => {
-		$SendTxDetails.fee?.convertTo(Coin.usd, Network.lightning).then((amount) => {
+		txState.fee?.convertTo(Coin.usd, Network.lightning).then((amount) => {
 			feeInUsd = amount;
 		});
 	});
@@ -280,8 +283,8 @@
 			});
 	});
 	const alteraFeeApplies = $derived(
-		!!$SendTxDetails.toNetwork &&
-			$SendTxDetails.toNetwork.value !== Network.magi.value &&
+		!!txState.toNetwork &&
+			txState.toNetwork.value !== Network.magi.value &&
 			toCoin.value !== Coin.hive.value &&
 			toCoin.value !== Coin.hbd.value &&
 			!!grossInUsd &&
@@ -310,9 +313,9 @@
 	// asset, then sum — both amounts are what the user effectively pays.
 	let swapFeeInUsd = $state<CoinAmount<Coin>>();
 	$effect(() => {
-		const totalFeeRaw = $SendTxDetails.swapTotalFee;
-		const hop1 = $SendTxDetails.swapHop1Fee;
-		if (!totalFeeRaw || !$SendTxDetails.toCoin) {
+		const totalFeeRaw = asSwap?.swapTotalFee;
+		const hop1 = asSwap?.swapHop1Fee;
+		if (!totalFeeRaw || !txState.toCoin) {
 			swapFeeInUsd = undefined;
 			return;
 		}
@@ -347,8 +350,8 @@
 	// USD equivalent of the min-amount-out (after Altera fee deduction if applicable).
 	let minAmountInUsd = $state<CoinAmount<Coin>>();
 	$effect(() => {
-		const minRaw = $SendTxDetails.minAmountOut;
-		if (!minRaw || !$SendTxDetails.toCoin) { minAmountInUsd = undefined; return; }
+		const minRaw = asSwap?.minAmountOut;
+		if (!minRaw || !txState.toCoin) { minAmountInUsd = undefined; return; }
 		const minNet = alteraFeeApplies
 			? Math.floor((Number(minRaw) * (10000 - ALTERA_FEE_BPS)) / 10000)
 			: Number(minRaw);
@@ -358,20 +361,20 @@
 	});
 
 	// Whether this is a two-hop swap (determines fee label %).
-	const isTwoHopSwap = $derived(!!$SendTxDetails.swapHop1Fee);
+	const isTwoHopSwap = $derived(!!asSwap?.swapHop1Fee);
 
 	let today = moment().format('MMM D, YYYY');
 
 	const senderAddress = $derived(
 		auth.value ? (getUsernameFromAuth(auth) ?? auth.value.address ?? '') : ''
 	);
-	const receiverAddress = $derived($SendTxDetails.toUsername ?? '');
+	const receiverAddress = $derived(txState.toUsername ?? '');
 
 	const isBtcSwap = $derived(
 		fromCoin.value === Coin.btc.value || toCoin.value === Coin.btc.value
 	);
 	const settlementTime = $derived(
-		isBtcSwap ? 'About 10 minutes' : ($SendTxDetails.method?.length ?? '')
+		isBtcSwap ? 'About 10 minutes' : (txState.method?.length ?? '')
 	);
 
 	const exchangeFeePct = $derived(getAlteraFeePct(fromCoin.value, toCoin.value));
@@ -394,13 +397,13 @@
 				</svg>
 				<table>
 					<tbody>
-						{#if $SendTxDetails.fromCoin && $SendTxDetails.fromNetwork}
+						{#if txState.fromCoin && txState.fromNetwork}
 							<tr>
 								<td class="icon">
-									<CoinNetworkIcon coin={fromCoin} network={$SendTxDetails.fromNetwork} size={32} />
+									<CoinNetworkIcon coin={fromCoin} network={txState.fromNetwork} size={32} />
 								</td>
 								<td class="sm-caption label"
-									>From {fromCoinDisplayLabel} on {$SendTxDetails.fromNetwork?.label}{senderAddress
+									>From {fromCoinDisplayLabel} on {txState.fromNetwork?.label}{senderAddress
 										? ` (${senderAddress})`
 										: ''}</td
 								>
@@ -420,8 +423,8 @@
 							<td class="icon"><Dot size="32" /></td>
 							<td class="sm-caption label">Fee</td>
 							<td class="content">
-								{#if $SendTxDetails.swapTotalFee && $SendTxDetails.toCoin}
-									{@const hop1 = $SendTxDetails.swapHop1Fee}
+								{#if asSwap?.swapTotalFee && txState.toCoin}
+									{@const hop1 = asSwap.swapHop1Fee}
 									{@const hop1Coin = hop1
 										? hop1.asset === Coin.hbd.value
 											? Coin.hbd
@@ -441,12 +444,12 @@
 											{/if}
 										</span>
 									</div>
-								{:else if $SendTxDetails.method?.value === TransferMethod.magiTransfer.value}
+								{:else if txState.method?.value === TransferMethod.magiTransfer.value}
 									No fee
-								{:else if !$SendTxDetails.fee || !feeInUsd}
+								{:else if !txState.fee || !feeInUsd}
 									<div class="fee-loading"><WaveLoading /></div>
 								{:else}
-									{prettyWithDisplayUnit($SendTxDetails.fee)}
+									{prettyWithDisplayUnit(txState.fee)}
 									<EqualApproximately size={16} />
 									{feeInUsd.toPrettyString()}
 								{/if}
@@ -461,7 +464,7 @@
 								</td>
 							</tr>
 						{/if}
-						{#if $SendTxDetails.toCoin && $SendTxDetails.toNetwork}
+						{#if txState.toCoin && txState.toNetwork}
 							{@const rawTo = convertedToAmount ?? new CoinAmount(effectiveToAmount, toCoin)}
 							{@const netToAmount = Math.max(0, rawTo.amount - (alteraFeeAmount?.amount ?? 0))}
 							{#if isToBtcMainnet && btcFeeEstimate}
@@ -493,10 +496,10 @@
 							{/if}
 							<tr>
 								<td class="icon">
-									<CoinNetworkIcon coin={toCoin} network={$SendTxDetails.toNetwork} size={32} />
+									<CoinNetworkIcon coin={toCoin} network={txState.toNetwork} size={32} />
 								</td>
 								<td class="sm-caption label"
-									>To {toCoinDisplayLabel} on {$SendTxDetails.toNetwork?.label}{receiverAddress
+									>To {toCoinDisplayLabel} on {txState.toNetwork?.label}{receiverAddress
 										? ` (${receiverAddress})`
 										: ''}</td
 								>
@@ -523,17 +526,17 @@
 									{/if}
 								</td>
 							</tr>
-							{#if $SendTxDetails.slippageBps != null}
+							{#if asSwap?.slippageBps != null}
 								<tr>
 									<td class="icon"><Dot size="32" /></td>
 									<td class="sm-caption label">Min amount received</td>
 									<td class="content">
-										{#if $SendTxDetails.minAmountOut && $SendTxDetails.toCoin}
+										{#if asSwap.minAmountOut && txState.toCoin}
 											{@const minRaw = alteraFeeApplies
 												? Math.floor(
-														(Number($SendTxDetails.minAmountOut) * (10000 - ALTERA_FEE_BPS)) / 10000
+														(Number(asSwap.minAmountOut) * (10000 - ALTERA_FEE_BPS)) / 10000
 													)
-												: Number($SendTxDetails.minAmountOut)}
+												: Number(asSwap.minAmountOut)}
 											{#if btcFeeEstimate}
 												~{prettyRangeWithDisplayUnit(
 													new CoinAmount(
@@ -571,12 +574,6 @@
 					<span class="sm-caption label">Initiated On</span>
 					<span class="content">{today}</span>
 				</li>
-				{#if $SendTxDetails.memo}
-					<li class="side-by-side memo">
-						<span class="sm-caption label">Memo</span>
-						<span class="content">{$SendTxDetails.memo}</span>
-					</li>
-				{/if}
 			</ul>
 		</Card>
 	</div>
@@ -642,12 +639,6 @@
 	tbody,
 	tr {
 		width: calc(100% - 1rem);
-	}
-	.memo {
-		width: calc(100% - 1rem);
-		margin: 0 0.5rem;
-		padding: 1rem 0;
-		border-bottom: 1px solid var(--dash-card-border);
 	}
 	tr {
 		display: grid;

--- a/src/lib/sendswap/stages/ReviewTransfer.svelte
+++ b/src/lib/sendswap/stages/ReviewTransfer.svelte
@@ -9,11 +9,13 @@
 	} from '$lib/getAccountName';
 	import { Coin, Network, SendAccount } from '$lib/sendswap/utils/sendOptions';
 	import moment from 'moment';
-	import { SendTxDetails } from '$lib/sendswap/utils/sendUtils';
+	import { useTransferState } from '$lib/sendswap/utils/txState.svelte';
 	import { ArrowDown } from '@lucide/svelte';
 	import BasicCopy from '$lib/components/BasicCopy.svelte';
 	import Instructions from '../components/Instructions.svelte';
 	import TxStatus from '../components/shared/TxStatus.svelte';
+
+	const txState = useTransferState();
 
 	let auth = $derived(getAuth()());
 	let {
@@ -38,43 +40,43 @@
 		}
 	});
 
-	let toCoin = $derived($SendTxDetails.toCoin?.coin ?? coins.unk);
-	let fromCoin = $derived($SendTxDetails.fromCoin?.coin ?? coins.unk);
+	let toCoin = $derived(txState.toCoin?.coin ?? coins.unk);
+	let fromCoin = $derived(txState.fromCoin?.coin ?? coins.unk);
 	let inUsd = $state('');
 	let isInstructions = $derived(
 		auth.value?.provider === 'reown' &&
-			$SendTxDetails.fromNetwork?.value === Network.hiveMainnet.value
+			txState.fromNetwork?.value === Network.hiveMainnet.value
 	);
 	$effect(() => {
-		new CoinAmount($SendTxDetails.toAmount, toCoin)
+		new CoinAmount(txState.toAmount, toCoin)
 			.convertTo(Coin.usd, Network.lightning)
 			.then((amount) => {
 				inUsd = amount.toMinFigs();
 			});
 	});
-	let isSwap = $derived($SendTxDetails.account?.value === SendAccount.swap.value);
+	let isSwap = $derived(txState.account?.value === SendAccount.swap.value);
 	let today = moment().format('MMM D, YYYY');
 	// let fromAccount = $derived.by(() => {
-	// 	if ($SendTxDetails.account?.value === SendAccount.magiAccount.value) {
-	// 		return $SendTxDetails.account.label;
+	// 	if (txState.account?.value === SendAccount.magiAccount.value) {
+	// 		return txState.account.label;
 	// 	}
-	// 	if ($SendTxDetails.account?.value === SendAccount.deposit.value) {
-	// 		return `Deposit from ${$SendTxDetails.fromNetwork?.label ?? 'UNK'}`;
+	// 	if (txState.account?.value === SendAccount.deposit.value) {
+	// 		return `Deposit from ${txState.fromNetwork?.label ?? 'UNK'}`;
 	// 	}
 	// 	if (isSwap) {
-	// 		return `Swap from ${$SendTxDetails.fromNetwork?.label ?? 'UNK'}`;
+	// 		return `Swap from ${txState.fromNetwork?.label ?? 'UNK'}`;
 	// 	}
 	// });
 	let fromNetwork = $derived.by(() => {
-		if ($SendTxDetails.fromNetwork?.value === Network.hiveMainnet.value) {
-			return `Deposit from ${$SendTxDetails.fromNetwork.label}`;
+		if (txState.fromNetwork?.value === Network.hiveMainnet.value) {
+			return `Deposit from ${txState.fromNetwork.label}`;
 		}
-		if ($SendTxDetails.fromNetwork?.value === Network.lightning.value) {
-			return `Swap from ${$SendTxDetails.fromNetwork.label}`;
+		if (txState.fromNetwork?.value === Network.lightning.value) {
+			return `Swap from ${txState.fromNetwork.label}`;
 		}
-		return $SendTxDetails.fromNetwork?.label ?? 'UNK';
+		return txState.fromNetwork?.label ?? 'UNK';
 	});
-	let toDid = $derived(getDidFromUsername($SendTxDetails.toUsername));
+	let toDid = $derived(getDidFromUsername(txState.toUsername));
 
 	// $inspect(waiting);
 </script>
@@ -85,16 +87,16 @@
 	<Instructions />
 {:else}
 	<Card>
-		<span class="dark sm-caption">Payment to {$SendTxDetails.toDisplayName}</span>
+		<span class="dark sm-caption">Payment to {txState.toDisplayName}</span>
 		<div class={['amount', { compact }]}>
 			{#if isSwap}
 				<div class="swap-header">
-					<p>{new CoinAmount($SendTxDetails.fromAmount, fromCoin).toPrettyString()}</p>
+					<p>{new CoinAmount(txState.fromAmount, fromCoin).toPrettyString()}</p>
 					<ArrowDown />
 				</div>
 			{/if}
 			<h4>
-				{new CoinAmount($SendTxDetails.toAmount, toCoin).toPrettyString()}
+				{new CoinAmount(txState.toAmount, toCoin).toPrettyString()}
 				{`(${inUsd} US$)`}
 			</h4>
 		</div>
@@ -107,16 +109,16 @@
 	<div class={['recipient', { compact }]}>
 		<table>
 			<tbody>
-				{#if $SendTxDetails.toDisplayName !== $SendTxDetails.toUsername}
+				{#if txState.toDisplayName !== txState.toUsername}
 					<tr>
 						<td class="sm-caption label">Recipient</td>
-						<td class="content">{$SendTxDetails.toDisplayName}</td>
+						<td class="content">{txState.toDisplayName}</td>
 					</tr>
 				{/if}
 				<tr>
 					<td class="sm-caption label">Address</td>
 					<td class="content">
-						<BasicCopy value={$SendTxDetails.toUsername}>{getAccountNameFromDid(toDid)}</BasicCopy>
+						<BasicCopy value={txState.toUsername}>{getAccountNameFromDid(toDid)}</BasicCopy>
 					</td>
 				</tr>
 				<tr>
@@ -128,7 +130,7 @@
 				</tr>
 				<tr>
 					<td class="sm-caption label">Network</td>
-					<td class="content">{$SendTxDetails.toNetwork?.label}</td>
+					<td class="content">{txState.toNetwork?.label}</td>
 				</tr>
 			</tbody>
 		</table>
@@ -146,7 +148,7 @@
 					<td class="sm-caption label">Network</td>
 					<td class="content">{fromNetwork}</td>
 				</tr>
-				{#if isSwap && $SendTxDetails.fee}
+				{#if isSwap && txState.fee}
 					<tr>
 						<td class="sm-caption label">Asset</td>
 						<td class="content coin">
@@ -157,13 +159,13 @@
 					<tr>
 						<td class="sm-caption label">Fee</td>
 						<td class="content">
-							{$SendTxDetails.fee}
+							{txState.fee}
 						</td>
 					</tr>
 					<tr>
 						<td class="sm-caption label">Total</td>
 						<td class="content">
-							{$SendTxDetails.fee?.add(new CoinAmount($SendTxDetails.fromAmount, fromCoin))}
+							{txState.fee?.add(new CoinAmount(txState.fromAmount, fromCoin))}
 						</td>
 					</tr>
 				{/if}
@@ -174,13 +176,13 @@
 			</tbody>
 		</table>
 	</div>
-	{#if $SendTxDetails.memo}
+	{#if txState.memo}
 		<div class={['memo', { compact }]}>
 			<table>
 				<tbody>
 					<tr>
 						<td class="sm-caption label">Memo</td>
-						<td class="content">{$SendTxDetails.memo}</td>
+						<td class="content">{txState.memo}</td>
 					</tr>
 				</tbody>
 			</table>

--- a/src/lib/sendswap/stages/SwapDestination.svelte
+++ b/src/lib/sendswap/stages/SwapDestination.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { getAuth } from '$lib/auth/store';
 	import { Coin, Network } from '$lib/sendswap/utils/sendOptions';
-	import { SendTxDetails } from '$lib/sendswap/utils/sendUtils';
+	import { useSwapState } from '$lib/sendswap/utils/txState.svelte';
 	import { Send, Wallet, X } from '@lucide/svelte';
 	import WaveLoading from '$lib/components/WaveLoading.svelte';
 	import PillButton from '$lib/PillButton.svelte';
@@ -10,6 +10,8 @@
 	import { browser } from '$app/environment';
 
 	const DEST_NETWORK_KEY = 'swap-dest-network';
+
+	const txState = useSwapState();
 
 	const auth = $derived(getAuth()());
 	let {
@@ -26,7 +28,7 @@
 		abort?: () => void;
 	} = $props();
 
-	let toCoin = $derived($SendTxDetails.toCoin?.coin ?? Coin.unk);
+	let toCoin = $derived(txState.toCoin?.coin ?? Coin.unk);
 
 	function coinDisplayLabel(coin: (typeof Coin)[keyof typeof Coin]): string {
 		return coin.value === Coin.hive.value
@@ -69,18 +71,18 @@
 	// Update toNetwork based on destination choice
 	$effect(() => {
 		if (destChoice === 'wallet') {
-			if ($SendTxDetails.toNetwork?.value !== Network.magi.value) {
-				$SendTxDetails.toNetwork = Network.magi;
+			if (txState.toNetwork?.value !== Network.magi.value) {
+				txState.toNetwork = Network.magi;
 			}
 		} else {
 			const net =
 				destNetworkChoice === 'magi'
 					? Network.magi
-					: $SendTxDetails.toCoin?.networks?.find(
+					: txState.toCoin?.networks?.find(
 							(n: Network) => n.value !== Network.magi.value
 						) ?? Network.hiveMainnet;
-			if ($SendTxDetails.toNetwork?.value !== net.value) {
-				$SendTxDetails.toNetwork = net;
+			if (txState.toNetwork?.value !== net.value) {
+				txState.toNetwork = net;
 			}
 		}
 	});
@@ -88,7 +90,7 @@
 	// Update toUsername when sending to address
 	$effect(() => {
 		if (destChoice === 'address' && destAddress.trim()) {
-			$SendTxDetails.toUsername = destAddress.trim();
+			txState.toUsername = destAddress.trim();
 		}
 	});
 </script>
@@ -96,9 +98,9 @@
 <div class="swap-dest-wrapper">
 	<span class="deliver-label">DELIVER TO</span>
 
-	{#if $SendTxDetails.toCoin}
+	{#if txState.toCoin}
 		<div class="dest-header">
-			<CoinNetworkIcon coin={toCoin} network={$SendTxDetails.toNetwork ?? Network.magi} size={32} />
+			<CoinNetworkIcon coin={toCoin} network={txState.toNetwork ?? Network.magi} size={32} />
 			<h3>Where should {coinDisplayLabel(toCoin)} go?</h3>
 		</div>
 	{/if}

--- a/src/lib/sendswap/stages/SwapOptions.svelte
+++ b/src/lib/sendswap/stages/SwapOptions.svelte
@@ -4,9 +4,9 @@
 		getFee,
 		getTxSessionId,
 		optionsEqual,
-		SendTxDetails,
 		solveNetworkConstraints
 	} from '$lib/sendswap/utils/sendUtils';
+	import { useSwapState } from '$lib/sendswap/utils/txState.svelte';
 	import { assetCard, type AssetObject } from '$lib/sendswap/components/info/SendSnippets.svelte';
 	import { onMount, untrack } from 'svelte';
 	import swapOptions, {
@@ -54,6 +54,8 @@
 		waiting?: boolean;
 		abort?: () => void;
 	} = $props();
+
+	const txState = useSwapState();
 
 	onMount(() => {
 		// Resolve each swap-eligible pool dynamically so calls are
@@ -120,16 +122,16 @@
 	// in the frontend yet) this ensures the router still gets the
 	// user's chosen tolerance when the tx is built.
 	$effect(() => {
-		if ($SendTxDetails.slippageBps !== slippageBps) {
-			$SendTxDetails.slippageBps = slippageBps;
+		if (txState.slippageBps !== slippageBps) {
+			txState.slippageBps = slippageBps;
 		}
 	});
 
 	// Recalculate swap whenever input amount, coins, or slippage changes.
 	$effect(() => {
-		const fromCoin = $SendTxDetails.fromCoin;
-		const toCoin = $SendTxDetails.toCoin;
-		const fromAmount = $SendTxDetails.fromAmount;
+		const fromCoin = txState.fromCoin;
+		const toCoin = txState.toCoin;
+		const fromAmount = txState.fromAmount;
 		if (!fromCoin || !toCoin || !fromAmount || fromAmount === '0') {
 			swapResult = null;
 			return;
@@ -212,39 +214,39 @@
 			const swapBaseFee = result.baseFee.toString();
 			const swapClpFee = result.clpFee.toString();
 			const swapTotalFee = result.totalFee.toString();
-			if ($SendTxDetails.expectedOutput !== expectedOutput) {
-				$SendTxDetails.expectedOutput = expectedOutput;
+			if (txState.expectedOutput !== expectedOutput) {
+				txState.expectedOutput = expectedOutput;
 			}
-			if ($SendTxDetails.slippageBps !== slippageBps) {
-				$SendTxDetails.slippageBps = slippageBps;
+			if (txState.slippageBps !== slippageBps) {
+				txState.slippageBps = slippageBps;
 			}
-			if ($SendTxDetails.minAmountOut !== minAmountOut) {
-				$SendTxDetails.minAmountOut = minAmountOut;
+			if (txState.minAmountOut !== minAmountOut) {
+				txState.minAmountOut = minAmountOut;
 			}
-			if ($SendTxDetails.swapBaseFee !== swapBaseFee) {
-				$SendTxDetails.swapBaseFee = swapBaseFee;
+			if (txState.swapBaseFee !== swapBaseFee) {
+				txState.swapBaseFee = swapBaseFee;
 			}
-			if ($SendTxDetails.swapClpFee !== swapClpFee) {
-				$SendTxDetails.swapClpFee = swapClpFee;
+			if (txState.swapClpFee !== swapClpFee) {
+				txState.swapClpFee = swapClpFee;
 			}
-			if ($SendTxDetails.swapTotalFee !== swapTotalFee) {
-				$SendTxDetails.swapTotalFee = swapTotalFee;
+			if (txState.swapTotalFee !== swapTotalFee) {
+				txState.swapTotalFee = swapTotalFee;
 			}
 			const hop1 = result.hop1Fee
 				? { asset: result.hop1Fee.asset, totalFee: result.hop1Fee.totalFee.toString() }
 				: undefined;
-			const prevHop1 = $SendTxDetails.swapHop1Fee;
+			const prevHop1 = txState.swapHop1Fee;
 			const hop1Changed = hop1
 				? !prevHop1 || prevHop1.asset !== hop1.asset || prevHop1.totalFee !== hop1.totalFee
 				: !!prevHop1;
 			if (hop1Changed) {
-				$SendTxDetails.swapHop1Fee = hop1;
+				txState.swapHop1Fee = hop1;
 			}
 
 			const outputAmt = new CoinAmount(Number(result.expectedOutput), toCoin.coin, true);
 			const outputStr = outputAmt.toAmountString();
-			if ($SendTxDetails.toAmount !== outputStr) {
-				$SendTxDetails.toAmount = outputStr;
+			if (txState.toAmount !== outputStr) {
+				txState.toAmount = outputStr;
 			}
 		});
 	});
@@ -267,7 +269,7 @@
 	}
 
 	let expectedOutputUsd = $derived.by(() => {
-		const toCoinDef = $SendTxDetails.toCoin;
+		const toCoinDef = txState.toCoin;
 		if (!swapResult || swapResult.expectedOutput <= 0n || toPriceUsdRaw <= 0 || !toCoinDef)
 			return null;
 		return (Number(swapResult.expectedOutput) / 10 ** toCoinDef.coin.decimalPlaces) * toPriceUsdRaw;
@@ -275,8 +277,8 @@
 
 	/** "You Receive" display value — formatted with thousands separator, same locale as the rest of the UI */
 	let formattedToAmount = $derived.by(() => {
-		const raw = $SendTxDetails.toAmount;
-		const toCoinDef = $SendTxDetails.toCoin;
+		const raw = txState.toAmount;
+		const toCoinDef = txState.toCoin;
 		if (!raw || raw === '0' || !toCoinDef) return null;
 		const num = Number(raw);
 		if (!Number.isFinite(num)) return null;
@@ -288,15 +290,15 @@
 	});
 
 	let minAmountOutUsd = $derived.by(() => {
-		const toCoinDef = $SendTxDetails.toCoin;
+		const toCoinDef = txState.toCoin;
 		if (!swapResult || swapResult.minAmountOut <= 0n || toPriceUsdRaw <= 0 || !toCoinDef)
 			return null;
 		return (Number(swapResult.minAmountOut) / 10 ** toCoinDef.coin.decimalPlaces) * toPriceUsdRaw;
 	});
 
 	let inputAmountUsd = $derived.by(() => {
-		const fromCoinDef = $SendTxDetails.fromCoin;
-		const fromAmount = $SendTxDetails.fromAmount;
+		const fromCoinDef = txState.fromCoin;
+		const fromAmount = txState.fromAmount;
 		if (!fromCoinDef || !fromAmount || fromAmount === '0' || fromPriceUsdRaw <= 0) return null;
 		const amt = new CoinAmount(fromAmount, fromCoinDef.coin).toNumber();
 		if (!Number.isFinite(amt) || amt <= 0) return null;
@@ -305,8 +307,8 @@
 
 	let exchangeFeePct = $derived(
 		getAlteraFeePct(
-			$SendTxDetails.fromCoin?.coin.value ?? '',
-			$SendTxDetails.toCoin?.coin.value ?? ''
+			txState.fromCoin?.coin.value ?? '',
+			txState.toCoin?.coin.value ?? ''
 		)
 	);
 
@@ -316,7 +318,7 @@
 	 * HBD (≈ $1 pegged). Final-hop fee is in the output coin.
 	 */
 	let totalProtocolFeeUsd = $derived.by(() => {
-		const toCoinDef = $SendTxDetails.toCoin;
+		const toCoinDef = txState.toCoin;
 		if (!swapResult || toPriceUsdRaw <= 0 || !toCoinDef) return null;
 		const finalHopUsd =
 			(Number(swapResult.baseFee) / 10 ** toCoinDef.coin.decimalPlaces) * toPriceUsdRaw;
@@ -351,18 +353,18 @@
 	// Update toNetwork based on destination choice
 	$effect(() => {
 		if (destChoice === 'wallet') {
-			if ($SendTxDetails.toNetwork?.value !== Network.magi.value) {
-				$SendTxDetails.toNetwork = Network.magi;
+			if (txState.toNetwork?.value !== Network.magi.value) {
+				txState.toNetwork = Network.magi;
 			}
 		} else {
 			const net =
 				destNetworkChoice === 'magi'
 					? Network.magi
-					: ($SendTxDetails.toCoin?.networks?.find(
+					: (txState.toCoin?.networks?.find(
 							(n: Network) => n.value !== Network.magi.value
 						) ?? Network.hiveMainnet);
-			if ($SendTxDetails.toNetwork?.value !== net.value) {
-				$SendTxDetails.toNetwork = net;
+			if (txState.toNetwork?.value !== net.value) {
+				txState.toNetwork = net;
 			}
 		}
 	});
@@ -370,7 +372,7 @@
 	// Update toUsername when sending to address
 	$effect(() => {
 		if (destChoice === 'address' && destAddress.trim()) {
-			$SendTxDetails.toUsername = destAddress.trim();
+			txState.toUsername = destAddress.trim();
 		}
 	});
 
@@ -378,24 +380,24 @@
 	let swapFieldsValid = $state(false);
 	$effect(() => {
 		const valid = !!(
-			$SendTxDetails.toNetwork &&
-			$SendTxDetails.toAmount &&
-			$SendTxDetails.toAmount !== '0' &&
-			$SendTxDetails.toCoin &&
-			$SendTxDetails.fromNetwork &&
-			$SendTxDetails.fromAmount &&
-			$SendTxDetails.fromAmount !== '0' &&
-			$SendTxDetails.fromCoin
+			txState.toNetwork &&
+			txState.toAmount &&
+			txState.toAmount !== '0' &&
+			txState.toCoin &&
+			txState.fromNetwork &&
+			txState.fromAmount &&
+			txState.fromAmount !== '0' &&
+			txState.fromCoin
 		);
 		swapFieldsValid = valid;
 		untrack(() => {
 			if (valid) {
-				getFee($SendTxDetails.toAmount).then((fee) => {
+				getFee(txState.toAmount, txState).then((fee) => {
 					if (
-						fee?.amount !== $SendTxDetails.fee?.amount ||
-						fee?.coin.value !== $SendTxDetails.fee?.coin.value
+						fee?.amount !== txState.fee?.amount ||
+						fee?.coin.value !== txState.fee?.coin.value
 					)
-						$SendTxDetails.fee = fee;
+						txState.fee = fee;
 				});
 			}
 		});
@@ -409,7 +411,7 @@
 		if (destChoice === 'wallet') return true;
 		const addr = destAddress.trim();
 		if (!addr) return false;
-		const isBtcTarget = $SendTxDetails.toCoin?.coin.value === Coin.btc.value;
+		const isBtcTarget = txState.toCoin?.coin.value === Coin.btc.value;
 		const wantsMainnet = destNetworkChoice === 'mainnet';
 		if (isBtcTarget && wantsMainnet) {
 			const net = isVscTestnet() ? BtcNetwork.testnet : BtcNetwork.mainnet;
@@ -426,9 +428,9 @@
 	 * the estimated intermediate amount vs pool2's input reserve.
 	 */
 	let exceedsPoolDepth = $derived.by(() => {
-		const fromCoin = $SendTxDetails.fromCoin;
-		const toCoin = $SendTxDetails.toCoin;
-		const fromAmount = $SendTxDetails.fromAmount;
+		const fromCoin = txState.fromCoin;
+		const toCoin = txState.toCoin;
+		const fromAmount = txState.fromAmount;
 		if (!fromCoin || !toCoin || !fromAmount || fromAmount === '0') return false;
 
 		const fromAmountInt = new CoinAmount(fromAmount, fromCoin.coin).amount;
@@ -458,11 +460,11 @@
 	$effect(() => {
 		const { assetOptions: newAssetOptions, networkOptions: newNetworkOptions } =
 			solveNetworkConstraints(
-				$SendTxDetails.method,
-				$SendTxDetails.fromCoin,
-				$SendTxDetails.toNetwork,
+				txState.method,
+				txState.fromCoin,
+				txState.toNetwork,
 				auth.value?.did,
-				$SendTxDetails.fromNetwork,
+				txState.fromNetwork,
 				true
 			);
 		if (!optionsEqual(newAssetOptions, assetOptions)) {
@@ -475,18 +477,16 @@
 
 	$effect(() => {
 		// FROM auto selection
-		if (!($SendTxDetails.fromCoin && $SendTxDetails.fromNetwork) && assetOptions.length > 0) {
+		if (!(txState.fromCoin && txState.fromNetwork) && assetOptions.length > 0) {
 			const btcOption = assetOptions.find(
 				(opt) => opt.coin.value === Coin.btc.value && !opt.disabled
 			);
 			const firstAvailable = assetOptions.find((opt) => !opt.disabled);
 			const fromOpt = btcOption ?? firstAvailable;
-			if (fromOpt)
-				SendTxDetails.update((d) => ({
-					...d,
-					fromCoin: fromOpt,
-					fromNetwork: Network.magi
-				}));
+			if (fromOpt) {
+				txState.fromCoin = fromOpt;
+				txState.fromNetwork = Network.magi;
+			}
 		}
 
 		// TO auto selection, update only if value changes!
@@ -496,7 +496,7 @@
 			const bal = getBalanceSmallestUnits($accountBalance, coinDef, Network.magi);
 			return bal > 0.001;
 		});
-		if (!($SendTxDetails.toCoin && $SendTxDetails.toNetwork)) {
+		if (!(txState.toCoin && txState.toNetwork)) {
 			let nextToCoin: (typeof swapOptions.to.coins)[number] | undefined;
 			let nextToNetwork: Network | undefined;
 			if (visibleToObjs.length > 0) {
@@ -521,36 +521,34 @@
 				nextToCoin = undefined;
 				nextToNetwork = undefined;
 			}
-			const prevToCoin = $SendTxDetails.toCoin;
-			const prevToNetwork = $SendTxDetails.toNetwork;
+			const prevToCoin = txState.toCoin;
+			const prevToNetwork = txState.toNetwork;
 			const changed =
 				prevToCoin?.coin.value !== nextToCoin?.coin.value ||
 				prevToNetwork?.value !== nextToNetwork?.value;
-			if (changed)
-				SendTxDetails.update((d) => ({
-					...d,
-					toCoin: nextToCoin,
-					toNetwork: nextToNetwork
-				}));
+			if (changed) {
+				txState.toCoin = nextToCoin;
+				txState.toNetwork = nextToNetwork;
+			}
 		}
 	});
 
 	// Same-coin error: show when from and to are the same asset
 	let sameCoinError = $derived(
-		$SendTxDetails.fromCoin && $SendTxDetails.toCoin
-			? $SendTxDetails.fromCoin.coin.value === $SendTxDetails.toCoin.coin.value
+		txState.fromCoin && txState.toCoin
+			? txState.fromCoin.coin.value === txState.toCoin.coin.value
 			: false
 	);
 
 	// Insufficient balance: check if from amount exceeds available balance
 	let insufficientBalance = $derived.by(() => {
-		const from = $SendTxDetails.fromCoin;
-		const fromAmount = $SendTxDetails.fromAmount;
+		const from = txState.fromCoin;
+		const fromAmount = txState.fromAmount;
 		if (!from || !fromAmount || fromAmount === '0') return false;
 		const bal = getBalanceSmallestUnits(
 			$accountBalance,
 			from.coin,
-			$SendTxDetails.fromNetwork ?? Network.magi
+			txState.fromNetwork ?? Network.magi
 		);
 		if (bal <= 0) return true;
 		const inputNum = new CoinAmount(fromAmount, from.coin).toNumber();
@@ -591,43 +589,43 @@
 		swapOptions.to.coins.map((opt) => ({
 			...opt.coin,
 			snippet: assetCard,
-			snippetData: { fromOpt: opt, net: $SendTxDetails.toNetwork, size: 'medium' }
+			snippetData: { fromOpt: opt, net: txState.toNetwork, size: 'medium' }
 		}))
 	);
 	// Only the from coin for the amount input – no dropdown; from is changed only via the left card.
 	let amountInputCoinOpts: CoinOnNetwork[] = $derived(
-		$SendTxDetails.fromCoin && $SendTxDetails.fromNetwork
-			? [{ coin: $SendTxDetails.fromCoin.coin, network: $SendTxDetails.fromNetwork }]
+		txState.fromCoin && txState.fromNetwork
+			? [{ coin: txState.fromCoin.coin, network: txState.fromNetwork }]
 			: []
 	);
 
 	let inputAmount = $state(new CoinAmount(0, Coin.unk));
 	$effect(() => {
-		if (!$SendTxDetails.fromCoin) return;
-		if (inputAmount.coin.value === $SendTxDetails.fromCoin.coin.value) {
+		if (!txState.fromCoin) return;
+		if (inputAmount.coin.value === txState.fromCoin.coin.value) {
 			const amt = inputAmount.toAmountString();
-			if (amt !== $SendTxDetails.fromAmount) $SendTxDetails.fromAmount = amt;
+			if (amt !== txState.fromAmount) txState.fromAmount = amt;
 		} else {
-			inputAmount.convertTo($SendTxDetails.fromCoin.coin, Network.lightning).then((amt) => {
-				if ($SendTxDetails.fromAmount !== amt.toAmountString()) {
-					$SendTxDetails.fromAmount = amt.toAmountString();
+			inputAmount.convertTo(txState.fromCoin.coin, Network.lightning).then((amt) => {
+				if (txState.fromAmount !== amt.toAmountString()) {
+					txState.fromAmount = amt.toAmountString();
 				}
 			});
 		}
 	});
 
 	$effect(() => {
-		if (!$SendTxDetails.toCoin) return;
+		if (!txState.toCoin) return;
 		// When pool-based swap calc is active, it sets toAmount directly
 		// (even when expectedOutput is 0 — e.g. amount exceeds pool reserves)
 		if (swapResult) return;
-		if (inputAmount.coin.value === $SendTxDetails.toCoin.coin.value) {
+		if (inputAmount.coin.value === txState.toCoin.coin.value) {
 			const amt = inputAmount.toAmountString();
-			if (amt !== $SendTxDetails.toAmount) $SendTxDetails.toAmount = amt;
+			if (amt !== txState.toAmount) txState.toAmount = amt;
 		} else {
-			inputAmount.convertTo($SendTxDetails.toCoin.coin, Network.lightning).then((amt) => {
-				if ($SendTxDetails.toAmount !== amt.toAmountString()) {
-					$SendTxDetails.toAmount = amt.toAmountString();
+			inputAmount.convertTo(txState.toCoin.coin, Network.lightning).then((amt) => {
+				if (txState.toAmount !== amt.toAmountString()) {
+					txState.toAmount = amt.toAmountString();
 				}
 			});
 		}
@@ -636,15 +634,15 @@
 	let fromPriceUsdRaw = $state(0);
 	let toPriceUsdRaw = $state(0);
 	$effect(() => {
-		if ($SendTxDetails.fromCoin) {
-			new CoinAmount(1, $SendTxDetails.fromCoin.coin)
+		if (txState.fromCoin) {
+			new CoinAmount(1, txState.fromCoin.coin)
 				.convertTo(Coin.usd, Network.lightning)
 				.then((amt) => {
 					fromPriceUsdRaw = amt.toNumber();
 				});
 		}
-		if ($SendTxDetails.toCoin) {
-			new CoinAmount(1, $SendTxDetails.toCoin.coin)
+		if (txState.toCoin) {
+			new CoinAmount(1, txState.toCoin.coin)
 				.convertTo(Coin.usd, Network.lightning)
 				.then((amt) => {
 					toPriceUsdRaw = amt.toNumber();
@@ -655,7 +653,7 @@
 	let minAmount: CoinAmount<Coin> | undefined = $state();
 	$effect(() => {
 		const amt =
-			$SendTxDetails.fromCoin?.coin.value === Coin.btc.value
+			txState.fromCoin?.coin.value === Coin.btc.value
 				? new CoinAmount(0.00000001, Coin.btc)
 				: undefined;
 		untrack(() => {
@@ -670,8 +668,8 @@
 	// reads from `$accountBalance.connectedBal` (the L1 account
 	// snapshot populated by aioha).
 	const maxAmount: CoinAmount<Coin> | undefined = $derived.by(() => {
-		const from = $SendTxDetails.fromCoin;
-		const fromNet = $SendTxDetails.fromNetwork;
+		const from = txState.fromCoin;
+		const fromNet = txState.fromNetwork;
 		if (!from) return undefined;
 		const coinValue = from.coin.value;
 		if (fromNet?.value === Network.hiveMainnet.value) {
@@ -767,12 +765,14 @@
 	}
 
 	function confirmFromSelection(coinOpt: CoinOptions['coins'][number], network: Network) {
-		SendTxDetails.update((d) => ({ ...d, fromCoin: coinOpt, fromNetwork: network }));
+		txState.fromCoin = coinOpt;
+		txState.fromNetwork = network;
 		closeDialog();
 	}
 
 	function confirmToSelection(coinOpt: CoinOptions['coins'][number], network: Network) {
-		SendTxDetails.update((d) => ({ ...d, toCoin: coinOpt, toNetwork: network }));
+		txState.toCoin = coinOpt;
+		txState.toNetwork = network;
 		closeDialog();
 	}
 
@@ -784,12 +784,12 @@
 				: coin.label;
 	}
 
-	let toCoin = $derived($SendTxDetails.toCoin?.coin ?? Coin.unk);
+	let toCoin = $derived(txState.toCoin?.coin ?? Coin.unk);
 
 	let priceImpactPct = $derived.by(() => {
-		const fromCoinDef = $SendTxDetails.fromCoin;
-		const toCoinDef = $SendTxDetails.toCoin;
-		const fromAmount = $SendTxDetails.fromAmount;
+		const fromCoinDef = txState.fromCoin;
+		const toCoinDef = txState.toCoin;
+		const fromAmount = txState.fromAmount;
 		if (!fromCoinDef || !toCoinDef || !fromAmount || fromAmount === '0') return 0;
 		if (!swapResult || swapResult.expectedOutput <= 0n) return 0;
 		const fromAmountInt = new CoinAmount(fromAmount, fromCoinDef.coin).amount;
@@ -872,14 +872,14 @@
 				<div class="section-header">
 					<span class="section-label">From</span>
 					<span class="section-header-center">
-						{#if $SendTxDetails.fromNetwork}
-							<span class="network-pill">{$SendTxDetails.fromNetwork.label}</span>
+						{#if txState.fromNetwork}
+							<span class="network-pill">{txState.fromNetwork.label}</span>
 						{/if}
 					</span>
 					<span class="section-balance sm-caption">
-						{#if $SendTxDetails.fromCoin && maxAmount}
+						{#if txState.fromCoin && maxAmount}
 							Balance: {maxAmount.toPrettyAmountString()}
-							{coinDisplayLabel($SendTxDetails.fromCoin.coin)}
+							{coinDisplayLabel(txState.fromCoin.coin)}
 						{/if}
 					</span>
 				</div>
@@ -896,13 +896,13 @@
 						/>
 					</div>
 					<button class="token-selector-btn" onclick={() => openDialog('from')}>
-						{#if $SendTxDetails.fromCoin}
+						{#if txState.fromCoin}
 							<img
-								src={$SendTxDetails.fromCoin.coin.icon}
-								alt={coinDisplayLabel($SendTxDetails.fromCoin.coin)}
+								src={txState.fromCoin.coin.icon}
+								alt={coinDisplayLabel(txState.fromCoin.coin)}
 								class="token-icon"
 							/>
-							<span class="token-name">{coinDisplayLabel($SendTxDetails.fromCoin.coin)}</span>
+							<span class="token-name">{coinDisplayLabel(txState.fromCoin.coin)}</span>
 						{:else}
 							<span class="token-name">Select</span>
 						{/if}
@@ -915,9 +915,9 @@
 					</span>
 					{#if sameCoinError}
 						<span class="section-error-inline">Select a different token</span>
-					{:else if insufficientBalance && $SendTxDetails.fromCoin}
+					{:else if insufficientBalance && txState.fromCoin}
 						<span class="section-error-inline"
-							>Insufficient {coinDisplayLabel($SendTxDetails.fromCoin.coin)} balance</span
+							>Insufficient {coinDisplayLabel(txState.fromCoin.coin)} balance</span
 						>
 					{:else if exceedsPoolDepth}
 						<span class="section-error-inline">Amount exceeds pool depth</span>
@@ -937,8 +937,8 @@
 				<div class="section-header">
 					<span class="section-label">You Receive</span>
 					<span class="sm-caption" style="color: var(--dash-text-muted)">
-						{#if $SendTxDetails.toNetwork}
-							{$SendTxDetails.toNetwork.label}
+						{#if txState.toNetwork}
+							{txState.toNetwork.label}
 						{:else}
 							Select destination
 						{/if}
@@ -953,13 +953,13 @@
 						{/if}
 					</div>
 					<button class="token-selector-btn" onclick={() => openDialog('to')}>
-						{#if $SendTxDetails.toCoin}
+						{#if txState.toCoin}
 							<img
-								src={$SendTxDetails.toCoin.coin.icon}
-								alt={coinDisplayLabel($SendTxDetails.toCoin.coin)}
+								src={txState.toCoin.coin.icon}
+								alt={coinDisplayLabel(txState.toCoin.coin)}
 								class="token-icon"
 							/>
-							<span class="token-name">{coinDisplayLabel($SendTxDetails.toCoin.coin)}</span>
+							<span class="token-name">{coinDisplayLabel(txState.toCoin.coin)}</span>
 						{:else}
 							<span class="token-name">Select</span>
 						{/if}
@@ -974,7 +974,7 @@
 			</div>
 
 			<!-- Route Info -->
-			{#if $SendTxDetails.fromCoin && $SendTxDetails.toCoin}
+			{#if txState.fromCoin && txState.toCoin}
 				<div class="route-info">
 					<span class="route-tags">
 						<span class="tag native">Native</span>
@@ -992,11 +992,11 @@
 		<div class="deliver-to-card">
 			<span class="deliver-label">DELIVER TO</span>
 
-			{#if $SendTxDetails.toCoin}
+			{#if txState.toCoin}
 				<div class="dest-header">
 					<CoinNetworkIcon
 						coin={toCoin}
-						network={$SendTxDetails.toNetwork ?? Network.magi}
+						network={txState.toNetwork ?? Network.magi}
 						size={28}
 					/>
 					<h3>Where should {coinDisplayLabel(toCoin)} go?</h3>
@@ -1088,11 +1088,11 @@
 			</div>
 		</div>
 		<!-- Fees Section (collapsible) -->
-		{#if $SendTxDetails.fromCoin && $SendTxDetails.toCoin}
-			{@const fromDec = $SendTxDetails.fromCoin.coin.decimalPlaces}
-			{@const toDec = $SendTxDetails.toCoin.coin.decimalPlaces}
-			{@const fromUnit = coinDisplayLabel($SendTxDetails.fromCoin.coin)}
-			{@const toUnit = coinDisplayLabel($SendTxDetails.toCoin.coin)}
+		{#if txState.fromCoin && txState.toCoin}
+			{@const fromDec = txState.fromCoin.coin.decimalPlaces}
+			{@const toDec = txState.toCoin.coin.decimalPlaces}
+			{@const fromUnit = coinDisplayLabel(txState.fromCoin.coin)}
+			{@const toUnit = coinDisplayLabel(txState.toCoin.coin)}
 			{@const hop1FeeCoin = swapResult?.hop1Fee
 				? swapResult.hop1Fee.asset === Coin.hbd.value
 					? Coin.hbd

--- a/src/lib/sendswap/stages/TransferOptions.svelte
+++ b/src/lib/sendswap/stages/TransferOptions.svelte
@@ -8,11 +8,11 @@
 		getLastPaidContact,
 		getLastPaidNetwork,
 		getRecipientNetworks,
-		SendTxDetails,
 		getFee,
 		solveToNetworks,
 		type NetworkOptionParam
 	} from '../utils/sendUtils';
+	import { useTransferState } from '../utils/txState.svelte';
 	import swapOptions, {
 		Coin,
 		Network,
@@ -54,6 +54,7 @@
 		editStage: (add: boolean) => void;
 	} = $props();
 
+	const txState = useTransferState();
 	const auth = $derived(getAuth()());
 
 	$effect(() => {
@@ -91,12 +92,12 @@
 
 	$effect(() => {
 		if (
-			$SendTxDetails.toUsername &&
-			$SendTxDetails.toNetwork &&
-			$SendTxDetails.toCoin &&
-			$SendTxDetails.fromCoin &&
-			$SendTxDetails.fromNetwork &&
-			$SendTxDetails.toAmount &&
+			txState.toUsername &&
+			txState.toNetwork &&
+			txState.toCoin &&
+			txState.fromCoin &&
+			txState.fromNetwork &&
+			txState.toAmount &&
 			inputAmt.amount > 0 &&
 			inputAmt.amount <= (max?.amount ?? Number.MAX_SAFE_INTEGER) &&
 			!toSelf
@@ -106,7 +107,7 @@
 			editStage(false);
 		}
 	});
-	const toDid = $derived(getDidFromUsername($SendTxDetails.toUsername));
+	const toDid = $derived(getDidFromUsername(txState.toUsername));
 
 	let lastPaid = $state('Never');
 	let lastNetwork = $state('Never');
@@ -114,7 +115,7 @@
 		if (!auth.value) return;
 		Promise.all([
 			getLastPaidContact(toDid),
-			getLastPaidNetwork($SendTxDetails.toNetwork?.value)
+			getLastPaidNetwork(txState.toNetwork?.value)
 		]).then(([paid, net]) => {
 			lastPaid = momentToLastPaidString(paid);
 			lastNetwork = momentToLastPaidString(net);
@@ -122,10 +123,10 @@
 	});
 
 	$effect(() => {
-		const newNetwork = $SendTxDetails.toNetwork;
-		const userNetworks = getRecipientNetworks(getDidFromUsername($SendTxDetails.toUsername));
+		const newNetwork = txState.toNetwork;
+		const userNetworks = getRecipientNetworks(getDidFromUsername(txState.toUsername));
 		if (userNetworks.find((net) => net.value === newNetwork?.value)?.disabled) {
-			$SendTxDetails.toNetwork = Network.magi;
+			txState.toNetwork = Network.magi;
 		}
 	});
 
@@ -138,7 +139,7 @@
 	let toggleContact = $state<(open?: boolean) => void>(() => {});
 	let contact = $state<Contact>();
 	let createNew: string | undefined = $derived(
-		!contact && $SendTxDetails.toUsername ? $SendTxDetails.toUsername : undefined
+		!contact && txState.toUsername ? txState.toUsername : undefined
 	);
 	let openToCreate = $state(false);
 
@@ -147,20 +148,20 @@
 		swapOptions.from.coins.map((opt) => ({
 			...opt.coin,
 			snippet: assetCard,
-			snippetData: { fromOpt: opt, net: $SendTxDetails.toNetwork, size: 'medium' }
+			snippetData: { fromOpt: opt, net: txState.toNetwork, size: 'medium' }
 		}))
 	);
 
 	let isSwap = $derived(
-		$SendTxDetails.fromCoin &&
-			$SendTxDetails.toCoin &&
-			$SendTxDetails.fromCoin?.coin.value !== $SendTxDetails.toCoin?.coin.value
+		txState.fromCoin &&
+			txState.toCoin &&
+			txState.fromCoin?.coin.value !== txState.toCoin?.coin.value
 	);
 
 	// default to USD
 	$effect(() => {
-		if (isSwap && !$SendTxDetails.toCoin) {
-			$SendTxDetails.toCoin = {
+		if (isSwap && !txState.toCoin) {
+			txState.toCoin = {
 				coin: coins.usd,
 				networks: []
 			};
@@ -172,17 +173,17 @@
 	let max: CoinAmount<Coin> | undefined = $state();
 
 	$effect(() => {
-		if ($SendTxDetails.fromAmount !== inputAmt.toAmountString()) {
-			$SendTxDetails.fromAmount = inputAmt.toAmountString();
+		if (txState.fromAmount !== inputAmt.toAmountString()) {
+			txState.fromAmount = inputAmt.toAmountString();
 		}
-		if ($SendTxDetails.toAmount !== inputAmt.toAmountString()) {
-			$SendTxDetails.toAmount = inputAmt.toAmountString();
+		if (txState.toAmount !== inputAmt.toAmountString()) {
+			txState.toAmount = inputAmt.toAmountString();
 		}
 	});
 
 	let toSelf = $derived(
-		$SendTxDetails.toUsername === getUsernameFromAuth(auth) &&
-			$SendTxDetails.fromNetwork?.value === $SendTxDetails.toNetwork?.value
+		txState.toUsername === getUsernameFromAuth(auth) &&
+			txState.fromNetwork?.value === txState.toNetwork?.value
 	);
 
 	let assetOpen = $state(false);
@@ -193,32 +194,33 @@
 	let toNetworkOptions: NetworkOptionParam[] = $state([]);
 	let transferError = $state('');
 	function getDisabledReason() {
-		if ($SendTxDetails.toUsername === getUsernameFromAuth(auth)) {
+		if (txState.toUsername === getUsernameFromAuth(auth)) {
 			return 'Cannot send funds to yourself on the same network.';
 		}
-		if (getDidFromUsername($SendTxDetails.toUsername).startsWith('did:pkh:eip155:1:')) {
+		if (getDidFromUsername(txState.toUsername).startsWith('did:pkh:eip155:1:')) {
 			return 'EVM accounts may only receive funds on Magi.';
 		}
-		if ($SendTxDetails.fromCoin?.coin.value === Coin.shbd.value) {
+		if (txState.fromCoin?.coin.value === Coin.shbd.value) {
 			return 'Cannot transfer sHBD to external networks.';
 		}
 		return 'This option is not available given your parameters.';
 	}
 	$effect(() => {
-		$SendTxDetails;
+		// read reactive fields to track changes
+		txState.toUsername; txState.fromCoin; txState.fromNetwork; txState.toCoin;
 		untrack(() => {
-			const newOptions = solveToNetworks();
+			const newOptions = solveToNetworks(txState);
 			const oldSet = new Set(toNetworkOptions.map((net) => net.value));
 			const newSet = new Set(newOptions.map((net) => net.value));
 			if (
 				newOptions.length === 0 &&
-				$SendTxDetails.toUsername &&
-				$SendTxDetails.fromCoin &&
-				$SendTxDetails.fromNetwork
+				txState.toUsername &&
+				txState.fromCoin &&
+				txState.fromNetwork
 			) {
-				transferError = `Cannot transfer ${$SendTxDetails.fromCoin.coin.label} 
-					from ${$SendTxDetails.fromNetwork.label} 
-					to ${$SendTxDetails.toDisplayName}.`;
+				transferError = `Cannot transfer ${txState.fromCoin.coin.label} 
+					from ${txState.fromNetwork.label} 
+					to ${txState.toDisplayName}.`;
 			} else {
 				transferError = '';
 			}
@@ -243,15 +245,15 @@
 				currentType === 'internal'
 					? Network.magi
 					: toNetworkOptions.find((net) => net.value !== Network.magi.value);
-			if (network?.value === $SendTxDetails.toNetwork?.value) return;
-			$SendTxDetails.toNetwork = network;
+			if (network?.value === txState.toNetwork?.value) return;
+			txState.toNetwork = network;
 		});
 	});
 	$effect(() => {
-		$SendTxDetails.fromCoin;
+		txState.fromCoin;
 		untrack(() => {
-			if ($SendTxDetails.toCoin?.coin.value !== $SendTxDetails.fromCoin?.coin.value) {
-				$SendTxDetails.toCoin = $SendTxDetails.fromCoin;
+			if (txState.toCoin?.coin.value !== txState.fromCoin?.coin.value) {
+				txState.toCoin = txState.fromCoin;
 			}
 		});
 	});
@@ -278,7 +280,7 @@
 						| 'external',
 					label: `${net.value === Network.magi.value ? 'Internal' : 'External'} Transfer`,
 					to: net,
-					from: $SendTxDetails.fromNetwork,
+					from: txState.fromNetwork,
 					snippet: transferBar
 				}))
 				.sort((a, b) => (a.value === b.value ? 0 : a.value === 'internal' ? -1 : 1));
@@ -297,8 +299,8 @@
 	// BTC network-fee estimate (only relevant when the transfer settles out
 	// to BTC mainnet). Matches the math the VSC contract uses at unmap time.
 	const isToBtcMainnet = $derived(
-		$SendTxDetails.fromCoin?.coin.value === Coin.btc.value &&
-			$SendTxDetails.toNetwork?.value === Network.btcMainnet.value
+		txState.fromCoin?.coin.value === Coin.btc.value &&
+			txState.toNetwork?.value === Network.btcMainnet.value
 	);
 	let btcFeeEstimate = $state<BtcFeeEstimate | null>(null);
 	$effect(() => {
@@ -325,8 +327,8 @@
 	let inputId = $state('');
 
 	const coinOpts: CoinOnNetwork[] = $derived(
-		$SendTxDetails.fromCoin && $SendTxDetails.fromNetwork
-			? [{ coin: $SendTxDetails.fromCoin.coin, network: $SendTxDetails.fromNetwork }]
+		txState.fromCoin && txState.fromNetwork
+			? [{ coin: txState.fromCoin.coin, network: txState.fromNetwork }]
 			: [{ coin: Coin.unk, network: Network.unknown }]
 	);
 
@@ -352,8 +354,8 @@
 		if (balanceCount === 0) return;
 
 		const currentCoinHasBalance =
-			$SendTxDetails.fromCoin &&
-			coinsWithBalance.some((item) => item.coin.value === $SendTxDetails.fromCoin?.coin.value);
+			txState.fromCoin &&
+			coinsWithBalance.some((item) => item.coin.value === txState.fromCoin?.coin.value);
 
 		if (currentCoinHasBalance) return;
 
@@ -361,10 +363,10 @@
 		const coinToSelect = hiveCoin || coinsWithBalance[0];
 
 		if (coinToSelect) {
-			$SendTxDetails.fromCoin = coinToSelect.coinOpt;
-			$SendTxDetails.fromNetwork = Network.magi;
-			$SendTxDetails.toCoin = coinToSelect.coinOpt;
-			$SendTxDetails.toNetwork = Network.magi;
+			txState.fromCoin = coinToSelect.coinOpt;
+			txState.fromNetwork = Network.magi;
+			txState.toCoin = coinToSelect.coinOpt;
+			txState.toNetwork = Network.magi;
 		}
 	});
 </script>
@@ -377,7 +379,7 @@
 <div class="sections">
 	<div class="contact-search">
 		<RecipientCard edit={openContact} {contact} />
-		<ContactSearchBox bind:value={$SendTxDetails.toUsername} bind:selectedContact={contact} />
+		<ContactSearchBox bind:value={txState.toUsername} bind:selectedContact={contact} />
 	</div>
 	<Divider text="Amount" />
 	<ClickableCard onclick={() => toggleAsset(true)}>
@@ -387,14 +389,14 @@
 				<div class="error">
 					No balance found on your account. Please make a deposit to get started.
 				</div>
-			{:else if $SendTxDetails.fromCoin && $SendTxDetails.fromNetwork}
+			{:else if txState.fromCoin && txState.fromNetwork}
 				<BalanceInfo
-					coin={$SendTxDetails.fromCoin.coin}
-					network={$SendTxDetails.fromNetwork}
+					coin={txState.fromCoin.coin}
+					network={txState.fromNetwork}
 					size="large"
 					styleType="vertical"
 				/>
-				<!-- <AssetInfo coinOpt={$SendTxDetails.fromCoin} size="medium" /> -->
+				<!-- <AssetInfo coinOpt={txState.fromCoin} size="medium" /> -->
 			{:else}
 				<span class="user-icon-placeholder"><Coins size="40" absoluteStrokeWidth={true} /></span>
 				Select Asset
@@ -408,7 +410,7 @@
 			<AmountInput
 				bind:coinAmount={inputAmt}
 				{coinOpts}
-				expressIn={$SendTxDetails.fromCoin?.coin}
+				expressIn={txState.fromCoin?.coin}
 				maxAmount={max}
 				bind:id={inputId}
 			/>
@@ -420,7 +422,7 @@
 					networks: []
 				}}
 				network={undefined}
-				connectedCoinAmount={new CoinAmount(fromAmount, $SendTxDetails.fromCoin?.coin ?? Coin.unk)}
+				connectedCoinAmount={new CoinAmount(fromAmount, txState.fromCoin?.coin ?? Coin.unk)}
 			/> -->
 		</div>
 	</div>
@@ -439,12 +441,11 @@
 	{#if isToBtcMainnet}
 		<div class="btc-unmap-options">
 			<label class="deduct-fee-row">
-				<input
-					type="checkbox"
-					bind:checked={$SendTxDetails.btcDeductFee}
-				/>
+				<input type="checkbox" bind:checked={txState.btcDeductFee} />
 				<span class="deduct-fee-label">Deduct fee from amount</span>
-				<span class="deduct-fee-hint">Fee is subtracted from your withdrawal instead of added on top</span>
+				<span class="deduct-fee-hint"
+					>Fee is subtracted from your withdrawal instead of added on top</span
+				>
 			</label>
 			<div class="fee-row">
 				<div class="fee-field">
@@ -463,10 +464,10 @@
 					<input
 						type="number"
 						placeholder="No limit"
-						value={$SendTxDetails.btcMaxFee ?? ''}
+						value={txState.btcMaxFee ?? ''}
 						onchange={(e) => {
-							const val = parseInt(e.currentTarget.value);
-							$SendTxDetails.btcMaxFee = isNaN(val) ? undefined : val;
+							const val = parseInt(e.currentTarget.value)
+							txState.btcMaxFee = isNaN(val) ? undefined : val
 						}}
 					/>
 					<span class="fee-hint">Transaction reverts if total fee exceeds this amount</span>
@@ -482,7 +483,7 @@
 			bind:value={memo}
 			maxlength="300"
 			onchange={() => {
-				$SendTxDetails.memo = memo;
+				txState.memo = memo;
 			}}
 		/>
 		<span>Custom message to the recipient.</span>
@@ -504,8 +505,8 @@
 		<SelectAssetFlattened
 			availableCoins={fromAssetObjs}
 			close={toggleAsset}
-			bind:coin={$SendTxDetails.fromCoin}
-			bind:network={$SendTxDetails.fromNetwork}
+			bind:coin={txState.fromCoin}
+			bind:network={txState.fromNetwork}
 			bind:max
 			externalNetwork={Network.hiveMainnet}
 		/>

--- a/src/lib/sendswap/stages/deposit/DepositOptions.svelte
+++ b/src/lib/sendswap/stages/deposit/DepositOptions.svelte
@@ -3,7 +3,8 @@
 	import ImageIconRenderer from '$lib/components/ImageIconRenderer.svelte';
 	import { ArrowLeft, ChevronRight } from '@lucide/svelte';
 	import swapOptions, { Coin, Network, TransferMethod } from '../../utils/sendOptions';
-	import { scanForBalance, SendTxDetails } from '../../utils/sendUtils';
+	import { scanForBalance } from '../../utils/sendUtils';
+	import { useDepositState } from '../../utils/txState.svelte';
 	import HiveMainnetDeposit from './HiveMainnetDeposit.svelte';
 	import CoinBaseDeposit from './CoinBaseDeposit.svelte';
 	import LightningDeposit from './LightningDeposit.svelte';
@@ -22,6 +23,8 @@
 		onHomePage: boolean;
 		customButtons: ComponentProps<typeof NavButtons>['buttons'] | undefined;
 	} = $props();
+
+	const txState = useDepositState();
 
 	const auth = $derived(getAuth()());
 
@@ -43,46 +46,40 @@
 		bitcoinMainnetOpen = open;
 	};
 
-	// using .update() here because it doesn't cause multiple state updates to change multiple values
 	$effect(() => {
 		if (!lightningOpen) return;
 		untrack(() => {
 			toggleHiveMainnet(false);
-			SendTxDetails.update((current) => {
-				const btcCoin = swapOptions.from.coins.find(
-					(coinOpt) => coinOpt.coin.value === Coin.btc.value
-				);
-				const shouldPreserveFromCoin =
-					current.fromCoin &&
-					current.fromCoin.networks?.some((n) => n.value === Network.lightning.value);
+			const btcCoin = swapOptions.from.coins.find(
+				(coinOpt) => coinOpt.coin.value === Coin.btc.value
+			);
+			const shouldPreserveFromCoin =
+				txState.fromCoin &&
+				txState.fromCoin.networks?.some((n) => n.value === Network.lightning.value);
 
-				const hiveCoin = swapOptions.to.coins.find((c) => c.coin.value === Coin.hive.value);
-				const hbdCoin = swapOptions.to.coins.find((c) => c.coin.value === Coin.hbd.value);
+			const hiveCoin = swapOptions.to.coins.find((c) => c.coin.value === Coin.hive.value);
+			const hbdCoin = swapOptions.to.coins.find((c) => c.coin.value === Coin.hbd.value);
 
-				let toCoinToUse = hiveCoin; // default
-				if (
-					current.toCoin &&
-					(current.toCoin.coin.value === Coin.hive.value ||
-						current.toCoin.coin.value === Coin.hbd.value)
-				) {
-					toCoinToUse = current.toCoin;
-				} else if (
-					current.fromCoin &&
-					(current.fromCoin.coin.value === Coin.hive.value ||
-						current.fromCoin.coin.value === Coin.hbd.value)
-				) {
-					toCoinToUse = current.fromCoin.coin.value === Coin.hive.value ? hiveCoin : hbdCoin;
-				}
+			let toCoinToUse = hiveCoin; // default
+			if (
+				txState.toCoin &&
+				(txState.toCoin.coin.value === Coin.hive.value ||
+					txState.toCoin.coin.value === Coin.hbd.value)
+			) {
+				toCoinToUse = txState.toCoin;
+			} else if (
+				txState.fromCoin &&
+				(txState.fromCoin.coin.value === Coin.hive.value ||
+					txState.fromCoin.coin.value === Coin.hbd.value)
+			) {
+				toCoinToUse = txState.fromCoin.coin.value === Coin.hive.value ? hiveCoin : hbdCoin;
+			}
 
-				return {
-					...current,
-					method: TransferMethod.lightningTransfer,
-					fromNetwork: Network.lightning,
-					fromCoin: shouldPreserveFromCoin ? current.fromCoin : btcCoin,
-					toNetwork: Network.magi,
-					toCoin: toCoinToUse
-				};
-			});
+			txState.method = TransferMethod.lightningTransfer;
+			txState.fromNetwork = Network.lightning;
+			txState.fromCoin = shouldPreserveFromCoin ? txState.fromCoin : btcCoin;
+			txState.toNetwork = Network.magi;
+			txState.toCoin = toCoinToUse;
 		});
 	});
 
@@ -90,50 +87,45 @@
 		if (!hiveMainnetOpen) return;
 		untrack(() => {
 			toggleLightning(false);
-			SendTxDetails.update((current) => {
-				const hiveCoin =
-					swapOptions.from.coins.find(
-						(coinOpt) =>
-							coinOpt.coin.value === Coin.hive.value &&
-							coinOpt.networks.some((n) => n.value === Network.hiveMainnet.value)
-					) ||
-					swapOptions.from.coins.find(
-						(coinOpt) =>
-							coinOpt.coin.value === Coin.hbd.value &&
-							coinOpt.networks.some((n) => n.value === Network.hiveMainnet.value)
-					);
-				const hbdCoin = swapOptions.from.coins.find(
+			const hiveCoin =
+				swapOptions.from.coins.find(
+					(coinOpt) =>
+						coinOpt.coin.value === Coin.hive.value &&
+						coinOpt.networks.some((n) => n.value === Network.hiveMainnet.value)
+				) ||
+				swapOptions.from.coins.find(
 					(coinOpt) =>
 						coinOpt.coin.value === Coin.hbd.value &&
 						coinOpt.networks.some((n) => n.value === Network.hiveMainnet.value)
 				);
+			const hbdCoin = swapOptions.from.coins.find(
+				(coinOpt) =>
+					coinOpt.coin.value === Coin.hbd.value &&
+					coinOpt.networks.some((n) => n.value === Network.hiveMainnet.value)
+			);
 
-				// For Hive Mainnet deposit, default to HIVE (or HBD) without
-				// requiring a Magi balance — user deposits precisely because
-				// their Magi balance may be 0.
-				let fromCoinToUse = hiveCoin;
-				if (
-					current.fromCoin &&
-					current.fromCoin.networks?.some((n) => n.value === Network.hiveMainnet.value)
-				) {
-					fromCoinToUse = current.fromCoin;
-				} else if (
-					current.toCoin &&
-					(current.toCoin.coin.value === Coin.hive.value ||
-						current.toCoin.coin.value === Coin.hbd.value)
-				) {
-					fromCoinToUse = current.toCoin.coin.value === Coin.hive.value ? hiveCoin : hbdCoin;
-				}
+			// For Hive Mainnet deposit, default to HIVE (or HBD) without
+			// requiring a Magi balance — user deposits precisely because
+			// their Magi balance may be 0.
+			let fromCoinToUse = hiveCoin;
+			if (
+				txState.fromCoin &&
+				txState.fromCoin.networks?.some((n) => n.value === Network.hiveMainnet.value)
+			) {
+				fromCoinToUse = txState.fromCoin;
+			} else if (
+				txState.toCoin &&
+				(txState.toCoin.coin.value === Coin.hive.value ||
+					txState.toCoin.coin.value === Coin.hbd.value)
+			) {
+				fromCoinToUse = txState.toCoin.coin.value === Coin.hive.value ? hiveCoin : hbdCoin;
+			}
 
-				return {
-					...current,
-					method: TransferMethod.magiTransfer,
-					fromNetwork: Network.hiveMainnet,
-					toNetwork: Network.magi,
-					fromCoin: fromCoinToUse,
-					toCoin: fromCoinToUse
-				};
-			});
+			txState.method = TransferMethod.magiTransfer;
+			txState.fromNetwork = Network.hiveMainnet;
+			txState.toNetwork = Network.magi;
+			txState.fromCoin = fromCoinToUse;
+			txState.toCoin = fromCoinToUse;
 		});
 	});
 

--- a/src/lib/sendswap/stages/deposit/HiveMainnetDeposit.svelte
+++ b/src/lib/sendswap/stages/deposit/HiveMainnetDeposit.svelte
@@ -14,8 +14,7 @@
 		type CoinOnNetwork,
 		type CoinOptions
 	} from '$lib/sendswap/utils/sendOptions';
-	import { SendTxDetails } from '$lib/sendswap/utils/sendUtils';
-	import { get } from 'svelte/store';
+	import { useTxState } from '$lib/sendswap/utils/txState.svelte';
 	import { accountBalance } from '$lib/stores/currentBalance';
 	import Select from '$lib/zag/Select.svelte';
 	import { ArrowLeft, ArrowRightLeft, Coins } from '@lucide/svelte';
@@ -27,6 +26,7 @@
 		secondaryMenu = $bindable()
 	}: { editStage: (complete: boolean) => void; open: boolean; secondaryMenu: boolean } = $props();
 
+	const txState = useTxState();
 	const auth = $derived(getAuth()());
 
 	let coinAmount = $state(new CoinAmount(0, Coin.unk));
@@ -39,7 +39,9 @@
 		const amt = coinAmount.toAmountString();
 		if (amt === lastSyncedAmt) return;
 		lastSyncedAmt = amt;
-		SendTxDetails.update((d) => ({ ...d, fromAmount: amt, toAmount: amt, enteredAmount: amt }));
+		txState.fromAmount = amt;
+		txState.toAmount = amt;
+		txState.enteredAmount = amt;
 	});
 
 	let max = $state(new CoinAmount(0, Coin.hive));
@@ -47,8 +49,8 @@
 	// Update max when fromCoin or connectedBal changes (skip while asset picker is open)
 	$effect(() => {
 		if (assetOpen) return;
-		const fromCoin = $SendTxDetails.fromCoin;
-		const fromNetwork = $SendTxDetails.fromNetwork;
+		const fromCoin = txState.fromCoin;
+		const fromNetwork = txState.fromNetwork;
 		if (!open || !fromCoin || !fromNetwork) return;
 		if (fromNetwork.value !== Network.hiveMainnet.value) return;
 
@@ -72,8 +74,8 @@
 
 	const unkOpt = { coin: Coin.unk, network: Network.unknown };
 	const coinOptions: CoinOnNetwork[] = $derived(
-		$SendTxDetails.fromCoin && $SendTxDetails.fromNetwork
-			? [{ coin: $SendTxDetails.fromCoin.coin, network: $SendTxDetails.fromNetwork }]
+		txState.fromCoin && txState.fromNetwork
+			? [{ coin: txState.fromCoin.coin, network: txState.fromNetwork }]
 			: [unkOpt]
 	);
 
@@ -82,9 +84,8 @@
 		assetOpen = open;
 		// When closing asset picker, sync toCoin to match the newly selected fromCoin
 		if (!open) {
-			const store = get(SendTxDetails);
-			if (store.fromCoin && store.toCoin?.coin?.value !== store.fromCoin?.coin?.value) {
-				SendTxDetails.update((d) => ({ ...d, toCoin: d.fromCoin }));
+			if (txState.fromCoin && txState.toCoin?.coin?.value !== txState.fromCoin?.coin?.value) {
+				txState.toCoin = txState.fromCoin;
 			}
 		}
 	}
@@ -102,8 +103,8 @@
 	<SelectAssetFlattened
 		availableCoins={[]}
 		close={toggleAsset}
-		bind:coin={$SendTxDetails.fromCoin}
-		bind:network={$SendTxDetails.fromNetwork}
+		bind:coin={txState.fromCoin}
+		bind:network={txState.fromNetwork}
 		bind:max
 		externalNetwork={Network.hiveMainnet}
 	/>
@@ -113,14 +114,14 @@
 			<label for="asset-card">Deposit From</label>
 			<ClickableCard onclick={() => toggleAsset(true)}>
 				<div class="asset-card">
-					{#if $SendTxDetails.fromCoin && $SendTxDetails.fromNetwork}
+					{#if txState.fromCoin && txState.fromNetwork}
 						<BalanceInfo
-							coin={$SendTxDetails.fromCoin.coin}
-							network={$SendTxDetails.fromNetwork}
+							coin={txState.fromCoin.coin}
+							network={txState.fromNetwork}
 							size="large"
 							styleType="vertical"
 						/>
-						<!-- <AssetInfo coinOpt={$SendTxDetails.fromCoin} size="medium" /> -->
+						<!-- <AssetInfo coinOpt={txState.fromCoin} size="medium" /> -->
 					{:else}
 						<span class="user-icon-placeholder"><Coins size="40" absoluteStrokeWidth={true} /></span
 						>
@@ -137,7 +138,7 @@
 					<AmountInput
 						bind:coinAmount
 						coinOpts={coinOptions}
-						expressIn={$SendTxDetails.fromCoin?.coin}
+						expressIn={txState.fromCoin?.coin}
 						maxAmount={max}
 						bind:id={inputId}
 					/>

--- a/src/lib/sendswap/stages/deposit/LightningDeposit.svelte
+++ b/src/lib/sendswap/stages/deposit/LightningDeposit.svelte
@@ -6,9 +6,9 @@
 	import SelectAssetFlattened from '$lib/sendswap/components/assetSelection/SelectAssetFlattened.svelte';
 	import BalanceInfo from '$lib/sendswap/components/info/BalanceInfo.svelte';
 	import { Coin, Network, type CoinOnNetwork } from '$lib/sendswap/utils/sendOptions';
-	import { getFee, SendTxDetails } from '$lib/sendswap/utils/sendUtils';
+	import { getFee } from '$lib/sendswap/utils/sendUtils';
+	import { useTxState } from '$lib/sendswap/utils/txState.svelte';
 	import { ArrowLeft, Coins } from '@lucide/svelte';
-	import { get } from 'svelte/store';
 	import { untrack } from 'svelte';
 
 	let {
@@ -17,17 +17,19 @@
 		secondaryMenu = $bindable()
 	}: { editStage: (add: boolean) => void; open: boolean; secondaryMenu: boolean } = $props();
 
+	const txState = useTxState();
+
 	let coinAmount: CoinAmount<Coin> = $state(new CoinAmount(0, Coin.unk));
 	let inputId = $state('');
 
-	// Derived primitives from store — only change when the actual values change,
-	// preventing effects from re-running on every unrelated store mutation
-	const _fromCoinValue = $derived($SendTxDetails.fromCoin?.coin?.value);
-	const _toCoinValue = $derived($SendTxDetails.toCoin?.coin?.value);
-	const _fromNetwork = $derived($SendTxDetails.fromNetwork?.value);
-	const _toNetwork = $derived($SendTxDetails.toNetwork?.value);
+	// Derived primitives from state — only change when the actual values change,
+	// preventing effects from re-running on every unrelated state mutation
+	const _fromCoinValue = $derived(txState.fromCoin?.coin?.value);
+	const _toCoinValue = $derived(txState.toCoin?.coin?.value);
+	const _fromNetwork = $derived(txState.fromNetwork?.value);
+	const _toNetwork = $derived(txState.toNetwork?.value);
 	// Track toAmount so validation blocks Review until async conversion completes
-	const _toAmount = $derived($SendTxDetails.toAmount);
+	const _toAmount = $derived(txState.toAmount);
 
 	// Sync coinAmount → fromAmount, toAmount, fee atomically
 	// Single effect to avoid race conditions between separate from/to effects
@@ -40,57 +42,50 @@
 		const coinVal = coinAmount.coin.value;
 		const coinAmountSnapshot = coinAmount;
 		untrack(() => {
-			const store = get(SendTxDetails);
-			if (!store.fromCoin) return;
+			if (!txState.fromCoin) return;
 
 			// Always preserve the raw user input as enteredAmount
-			if (amt !== store.enteredAmount) {
-				SendTxDetails.update((s) => ({ ...s, enteredAmount: amt }));
+			if (amt !== txState.enteredAmount) {
+				txState.enteredAmount = amt;
 			}
 
 			// Compute fromAmount
 			if (coinVal === fromCoinVal) {
-				if (amt !== store.fromAmount) {
-					SendTxDetails.update((s) => ({ ...s, fromAmount: amt }));
+				if (amt !== txState.fromAmount) {
+					txState.fromAmount = amt;
 				}
 			} else {
 				coinAmountSnapshot
-					.convertTo(store.fromCoin.coin, Network.lightning)
+					.convertTo(txState.fromCoin.coin, Network.lightning)
 					.then((converted) => {
-						const current = get(SendTxDetails);
 						const convertedAmt = converted.toAmountString();
-						if (current.fromAmount !== convertedAmt) {
-							SendTxDetails.update((s) => ({
-								...s,
-								fromAmount: convertedAmt
-							}));
+						if (txState.fromAmount !== convertedAmt) {
+							txState.fromAmount = convertedAmt;
 						}
 					});
 			}
 
 			// Compute toAmount
-			if (!store.toCoin || !toCoinVal) return;
+			if (!txState.toCoin || !toCoinVal) return;
 			if (coinVal === toCoinVal) {
-				if (amt !== store.toAmount) {
-					SendTxDetails.update((s) => ({ ...s, toAmount: amt }));
+				if (amt !== txState.toAmount) {
+					txState.toAmount = amt;
 				}
 			} else {
 				coinAmountSnapshot
-					.convertTo(store.toCoin.coin, Network.lightning)
+					.convertTo(txState.toCoin.coin, Network.lightning)
 					.then((converted) => {
-						const current = get(SendTxDetails);
 						const convertedAmt = converted.toAmountString();
-						if (current.toAmount !== convertedAmt) {
-							SendTxDetails.update((s) => ({ ...s, toAmount: convertedAmt }));
+						if (txState.toAmount !== convertedAmt) {
+							txState.toAmount = convertedAmt;
 						}
 						// Compute fee based on converted toAmount
-						getFee(convertedAmt).then((fee) => {
-							const latest = get(SendTxDetails);
+						getFee(convertedAmt, txState).then((fee) => {
 							if (
-								fee?.amount !== latest.fee?.amount ||
-								fee?.coin.value !== latest.fee?.coin.value
+								fee?.amount !== txState.fee?.amount ||
+								fee?.coin.value !== txState.fee?.coin.value
 							) {
-								SendTxDetails.update((s) => ({ ...s, fee }));
+								txState.fee = fee;
 							}
 						});
 					});
@@ -107,8 +102,7 @@
 		const amt = coinAmount.amount;
 		const hasToAmount = !!_toAmount && _toAmount !== '0';
 		untrack(() => {
-			const store = get(SendTxDetails);
-			if (hasCoins && store.fromAmount && hasNetwork && amt > 0 && hasToAmount) {
+			if (hasCoins && txState.fromAmount && hasNetwork && amt > 0 && hasToAmount) {
 				editStage(true);
 			} else {
 				editStage(false);
@@ -124,18 +118,16 @@
 		const tCoin = _toCoinValue;
 		const fNet = _fromNetwork;
 		const tNet = _toNetwork;
-		// Use get() to access the full objects without subscribing the derived to the whole store
-		const store = get(SendTxDetails);
-		if (fCoin && fNet && store.fromCoin && store.fromNetwork) {
+		if (fCoin && fNet && txState.fromCoin && txState.fromNetwork) {
 			result.push({
-				coin: store.fromCoin.coin,
-				network: store.fromNetwork
+				coin: txState.fromCoin.coin,
+				network: txState.fromNetwork
 			});
 		}
-		if (tCoin && tNet && store.toCoin && store.toNetwork) {
+		if (tCoin && tNet && txState.toCoin && txState.toNetwork) {
 			result.push({
-				coin: store.toCoin.coin,
-				network: store.toNetwork
+				coin: txState.toCoin.coin,
+				network: txState.toNetwork
 			});
 		}
 		if (result.map((coinOpt) => coinOpt.coin.value).includes(Coin.btc.value)) {
@@ -165,8 +157,8 @@
 	<SelectAssetFlattened
 		availableCoins={[Coin.hive, Coin.hbd]}
 		close={toggleAsset}
-		bind:coin={$SendTxDetails.toCoin}
-		bind:network={$SendTxDetails.toNetwork}
+		bind:coin={txState.toCoin}
+		bind:network={txState.toNetwork}
 		isTo
 	/>
 {/if}
@@ -175,14 +167,14 @@
 		<label for="asset-card">Deposit To</label>
 		<ClickableCard onclick={() => toggleAsset(true)}>
 			<div class="asset-card">
-				{#if $SendTxDetails.toCoin && $SendTxDetails.toNetwork}
+				{#if txState.toCoin && txState.toNetwork}
 					<BalanceInfo
-						coin={$SendTxDetails.toCoin.coin}
-						network={$SendTxDetails.toNetwork}
+						coin={txState.toCoin.coin}
+						network={txState.toNetwork}
 						size="large"
 						styleType="vertical"
 					/>
-					<!-- <AssetInfo coinOpt={$SendTxDetails.fromCoin} size="medium" /> -->
+					<!-- <AssetInfo coinOpt={txState.fromCoin} size="medium" /> -->
 				{:else}
 					<span class="user-icon-placeholder"><Coins size="40" absoluteStrokeWidth={true} /></span>
 					Select Destination Account

--- a/src/lib/sendswap/stages/withdraw/BitcoinMainnetWithdraw.svelte
+++ b/src/lib/sendswap/stages/withdraw/BitcoinMainnetWithdraw.svelte
@@ -3,7 +3,7 @@
 	import AmountInput from '$lib/currency/AmountInput.svelte';
 	import { CoinAmount } from '$lib/currency/CoinAmount';
 	import { Coin, Network, type CoinOnNetwork } from '$lib/sendswap/utils/sendOptions';
-	import { SendTxDetails } from '$lib/sendswap/utils/sendUtils';
+	import { useWithdrawState } from '$lib/sendswap/utils/txState.svelte';
 	import { accountBalance, getBalanceAmount } from '$lib/stores/currentBalance';
 	import { validate, Network as BtcNetwork } from 'bitcoin-address-validation';
 	import {
@@ -14,6 +14,7 @@
 
 	let { editStage, open }: { editStage: (complete: boolean) => void; open: boolean } = $props();
 
+	const txState = useWithdrawState();
 	const auth = $derived(getAuth()());
 
 	let coinAmount = $state(new CoinAmount(0, Coin.btc));
@@ -52,37 +53,36 @@
 			isBtcAddressValid = false;
 			btcAddressError = 'Invalid Bitcoin mainnet address.';
 		}
-		SendTxDetails.update((d) => ({ ...d, toUsername: value }));
+		txState.toUsername = value;
 	}
 
-	// Sync deductFee and maxFee into store
+	// Sync deductFee and maxFee into state
 	$effect(() => {
 		const maxFee = maxFeeRaw ? parseInt(maxFeeRaw) : undefined;
-		SendTxDetails.update((d) => ({
-			...d,
-			btcDeductFee: deductFee,
-			btcMaxFee: maxFee !== undefined && !isNaN(maxFee) ? maxFee : undefined
-		}));
+		txState.btcDeductFee = deductFee;
+		txState.btcMaxFee = maxFee !== undefined && !isNaN(maxFee) ? maxFee : undefined;
 	});
 
 	let max = $state(new CoinAmount(0, Coin.btc));
 	$effect(() => {
-		if (!open || !$SendTxDetails.fromCoin || !$SendTxDetails.fromNetwork) return;
+		if (!open || !txState.fromCoin || !txState.fromNetwork) return;
 		max = getBalanceAmount(
 			$accountBalance,
-			$SendTxDetails.fromCoin.coin,
-			$SendTxDetails.fromNetwork
+			txState.fromCoin.coin,
+			txState.fromNetwork
 		);
 	});
 
-	// Sync coinAmount → store
+	// Sync coinAmount → state
 	let lastSyncedAmt = '';
 	$effect(() => {
 		if (!open) return;
 		const amt = coinAmount.toAmountString();
 		if (amt === lastSyncedAmt) return;
 		lastSyncedAmt = amt;
-		SendTxDetails.update((d) => ({ ...d, fromAmount: amt, toAmount: amt, enteredAmount: amt }));
+		txState.fromAmount = amt;
+		txState.toAmount = amt;
+		txState.enteredAmount = amt;
 	});
 
 	// Signal stage completion
@@ -90,8 +90,8 @@
 		if (!open) return;
 		const valid = !!(
 			isBtcAddressValid &&
-			$SendTxDetails.fromCoin &&
-			$SendTxDetails.fromNetwork &&
+			txState.fromCoin &&
+			txState.fromNetwork &&
 			coinAmount.amount > 0 &&
 			coinAmount.amount <= (max?.amount ?? Number.MAX_SAFE_INTEGER)
 		);
@@ -99,8 +99,8 @@
 	});
 
 	const coinOptions: CoinOnNetwork[] = $derived(
-		$SendTxDetails.fromCoin && $SendTxDetails.fromNetwork
-			? [{ coin: $SendTxDetails.fromCoin.coin, network: $SendTxDetails.fromNetwork }]
+		txState.fromCoin && txState.fromNetwork
+			? [{ coin: txState.fromCoin.coin, network: txState.fromNetwork }]
 			: [{ coin: Coin.btc, network: Network.magi }]
 	);
 </script>
@@ -127,7 +127,7 @@
 				<AmountInput
 					bind:coinAmount
 					coinOpts={coinOptions}
-					expressIn={$SendTxDetails.fromCoin?.coin ?? Coin.btc}
+					expressIn={txState.fromCoin?.coin ?? Coin.btc}
 					maxAmount={max}
 					bind:id={inputId}
 				/>

--- a/src/lib/sendswap/stages/withdraw/BitcoinMainnetWithdraw.svelte
+++ b/src/lib/sendswap/stages/withdraw/BitcoinMainnetWithdraw.svelte
@@ -22,6 +22,17 @@
 	let btcAddress = $state('');
 	let btcAddressError = $state<string | undefined>(undefined);
 	let isBtcAddressValid = $state(false);
+	let previousOpen: boolean | undefined;
+
+	// Autofill BTC address when the user is logged in with a Bitcoin wallet
+	$effect(() => {
+		if (!open || open === previousOpen) return;
+		previousOpen = open;
+		if (auth.value?.did?.startsWith('did:pkh:bip122:') && auth.value?.address && !btcAddress) {
+			onAddressInput(auth.value.address);
+		}
+	});
+
 	let deductFee = $state(false);
 	let maxFeeRaw = $state('');
 	let btcFeeEstimate = $state<BtcFeeEstimate | null>(null);

--- a/src/lib/sendswap/stages/withdraw/HiveMainnetWithdraw.svelte
+++ b/src/lib/sendswap/stages/withdraw/HiveMainnetWithdraw.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { getAuth } from '$lib/auth/store';
+	import { getUsernameFromAuth } from '$lib/getAccountName';
 	import ClickableCard from '$lib/cards/ClickableCard.svelte';
 	import AmountInput from '$lib/currency/AmountInput.svelte';
 	import { CoinAmount } from '$lib/currency/CoinAmount';
@@ -75,8 +76,8 @@
 
 		if (open) {
 			if (auth.value?.provider === 'aioha') {
-				// For Hive accounts, use txState.toUsername if available
-				hiveAccount = txState.toUsername || '';
+				// Autofill with the logged-in Hive username
+				hiveAccount = txState.toUsername || getUsernameFromAuth(auth) || '';
 			} else {
 				const shouldReset =
 					!currentUsername || (currentUsername.length === 42 && currentUsername.startsWith('0x'));

--- a/src/lib/sendswap/stages/withdraw/HiveMainnetWithdraw.svelte
+++ b/src/lib/sendswap/stages/withdraw/HiveMainnetWithdraw.svelte
@@ -9,11 +9,11 @@
 	import ContactSearchBox from '$lib/sendswap/contacts/ContactSearchBox.svelte';
 	import type { Contact } from '$lib/sendswap/contacts/contacts';
 	import swapOptions, { Coin, Network, type CoinOnNetwork } from '$lib/sendswap/utils/sendOptions';
-	import { SendTxDetails, validateAddress } from '$lib/sendswap/utils/sendUtils';
+	import { validateAddress } from '$lib/sendswap/utils/sendUtils';
+	import { useWithdrawState } from '$lib/sendswap/utils/txState.svelte';
 	import { accountBalance, getBalanceAmount } from '$lib/stores/currentBalance';
 	import { ArrowLeft, Coins } from '@lucide/svelte';
 	import Divider from '$lib/components/Divider.svelte';
-	import { get } from 'svelte/store';
 
 	let {
 		editStage,
@@ -21,12 +21,13 @@
 		secondaryMenu = $bindable(false)
 	}: { editStage: (complete: boolean) => void; open: boolean; secondaryMenu: boolean } = $props();
 
+	const txState = useWithdrawState();
 	const auth = $derived(getAuth()());
 
 	let coinAmount = $state(new CoinAmount(0, Coin.unk));
 	let inputId = $state('');
 
-	// For EVM accounts, always start with empty string. For Hive accounts, use SendTxDetails.toUsername
+	// For EVM accounts, always start with empty string. For Hive accounts, use txState.toUsername
 	let hiveAccount = $state('');
 	let hiveAccountError = $state<string | undefined>(undefined);
 	let isHiveAccountValid = $state(false);
@@ -34,7 +35,7 @@
 	let contactOpen = $state(false);
 	let openToCreate = $state(false);
 	let createNew: string | undefined = $derived(
-		!contact && $SendTxDetails.toUsername ? $SendTxDetails.toUsername : undefined
+		!contact && txState.toUsername ? txState.toUsername : undefined
 	);
 	const toggleContact = (open = false) => {
 		contactOpen = open;
@@ -45,28 +46,14 @@
 	}
 
 	function setToUsername(nextValue: string) {
-		SendTxDetails.update((details) => {
-			if (details.toUsername === nextValue) return details;
-			return { ...details, toUsername: nextValue };
-		});
+		if (txState.toUsername !== nextValue) txState.toUsername = nextValue;
 	}
 	function syncAmountFromInput(nextAmount: CoinAmount<Coin>) {
 		if (!open) return;
 		const amt = nextAmount.toAmountString();
-		SendTxDetails.update((details) => {
-			if (
-				details.toAmount === amt &&
-				details.fromAmount === amt &&
-				details.enteredAmount === amt
-			)
-				return details;
-			return {
-				...details,
-				toAmount: amt,
-				fromAmount: amt,
-				enteredAmount: amt
-			};
-		});
+		if (txState.toAmount !== amt) txState.toAmount = amt;
+		if (txState.fromAmount !== amt) txState.fromAmount = amt;
+		if (txState.enteredAmount !== amt) txState.enteredAmount = amt;
 	}
 
 	let previousOpen: boolean | undefined;
@@ -84,12 +71,12 @@
 		previousOpen = open;
 		previousProvider = provider;
 
-		const currentUsername = get(SendTxDetails).toUsername || '';
+		const currentUsername = txState.toUsername || '';
 
 		if (open) {
 			if (auth.value?.provider === 'aioha') {
-				// For Hive accounts, use SendTxDetails.toUsername if available
-				hiveAccount = $SendTxDetails.toUsername || '';
+				// For Hive accounts, use txState.toUsername if available
+				hiveAccount = txState.toUsername || '';
 			} else {
 				const shouldReset =
 					!currentUsername || (currentUsername.length === 42 && currentUsername.startsWith('0x'));
@@ -101,7 +88,7 @@
 		} else {
 			// Reset when component closes
 			if (auth.value?.provider === 'aioha') {
-				hiveAccount = $SendTxDetails.toUsername || '';
+				hiveAccount = txState.toUsername || '';
 			} else {
 				hiveAccount = '';
 				setToUsername('');
@@ -109,10 +96,10 @@
 		}
 	});
 
-	// Keep local hiveAccount in sync with SendTxDetails (covers SelectContact updates)
+	// Keep local hiveAccount in sync with txState (covers SelectContact updates)
 	$effect(() => {
 		if (!open) return;
-		const current = ($SendTxDetails.toUsername ?? '').trim();
+		const current = (txState.toUsername ?? '').trim();
 		if (current === lastSyncedUsername) return;
 		lastSyncedUsername = current;
 		if (hiveAccount !== current) {
@@ -120,7 +107,7 @@
 		}
 	});
 
-	// Push local hiveAccount changes back into SendTxDetails
+	// Push local hiveAccount changes back into txState
 	$effect(() => {
 		if (!open) return;
 		const trimmed = hiveAccount.trim();
@@ -129,29 +116,31 @@
 		setToUsername(trimmed);
 	});
 
-	// Sync coinAmount → store. Uses local guard to avoid reading store reactively.
+	// Sync coinAmount → state. Uses local guard to avoid reading state reactively.
 	let lastSyncedAmt = '';
 	$effect(() => {
 		if (!open) return;
 		const amt = coinAmount.toAmountString();
 		if (amt === lastSyncedAmt) return;
 		lastSyncedAmt = amt;
-		SendTxDetails.update((d) => ({ ...d, fromAmount: amt, toAmount: amt, enteredAmount: amt }));
+		txState.fromAmount = amt;
+		txState.toAmount = amt;
+		txState.enteredAmount = amt;
 	});
 
 	let max = $state(new CoinAmount(0, Coin.hive));
 
 	// Update max when fromCoin changes for magi network
 	$effect(() => {
-		if (!open || !$SendTxDetails.fromCoin || !$SendTxDetails.fromNetwork) return;
-		if ($SendTxDetails.fromNetwork.value !== Network.magi.value) return;
+		if (!open || !txState.fromCoin || !txState.fromNetwork) return;
+		if (txState.fromNetwork.value !== Network.magi.value) return;
 
-		const coinValue = $SendTxDetails.fromCoin.coin.value;
+		const coinValue = txState.fromCoin.coin.value;
 		if (coinValue === Coin.hive.value || coinValue === Coin.hbd.value) {
 			max = getBalanceAmount(
 				$accountBalance,
-				$SendTxDetails.fromCoin.coin,
-				$SendTxDetails.fromNetwork
+				txState.fromCoin.coin,
+				txState.fromNetwork
 			);
 		}
 	});
@@ -192,9 +181,8 @@
 				isHiveAccountValid = true;
 				hiveAccountError = undefined;
 				setToUsername(rawAccount);
-				if (result.displayName) {
-					$SendTxDetails.toDisplayName = result.displayName;
-				}
+				// toDisplayName not available on WithdrawTxState; skip write
+				// if (result.displayName) { txState.toDisplayName = result.displayName; }
 			} else {
 				isHiveAccountValid = false;
 				hiveAccountError = result.error;
@@ -205,9 +193,9 @@
 	$effect(() => {
 		if (!open) return;
 		const baseValidation = !!(
-			$SendTxDetails.fromCoin &&
-			$SendTxDetails.toCoin &&
-			$SendTxDetails.fromNetwork &&
+			txState.fromCoin &&
+			txState.toCoin &&
+			txState.fromNetwork &&
 			coinAmount.amount > 0 &&
 			coinAmount.amount <= (max?.amount ?? Number.MAX_SAFE_INTEGER)
 		);
@@ -217,14 +205,14 @@
 			editStage(baseValidation);
 		} else {
 			// For EVM accounts, also require valid Hive account
-			editStage(baseValidation && isHiveAccountValid && !!$SendTxDetails.toUsername);
+			editStage(baseValidation && isHiveAccountValid && !!txState.toUsername);
 		}
 	});
 
 	const unkOpt = { coin: Coin.unk, network: Network.unknown };
 	const coinOptions: CoinOnNetwork[] = $derived(
-		$SendTxDetails.fromCoin && $SendTxDetails.fromNetwork
-			? [{ coin: $SendTxDetails.fromCoin.coin, network: $SendTxDetails.fromNetwork }]
+		txState.fromCoin && txState.fromNetwork
+			? [{ coin: txState.fromCoin.coin, network: txState.fromNetwork }]
 			: [unkOpt]
 	);
 
@@ -233,9 +221,8 @@
 		assetOpen = open;
 		// When closing asset picker, sync toCoin to match the newly selected fromCoin
 		if (!open) {
-			const store = get(SendTxDetails);
-			if (store.fromCoin && store.toCoin?.coin?.value !== store.fromCoin?.coin?.value) {
-				SendTxDetails.update((d) => ({ ...d, toCoin: d.fromCoin }));
+			if (txState.fromCoin && txState.toCoin?.coin?.value !== txState.fromCoin?.coin?.value) {
+				txState.toCoin = txState.fromCoin;
 			}
 		}
 	}
@@ -253,8 +240,8 @@
 	<SelectAssetFlattened
 		availableCoins={[Coin.hive, Coin.hbd]}
 		close={toggleAsset}
-		bind:coin={$SendTxDetails.fromCoin}
-		bind:network={$SendTxDetails.fromNetwork}
+		bind:coin={txState.fromCoin}
+		bind:network={txState.fromNetwork}
 		bind:max
 	/>
 {:else}
@@ -278,10 +265,10 @@
 				<label for="asset-card">Withdraw From</label>
 				<ClickableCard onclick={() => toggleAsset(true)}>
 					<div class="asset-card">
-						{#if $SendTxDetails.fromCoin && $SendTxDetails.fromNetwork}
+						{#if txState.fromCoin && txState.fromNetwork}
 							<BalanceInfo
-								coin={$SendTxDetails.fromCoin.coin}
-								network={$SendTxDetails.fromNetwork}
+								coin={txState.fromCoin.coin}
+								network={txState.fromNetwork}
 								size="large"
 								styleType="vertical"
 							/>
@@ -302,7 +289,7 @@
 						<AmountInput
 							bind:coinAmount
 							coinOpts={coinOptions}
-							expressIn={$SendTxDetails.fromCoin?.coin}
+							expressIn={txState.fromCoin?.coin}
 							maxAmount={max}
 							onAmountChange={syncAmountFromInput}
 							bind:id={inputId}

--- a/src/lib/sendswap/stages/withdraw/LightningWithdraw.svelte
+++ b/src/lib/sendswap/stages/withdraw/LightningWithdraw.svelte
@@ -4,7 +4,7 @@
 	import PillButton from '$lib/PillButton.svelte';
 	import BalanceInfo from '$lib/sendswap/components/info/BalanceInfo.svelte';
 	import swapOptions, { Coin, Network, type CoinOptions } from '$lib/sendswap/utils/sendOptions';
-	import { SendTxDetails } from '$lib/sendswap/utils/sendUtils';
+	import { useTxState } from '$lib/sendswap/utils/txState.svelte';
 	import { accountBalance, getBalanceAmount } from '$lib/stores/currentBalance';
 	import Select from '$lib/zag/Select.svelte';
 	import { ArrowRightLeft } from '@lucide/svelte';
@@ -12,22 +12,24 @@
 
 	let { editStage, open }: { editStage: (complete: boolean) => void; open: boolean } = $props();
 
+	const txState = useTxState();
+
 	let amount = $state('');
 	let lightningAddress = $state('');
 
 	$effect(() => {
 		if (!open) return;
-		if (!$SendTxDetails.toCoin) return;
-		if (shownCoin.coin.value === $SendTxDetails.toCoin.coin.value) {
-			const amt = new CoinAmount(amount, $SendTxDetails.toCoin.coin).toAmountString();
-			if (amt !== $SendTxDetails.toAmount)
-				$SendTxDetails.toAmount = $SendTxDetails.fromAmount = amt;
+		if (!txState.toCoin) return;
+		if (shownCoin.coin.value === txState.toCoin.coin.value) {
+			const amt = new CoinAmount(amount, txState.toCoin.coin).toAmountString();
+			if (amt !== txState.toAmount)
+				txState.toAmount = txState.fromAmount = amt;
 		} else {
 			new CoinAmount(amount, shownCoin.coin)
-				.convertTo($SendTxDetails.toCoin.coin, Network.lightning)
+				.convertTo(txState.toCoin.coin, Network.lightning)
 				.then((amt) => {
-					if ($SendTxDetails.toAmount !== amt.toAmountString()) {
-						$SendTxDetails.toAmount = $SendTxDetails.fromAmount = amt.toAmountString();
+					if (txState.toAmount !== amt.toAmountString()) {
+						txState.toAmount = txState.fromAmount = amt.toAmountString();
 					}
 				});
 		}
@@ -46,8 +48,8 @@
 	];
 
 	const max = $derived.by(() => {
-		const coin = $SendTxDetails.fromCoin?.coin;
-		const network = $SendTxDetails.fromNetwork;
+		const coin = txState.fromCoin?.coin;
+		const network = txState.fromNetwork;
 		if (!coin || !network) return;
 		return getBalanceAmount($accountBalance, coin, network);
 	});
@@ -56,10 +58,10 @@
 	$effect(() => {
 		if (!open) return;
 		if (
-			$SendTxDetails.fromCoin &&
-			$SendTxDetails.toCoin &&
-			$SendTxDetails.toAmount &&
-			$SendTxDetails.toNetwork &&
+			txState.fromCoin &&
+			txState.toCoin &&
+			txState.toAmount &&
+			txState.toNetwork &&
 			lightningAddress &&
 			amountNumber > 0 &&
 			amountNumber <= (max?.toNumber() ?? Number.MAX_SAFE_INTEGER)
@@ -72,8 +74,8 @@
 
 	let possibleCoins: CoinOptions['coins'] = $derived.by(() => {
 		let result: CoinOptions['coins'] = [{ coin: Coin.usd, networks: [] }];
-		if ($SendTxDetails.toCoin) {
-			result = [$SendTxDetails.toCoin, ...result];
+		if (txState.toCoin) {
+			result = [txState.toCoin, ...result];
 		}
 		return result;
 	});
@@ -105,7 +107,7 @@
 	});
 	let shownIndex = $state(0);
 	let shownCoin: CoinOptions['coins'][number] = $state(
-		$SendTxDetails.toCoin ?? { coin: Coin.usd, networks: [] }
+		txState.toCoin ?? { coin: Coin.usd, networks: [] }
 	);
 	function cycleShown() {
 		shownIndex = (shownIndex + 1) % possibleCoins.length;
@@ -114,9 +116,9 @@
 
 	$effect(() => {
 		if (open) {
-			$SendTxDetails.fromNetwork = Network.magi;
-			$SendTxDetails.toNetwork = Network.lightning;
-			$SendTxDetails.toUsername = lightningAddress;
+			txState.fromNetwork = Network.magi;
+			txState.toNetwork = Network.lightning;
+			txState.toUsername = lightningAddress;
 		}
 	});
 </script>
@@ -132,7 +134,7 @@
 				<AmountInput
 					bind:amount
 					coinOpt={shownCoin}
-					network={$SendTxDetails.toNetwork}
+					network={txState.toNetwork}
 					maxAmount={max}
 					id="withdraw-amount"
 				/>
@@ -149,10 +151,10 @@
 			<span class="label-like">Withdraw Asset</span>
 			<Select
 				items={toOptions}
-				initial={$SendTxDetails.toCoin?.coin.value}
+				initial={txState.toCoin?.coin.value}
 				onValueChange={(details) => {
 					if (open) {
-						$SendTxDetails.toCoin = $SendTxDetails.fromCoin = swapOptions.to.coins.find(
+						txState.toCoin = txState.fromCoin = swapOptions.to.coins.find(
 							(coinOpt) => coinOpt.coin.value === details.value[0]
 						);
 					}

--- a/src/lib/sendswap/stages/withdraw/WithdrawOptions.svelte
+++ b/src/lib/sendswap/stages/withdraw/WithdrawOptions.svelte
@@ -3,7 +3,8 @@
 	import ImageIconRenderer from '$lib/components/ImageIconRenderer.svelte';
 	import { ArrowLeft, ChevronRight } from '@lucide/svelte';
 	import swapOptions, { Coin, Network, TransferMethod } from '../../utils/sendOptions';
-	import { scanForBalance, SendTxDetails } from '../../utils/sendUtils';
+	import { scanForBalance } from '../../utils/sendUtils';
+	import { useWithdrawState } from '../../utils/txState.svelte';
 	import HiveMainnetWithdraw from './HiveMainnetWithdraw.svelte';
 	import BitcoinMainnetWithdraw from './BitcoinMainnetWithdraw.svelte';
 	import { untrack, type ComponentProps } from 'svelte';
@@ -22,6 +23,8 @@
 		customButtons: ComponentProps<typeof NavButtons>['buttons'] | undefined;
 	} = $props();
 
+	const txState = useWithdrawState();
+
 	let hiveMainnetOpen = $state(false);
 	let btcMainnetOpen = $state(false);
 	let secondaryMenu = $state(false);
@@ -36,71 +39,61 @@
 	$effect(() => {
 		if (!hiveMainnetOpen) return;
 		untrack(() => {
-			SendTxDetails.update((current) => {
-				const hiveCoin =
-					swapOptions.from.coins.find(
-						(coinOpt) =>
-							coinOpt.coin.value === Coin.hive.value &&
-							coinOpt.networks.some((n) => n.value === Network.magi.value)
-					) ||
-					swapOptions.from.coins.find(
-						(coinOpt) =>
-							coinOpt.coin.value === Coin.hbd.value &&
-							coinOpt.networks.some((n) => n.value === Network.magi.value)
-					);
-				const hbdCoin = swapOptions.from.coins.find(
+			const hiveCoin =
+				swapOptions.from.coins.find(
+					(coinOpt) =>
+						coinOpt.coin.value === Coin.hive.value &&
+						coinOpt.networks.some((n) => n.value === Network.magi.value)
+				) ||
+				swapOptions.from.coins.find(
 					(coinOpt) =>
 						coinOpt.coin.value === Coin.hbd.value &&
 						coinOpt.networks.some((n) => n.value === Network.magi.value)
 				);
+			const hbdCoin = swapOptions.from.coins.find(
+				(coinOpt) =>
+					coinOpt.coin.value === Coin.hbd.value &&
+					coinOpt.networks.some((n) => n.value === Network.magi.value)
+			);
 
-				const hiveHasBalance = !!(
-					hiveCoin && scanForBalance([{ coin: hiveCoin.coin, network: Network.magi }]) !== undefined
-				);
-				const hbdHasBalance = !!(
-					hbdCoin && scanForBalance([{ coin: hbdCoin.coin, network: Network.magi }]) !== undefined
-				);
+			const hiveHasBalance = !!(
+				hiveCoin && scanForBalance([{ coin: hiveCoin.coin, network: Network.magi }]) !== undefined
+			);
+			const hbdHasBalance = !!(
+				hbdCoin && scanForBalance([{ coin: hbdCoin.coin, network: Network.magi }]) !== undefined
+			);
 
-				let fromCoinToUse = hiveHasBalance ? hiveCoin : hbdHasBalance ? hbdCoin : hiveCoin;
-				if (
-					current.fromCoin &&
-					current.fromCoin.networks?.some((n) => n.value === Network.magi.value) &&
-					(current.fromCoin.coin.value === Coin.hive.value ||
-						current.fromCoin.coin.value === Coin.hbd.value)
-				) {
-					fromCoinToUse = current.fromCoin;
-				}
+			let fromCoinToUse = hiveHasBalance ? hiveCoin : hbdHasBalance ? hbdCoin : hiveCoin;
+			if (
+				txState.fromCoin &&
+				txState.fromCoin.networks?.some((n) => n.value === Network.magi.value) &&
+				(txState.fromCoin.coin.value === Coin.hive.value ||
+					txState.fromCoin.coin.value === Coin.hbd.value)
+			) {
+				fromCoinToUse = txState.fromCoin;
+			}
 
-				return {
-					...current,
-					method: TransferMethod.magiTransfer,
-					fromNetwork: Network.magi,
-					fromCoin: fromCoinToUse,
-					toNetwork: Network.hiveMainnet,
-					toCoin: fromCoinToUse
-				};
-			});
+			txState.method = TransferMethod.magiTransfer;
+			txState.fromNetwork = Network.magi;
+			txState.fromCoin = fromCoinToUse;
+			txState.toNetwork = Network.hiveMainnet;
+			txState.toCoin = fromCoinToUse;
 		});
 	});
 
 	$effect(() => {
 		if (!btcMainnetOpen) return;
 		untrack(() => {
-			SendTxDetails.update((current) => {
-				const btcCoin = swapOptions.from.coins.find(
-					(coinOpt) =>
-						coinOpt.coin.value === Coin.btc.value &&
-						coinOpt.networks.some((n) => n.value === Network.magi.value)
-				);
-				return {
-					...current,
-					method: TransferMethod.magiTransfer,
-					fromNetwork: Network.magi,
-					fromCoin: btcCoin,
-					toNetwork: Network.btcMainnet,
-					toCoin: btcCoin
-				};
-			});
+			const btcCoin = swapOptions.from.coins.find(
+				(coinOpt) =>
+					coinOpt.coin.value === Coin.btc.value &&
+					coinOpt.networks.some((n) => n.value === Network.magi.value)
+			);
+			txState.method = TransferMethod.magiTransfer;
+			txState.fromNetwork = Network.magi;
+			txState.fromCoin = btcCoin;
+			txState.toNetwork = Network.btcMainnet;
+			txState.toCoin = btcCoin;
 		});
 	});
 

--- a/src/lib/sendswap/utils/sendOptions.ts
+++ b/src/lib/sendswap/utils/sendOptions.ts
@@ -256,34 +256,6 @@ export type CoinOptions = {
 	}[];
 };
 
-export type SendDetails = {
-	fromCoin: CoinOptions['coins'][number] | undefined;
-	fromNetwork: Network | undefined;
-	fromAmount: string;
-	enteredAmount: string;
-	toCoin: CoinOptions['coins'][number] | undefined;
-	toNetwork: Network | undefined;
-	toAmount: string;
-	toUsername: string;
-	fee: CoinAmount<Coin> | undefined;
-	method: TransferMethod | undefined;
-	account: SendAccount | undefined;
-	toDisplayName: string;
-	memo: string;
-	// Swap-specific fields
-	expectedOutput: string | undefined;
-	slippageBps: number | undefined;
-	minAmountOut: string | undefined;
-	swapBaseFee: string | undefined;
-	swapClpFee: string | undefined;
-	swapTotalFee: string | undefined;
-	// Set on two-hop swaps: hop1's fee in the intermediate asset.
-	swapHop1Fee: { asset: string; totalFee: string } | undefined;
-	// BTC unmap fields
-	btcDeductFee: boolean;
-	btcMaxFee: number | undefined;
-};
-
 export type NecessarySendDetails = {
 	fromCoin: CoinOptions['coins'][number];
 	fromNetwork: Network;
@@ -292,6 +264,14 @@ export type NecessarySendDetails = {
 	toNetwork: Network;
 	toUsername: string;
 	memo?: string;
+	/** Raw from-asset amount string used for swap ops (pre-fee input). */
+	fromAmount?: string;
+	/** Pool slippage minimum-out (swap flows only). */
+	minAmountOut?: string;
+	/** Whether to deduct the BTC network fee from the output (unmap flows only). */
+	btcDeductFee?: boolean;
+	/** Sat cap on the BTC network fee (unmap flows only). */
+	btcMaxFee?: number;
 };
 
 export type TransferMethod = {

--- a/src/lib/sendswap/utils/sendOptions.ts
+++ b/src/lib/sendswap/utils/sendOptions.ts
@@ -256,24 +256,6 @@ export type CoinOptions = {
 	}[];
 };
 
-export type NecessarySendDetails = {
-	fromCoin: CoinOptions['coins'][number];
-	fromNetwork: Network;
-	amount: string;
-	toCoin: CoinOptions['coins'][number];
-	toNetwork: Network;
-	toUsername: string;
-	memo?: string;
-	/** Raw from-asset amount string used for swap ops (pre-fee input). */
-	fromAmount?: string;
-	/** Pool slippage minimum-out (swap flows only). */
-	minAmountOut?: string;
-	/** Whether to deduct the BTC network fee from the output (unmap flows only). */
-	btcDeductFee?: boolean;
-	/** Sat cap on the BTC network fee (unmap flows only). */
-	btcMaxFee?: number;
-};
-
 export type TransferMethod = {
 	label: string;
 	value: string;

--- a/src/lib/sendswap/utils/sendUtils.ts
+++ b/src/lib/sendswap/utils/sendUtils.ts
@@ -10,8 +10,7 @@ import swapOptions, {
 	type CoinOnNetwork,
 	type CoinOptions,
 	type IntermediaryNetwork,
-	type NecessarySendDetails,
-	type SendDetails
+	type NecessarySendDetails
 } from './sendOptions';
 import { authStore, getAuth, type Auth } from '$lib/auth/store';
 import { executeTx, getSendOpGenerator, getSendOpType } from '$lib/magiTransactions/hive';
@@ -25,7 +24,7 @@ import { createClient, signAndBrodcastTransaction } from '$lib/magiTransactions/
 import { wagmiSigner } from '$lib/magiTransactions/eth/wagmi';
 import { btcSigner } from '$lib/magiTransactions/bitcoin/signer';
 import { wagmiConfig } from '$lib/auth/reown';
-import { get, writable } from 'svelte/store';
+import { get } from 'svelte/store';
 import {
 	fetchTxs,
 	getTimestamp,
@@ -41,35 +40,7 @@ import {
 	type AccountBalance,
 	type HiveMainnetBalance
 } from '$lib/stores/currentBalance';
-
-export const SendTxDetails = writable<SendDetails>(blankDetails());
-
-export function blankDetails(): SendDetails {
-	return {
-		fromCoin: undefined,
-		fromNetwork: undefined,
-		fromAmount: '0',
-		enteredAmount: '0',
-		toCoin: undefined,
-		toNetwork: undefined,
-		toAmount: '0',
-		toUsername: '',
-		toDisplayName: '',
-		method: undefined,
-		account: undefined,
-		fee: undefined,
-		memo: '',
-		expectedOutput: undefined,
-		slippageBps: 100,
-		minAmountOut: undefined,
-		swapBaseFee: undefined,
-		swapClpFee: undefined,
-		swapTotalFee: undefined,
-		swapHop1Fee: undefined,
-		btcDeductFee: false,
-		btcMaxFee: undefined
-	};
-}
+import type { TxStateBase } from './txState.svelte';
 
 export function scanForBalance(opts: CoinOnNetwork[]): CoinOnNetwork | undefined {
 	const accBal = get(accountBalance);
@@ -379,20 +350,18 @@ export async function getLastPaidNetwork(netVal?: string): Promise<moment.Moment
 	return 'Never';
 }
 
-export async function getFee(toAmount: string) {
-	const store = get(SendTxDetails);
-
+export async function getFee(toAmount: string, state: TxStateBase) {
 	if (
-		store.fromCoin &&
-		store.fromNetwork &&
-		store.toCoin &&
-		store.toCoin.coin.value !== coins.usd.value &&
-		store.toNetwork
+		state.fromCoin &&
+		state.fromNetwork &&
+		state.toCoin &&
+		state.toCoin.coin.value !== coins.usd.value &&
+		state.toNetwork
 	) {
 		const fee = await getIntermediaryNetwork(
-			{ coin: store.fromCoin.coin, network: store.fromNetwork },
-			{ coin: store.toCoin.coin, network: store.toNetwork }
-		).feeCalculation(new CoinAmount(Number(toAmount), store.toCoin.coin), store.fromCoin.coin);
+			{ coin: state.fromCoin.coin, network: state.fromNetwork },
+			{ coin: state.toCoin.coin, network: state.toNetwork }
+		).feeCalculation(new CoinAmount(Number(toAmount), state.toCoin.coin), state.fromCoin.coin);
 		return fee;
 	}
 }
@@ -610,21 +579,20 @@ export function solveNetworkConstraints(
 	};
 }
 
-export function solveToNetworks(): Network[] {
-	const txDetails = get(SendTxDetails);
-	const recipientNetworks: Network[] | undefined = txDetails.toUsername
-		? getRecipientNetworks(getDidFromUsername(txDetails.toUsername)).filter((net) => !net.disabled)
+export function solveToNetworks(state: TxStateBase): Network[] {
+	const recipientNetworks: Network[] | undefined = state.toUsername
+		? getRecipientNetworks(getDidFromUsername(state.toUsername)).filter((net) => !net.disabled)
 		: undefined;
 	const coinNetworks =
-		txDetails.fromNetwork && txDetails.fromCoin ? txDetails.fromCoin.networks : undefined;
+		state.fromNetwork && state.fromCoin ? state.fromCoin.networks : undefined;
 	const intersection =
 		recipientNetworks && coinNetworks
 			? coinNetworks.filter((net) =>
 					recipientNetworks.map((rnet) => rnet.value).includes(net.value)
 				)
 			: (recipientNetworks ?? coinNetworks ?? []);
-	if (getUsernameFromAuth(getAuth()()) === txDetails.toUsername) {
-		return intersection.filter((net) => net.value !== txDetails.fromNetwork?.value);
+	if (getUsernameFromAuth(getAuth()()) === state.toUsername) {
+		return intersection.filter((net) => net.value !== state.fromNetwork?.value);
 	} else {
 		return intersection;
 	}
@@ -748,12 +716,11 @@ export async function send(
 		let extraOps: Operation[] = [];
 		let opType: string | undefined;
 
-		const tx = get(SendTxDetails);
 		if (isSwap) {
 			setStatus('Waiting for Hive wallet approval…');
 			// For swap, amount_in must be the from-asset amount (asset_in), e.g. 5 TBD => 5000
-			const fromAmountStr = tx.fromAmount && tx.fromAmount !== '0' ? tx.fromAmount : amount;
-			const minOut = tx.minAmountOut ? Number(tx.minAmountOut) : undefined;
+			const fromAmountStr = details.fromAmount && details.fromAmount !== '0' ? details.fromAmount : amount;
+			const minOut = details.minAmountOut ? Number(details.minAmountOut) : undefined;
 			const fromCa = new CoinAmount(fromAmountStr, fromCoin.coin);
 			if (fromCoin.coin.value === Coin.btc.value) {
 				extraOps.push(
@@ -799,7 +766,7 @@ export async function send(
 			toCoin.coin.value === Coin.btc.value &&
 			toNetwork.value === Network.btcMainnet.value
 		) {
-			// BTC unmap — pass deduct_fee and max_fee from store
+			// BTC unmap — pass deduct_fee and max_fee from NecessarySendDetails
 			opType = 'withdrawal';
 			setStatus('Waiting for Hive wallet approval…');
 			const { getBitcoinUnmapOp: getUnmapOp } =
@@ -809,8 +776,8 @@ export async function send(
 				auth.value.did,
 				toUsername,
 				new CoinAmount(amount, toCoin.coin),
-				tx.btcDeductFee || undefined,
-				tx.btcMaxFee
+				details.btcDeductFee || undefined,
+				details.btcMaxFee
 			);
 		} else {
 			const getSendOp = getSendOpGenerator(fromNetwork, toNetwork, toCoin.coin);

--- a/src/lib/sendswap/utils/sendUtils.ts
+++ b/src/lib/sendswap/utils/sendUtils.ts
@@ -9,9 +9,9 @@ import swapOptions, {
 	TransferMethod,
 	type CoinOnNetwork,
 	type CoinOptions,
-	type IntermediaryNetwork,
-	type NecessarySendDetails
+	type IntermediaryNetwork
 } from './sendOptions';
+import { type TxState, SwapTxState, TransferTxState } from './txState.svelte';
 import { authStore, getAuth, type Auth } from '$lib/auth/store';
 import { executeTx, getSendOpGenerator, getSendOpType } from '$lib/magiTransactions/hive';
 import { getHiveSwapOp, getBtcApproveOp } from '$lib/magiTransactions/hive/vscOperations/swap';
@@ -599,14 +599,28 @@ export function solveToNetworks(state: TxStateBase): Network[] {
 }
 
 export async function send(
-	details: NecessarySendDetails,
+	details: TxState,
 	auth: Auth,
 	intermediary: IntermediaryNetwork,
 	setStatus: (status: string, isError?: boolean) => void,
 	signal?: AbortSignal | undefined
 ): Promise<Error | { id: string }> {
 	// console.log('start of send() function, details:', details);
-	const { fromCoin, fromNetwork, amount, toCoin, toNetwork, toUsername } = details;
+	const fromCoin = details.fromCoin!;
+	const fromNetwork = details.fromNetwork!;
+	const toCoin = details.toCoin!;
+	const toNetwork = details.toNetwork!;
+	const toUsername = details.toUsername;
+	// Resolve send amount — toAmount may lag on deposit/withdraw due to effect timing
+	const raw = details.toAmount;
+	const amount =
+		raw && raw !== '0'
+			? raw
+			: details.fromAmount && details.fromAmount !== '0'
+				? details.fromAmount
+				: details.enteredAmount && details.enteredAmount !== '0'
+					? details.enteredAmount
+					: raw;
 	if (intermediary == Network.magi) {
 		// console.log('intermediary network is Magi');
 		if (auth.value?.provider == 'reown') {
@@ -720,7 +734,7 @@ export async function send(
 			setStatus('Waiting for Hive wallet approval…');
 			// For swap, amount_in must be the from-asset amount (asset_in), e.g. 5 TBD => 5000
 			const fromAmountStr = details.fromAmount && details.fromAmount !== '0' ? details.fromAmount : amount;
-			const minOut = details.minAmountOut ? Number(details.minAmountOut) : undefined;
+			const minOut = details instanceof SwapTxState && details.minAmountOut ? Number(details.minAmountOut) : undefined;
 			const fromCa = new CoinAmount(fromAmountStr, fromCoin.coin);
 			if (fromCoin.coin.value === Coin.btc.value) {
 				extraOps.push(
@@ -766,7 +780,7 @@ export async function send(
 			toCoin.coin.value === Coin.btc.value &&
 			toNetwork.value === Network.btcMainnet.value
 		) {
-			// BTC unmap — pass deduct_fee and max_fee from NecessarySendDetails
+			// BTC unmap — pass deduct_fee and max_fee from txState
 			opType = 'withdrawal';
 			setStatus('Waiting for Hive wallet approval…');
 			const { getBitcoinUnmapOp: getUnmapOp } =
@@ -787,7 +801,7 @@ export async function send(
 				auth.value.username!,
 				getDidFromUsername(toUsername),
 				new CoinAmount(amount, toCoin.coin),
-				details.memo ? new URLSearchParams({ msg: details.memo }) : undefined
+				details instanceof TransferTxState && details.memo ? new URLSearchParams({ msg: details.memo }) : undefined
 			);
 		}
 
@@ -835,7 +849,7 @@ export async function send(
 					from: auth.value.username!,
 					to: toUsername,
 					amount: toCoinAmount.toPrettyString(),
-					memo: details.memo ?? ''
+					memo: details instanceof TransferTxState ? details.memo : ''
 				}
 			] satisfies TransferOperation
 		]);
@@ -849,7 +863,7 @@ export async function send(
 							asset: toCoin!.coin.unit.toLowerCase(),
 							from: auth.value.did,
 							to: getDidFromUsername(toUsername),
-							memo: details.memo ?? '',
+							memo: details instanceof TransferTxState ? details.memo : '',
 							type: 'transfer'
 						},
 						type: 'transfer',

--- a/src/lib/sendswap/utils/txState.svelte.test.ts
+++ b/src/lib/sendswap/utils/txState.svelte.test.ts
@@ -4,8 +4,8 @@
  * These tests verify three things without touching the network or moving tokens:
  *  1. State isolation  — two flow instances never share fields (the original bug).
  *  2. Correct defaults — each class starts with the expected zero-state.
- *  3. Payload building — the NecessarySendDetails fields produced for `send()`
- *     carry the right values for each flow kind, including BTC-specific ones.
+ *  3. Payload building — the kind-specific fields read by `send()` carry the
+ *     right values for each flow kind, including BTC-specific ones.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -16,21 +16,18 @@ import {
 	WithdrawTxState,
 	TxStateBase
 } from './txState.svelte'
-import type { NecessarySendDetails } from './sendOptions'
-
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /**
- * Mirrors what StepsMachine.initSend() does: build the fields of
- * NecessarySendDetails that vary per flow kind.
+ * Mirrors what send() reads from txState for the kind-specific fields.
  * (coin/network/amount wiring is not tested here — only the kind-specific fields.)
  */
-function buildKindFields(txState: TxStateBase): Partial<NecessarySendDetails> {
+function buildKindFields(txState: TxStateBase) {
 	return {
 		toUsername: txState.toUsername,
 		fromAmount: txState.fromAmount,
-		memo: txState.kind === 'transfer' ? (txState as TransferTxState).memo : undefined,
-		minAmountOut: txState.kind === 'swap' ? (txState as SwapTxState).minAmountOut : undefined,
+		memo: txState instanceof TransferTxState ? txState.memo : undefined,
+		minAmountOut: txState instanceof SwapTxState ? txState.minAmountOut : undefined,
 		btcDeductFee: txState.btcDeductFee || undefined,
 		btcMaxFee: txState.btcMaxFee
 	}
@@ -141,7 +138,7 @@ describe('default values — each class starts at zero-state', () => {
 
 // ─── 3. Payload building ──────────────────────────────────────────────────────
 
-describe('payload building — kind-specific NecessarySendDetails fields', () => {
+describe('payload building — kind-specific fields read by send()', () => {
 	it('swap flow: minAmountOut is included, memo is absent', () => {
 		const state = new SwapTxState()
 		state.toUsername = 'alice'

--- a/src/lib/sendswap/utils/txState.svelte.test.ts
+++ b/src/lib/sendswap/utils/txState.svelte.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for the per-flow isolated $state refactor.
+ *
+ * These tests verify three things without touching the network or moving tokens:
+ *  1. State isolation  — two flow instances never share fields (the original bug).
+ *  2. Correct defaults — each class starts with the expected zero-state.
+ *  3. Payload building — the NecessarySendDetails fields produced for `send()`
+ *     carry the right values for each flow kind, including BTC-specific ones.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+	SwapTxState,
+	TransferTxState,
+	DepositTxState,
+	WithdrawTxState,
+	TxStateBase
+} from './txState.svelte'
+import type { NecessarySendDetails } from './sendOptions'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Mirrors what StepsMachine.initSend() does: build the fields of
+ * NecessarySendDetails that vary per flow kind.
+ * (coin/network/amount wiring is not tested here — only the kind-specific fields.)
+ */
+function buildKindFields(txState: TxStateBase): Partial<NecessarySendDetails> {
+	return {
+		toUsername: txState.toUsername,
+		fromAmount: txState.fromAmount,
+		memo: txState.kind === 'transfer' ? (txState as TransferTxState).memo : undefined,
+		minAmountOut: txState.kind === 'swap' ? (txState as SwapTxState).minAmountOut : undefined,
+		btcDeductFee: txState.btcDeductFee || undefined,
+		btcMaxFee: txState.btcMaxFee
+	}
+}
+
+// ─── 1. State isolation ───────────────────────────────────────────────────────
+
+describe('state isolation — two flow instances never share fields', () => {
+	it('writing toUsername on SwapTxState does not affect a separate TransferTxState', () => {
+		const swapState = new SwapTxState()
+		const transferState = new TransferTxState()
+
+		swapState.toUsername = 'alice'
+
+		expect(transferState.toUsername).toBe('')
+	})
+
+	it('writing toUsername on TransferTxState does not affect a separate SwapTxState', () => {
+		const swapState = new SwapTxState()
+		const transferState = new TransferTxState()
+
+		transferState.toUsername = 'bob'
+
+		expect(swapState.toUsername).toBe('')
+	})
+
+	it('two SwapTxState instances are fully independent', () => {
+		const s1 = new SwapTxState()
+		const s2 = new SwapTxState()
+
+		s1.toUsername = 'alice'
+		s1.fromAmount = '1000'
+		s1.minAmountOut = '950'
+
+		expect(s2.toUsername).toBe('')
+		expect(s2.fromAmount).toBe('0')
+		expect(s2.minAmountOut).toBeUndefined()
+	})
+
+	it('two TransferTxState instances are fully independent', () => {
+		const t1 = new TransferTxState()
+		const t2 = new TransferTxState()
+
+		t1.toUsername = 'charlie'
+		t1.memo = 'payment'
+		t1.toDisplayName = 'Charlie'
+
+		expect(t2.toUsername).toBe('')
+		expect(t2.memo).toBe('')
+		expect(t2.toDisplayName).toBe('')
+	})
+
+	it('DepositTxState and WithdrawTxState do not share btc fields', () => {
+		const deposit = new DepositTxState()
+		const withdraw = new WithdrawTxState()
+
+		withdraw.btcDeductFee = true
+		withdraw.btcMaxFee = 5000
+
+		expect(deposit.btcDeductFee).toBe(false)
+		expect(deposit.btcMaxFee).toBeUndefined()
+	})
+})
+
+// ─── 2. Default values ────────────────────────────────────────────────────────
+
+describe('default values — each class starts at zero-state', () => {
+	it('TxStateBase shared fields default correctly', () => {
+		const state = new SwapTxState()
+		expect(state.toUsername).toBe('')
+		expect(state.fromAmount).toBe('0')
+		expect(state.toAmount).toBe('0')
+		expect(state.enteredAmount).toBe('0')
+		expect(state.fee).toBeUndefined()
+		expect(state.fromCoin).toBeUndefined()
+		expect(state.toCoin).toBeUndefined()
+		expect(state.fromNetwork).toBeUndefined()
+		expect(state.toNetwork).toBeUndefined()
+		expect(state.btcDeductFee).toBe(false)
+		expect(state.btcMaxFee).toBeUndefined()
+	})
+
+	it('SwapTxState-specific defaults', () => {
+		const state = new SwapTxState()
+		expect(state.kind).toBe('swap')
+		expect(state.expectedOutput).toBeUndefined()
+		expect(state.slippageBps).toBe(100)
+		expect(state.minAmountOut).toBeUndefined()
+		expect(state.swapTotalFee).toBeUndefined()
+		expect(state.swapHop1Fee).toBeUndefined()
+	})
+
+	it('TransferTxState-specific defaults', () => {
+		const state = new TransferTxState()
+		expect(state.kind).toBe('transfer')
+		expect(state.memo).toBe('')
+		expect(state.toDisplayName).toBe('')
+	})
+
+	it('DepositTxState kind', () => {
+		expect(new DepositTxState().kind).toBe('deposit')
+	})
+
+	it('WithdrawTxState kind', () => {
+		expect(new WithdrawTxState().kind).toBe('withdraw')
+	})
+})
+
+// ─── 3. Payload building ──────────────────────────────────────────────────────
+
+describe('payload building — kind-specific NecessarySendDetails fields', () => {
+	it('swap flow: minAmountOut is included, memo is absent', () => {
+		const state = new SwapTxState()
+		state.toUsername = 'alice'
+		state.fromAmount = '5000'
+		state.minAmountOut = '4750'
+
+		const payload = buildKindFields(state)
+
+		expect(payload.toUsername).toBe('alice')
+		expect(payload.fromAmount).toBe('5000')
+		expect(payload.minAmountOut).toBe('4750')
+		expect(payload.memo).toBeUndefined()
+		expect(payload.btcDeductFee).toBeUndefined()
+		expect(payload.btcMaxFee).toBeUndefined()
+	})
+
+	it('transfer flow: memo is included, minAmountOut is absent', () => {
+		const state = new TransferTxState()
+		state.toUsername = 'bob'
+		state.fromAmount = '1000'
+		state.memo = 'for lunch'
+
+		const payload = buildKindFields(state)
+
+		expect(payload.toUsername).toBe('bob')
+		expect(payload.memo).toBe('for lunch')
+		expect(payload.minAmountOut).toBeUndefined()
+		expect(payload.btcDeductFee).toBeUndefined()
+		expect(payload.btcMaxFee).toBeUndefined()
+	})
+
+	it('withdraw flow targeting BTC mainnet: btcDeductFee and btcMaxFee are included', () => {
+		const state = new WithdrawTxState()
+		state.toUsername = 'bc1qalice'
+		state.btcDeductFee = true
+		state.btcMaxFee = 3000
+
+		const payload = buildKindFields(state)
+
+		expect(payload.btcDeductFee).toBe(true)
+		expect(payload.btcMaxFee).toBe(3000)
+		expect(payload.memo).toBeUndefined()
+		expect(payload.minAmountOut).toBeUndefined()
+	})
+
+	it('transfer flow targeting BTC mainnet: btcDeductFee and btcMaxFee also flow through', () => {
+		// TransferOptions.svelte renders the BTC fee UI for external BTC transfers.
+		// btcDeductFee/btcMaxFee live on TxStateBase so they pass through
+		// for transfer kind too — previously a bug (kind === 'withdraw' guard
+		// in StepsMachine would have swallowed them).
+		const state = new TransferTxState()
+		state.toUsername = 'bc1qbob'
+		state.btcDeductFee = true
+		state.btcMaxFee = 5000
+
+		const payload = buildKindFields(state)
+
+		expect(payload.btcDeductFee).toBe(true)
+		expect(payload.btcMaxFee).toBe(5000)
+	})
+
+	it('btcDeductFee=false collapses to undefined in payload (no-op for contract)', () => {
+		const state = new WithdrawTxState()
+		state.btcDeductFee = false
+
+		const payload = buildKindFields(state)
+
+		// false || undefined = undefined — the contract receives no deduct_fee flag
+		expect(payload.btcDeductFee).toBeUndefined()
+	})
+
+	it('deposit flow: no memo, no minAmountOut, no btc fields', () => {
+		const state = new DepositTxState()
+		state.toUsername = 'carol'
+		state.fromAmount = '2000'
+
+		const payload = buildKindFields(state)
+
+		expect(payload.toUsername).toBe('carol')
+		expect(payload.memo).toBeUndefined()
+		expect(payload.minAmountOut).toBeUndefined()
+		expect(payload.btcDeductFee).toBeUndefined()
+		expect(payload.btcMaxFee).toBeUndefined()
+	})
+})
+
+// ─── 4. The original bug — reproduced and verified fixed ─────────────────────
+
+describe('original bug: QuickSwap writing toUsername must not reach QuickSend', () => {
+	it('simulates the dashboard: swap sets toUsername, send stays blank', () => {
+		// Before the refactor both widgets wrote to the same global SendTxDetails store.
+		// Now each owns its own instance — changes in one are invisible to the other.
+		const swapState = new SwapTxState()
+		const sendState = new TransferTxState()
+
+		// QuickSwap auto-fills toUsername with the signed-in user
+		swapState.toUsername = 'myusername'
+
+		// QuickSend's recipient must remain blank
+		expect(sendState.toUsername).toBe('')
+	})
+
+	it('QuickSend sets a recipient without affecting QuickSwap destination', () => {
+		const swapState = new SwapTxState()
+		const sendState = new TransferTxState()
+
+		sendState.toUsername = 'friend'
+
+		expect(swapState.toUsername).toBe('')
+	})
+})

--- a/src/lib/sendswap/utils/txState.svelte.ts
+++ b/src/lib/sendswap/utils/txState.svelte.ts
@@ -1,0 +1,87 @@
+import { getContext, setContext } from 'svelte'
+import type { CoinAmount } from '$lib/currency/CoinAmount'
+import type { Coin } from './sendOptions'
+import type { CoinOptions, Network, TransferMethod, SendAccount } from './sendOptions'
+
+// ─── Base (fields every flow shares) ─────────────────────────────────────────
+
+export class TxStateBase {
+	fromCoin: CoinOptions['coins'][number] | undefined = $state(undefined)
+	fromNetwork: Network | undefined = $state(undefined)
+	fromAmount: string = $state('0')
+	enteredAmount: string = $state('0')
+	toCoin: CoinOptions['coins'][number] | undefined = $state(undefined)
+	toNetwork: Network | undefined = $state(undefined)
+	toAmount: string = $state('0')
+	toUsername: string = $state('')
+	fee: CoinAmount<Coin> | undefined = $state(undefined)
+	method: TransferMethod | undefined = $state(undefined)
+	account: SendAccount | undefined = $state(undefined)
+	/** Whether to deduct the BTC network fee from the output (BTC unmap flows). */
+	btcDeductFee: boolean = $state(false)
+	/** Sat cap on the BTC network fee (BTC unmap flows). */
+	btcMaxFee: number | undefined = $state(undefined)
+}
+
+// ─── Swap (QuickSwap card, /swap page) ───────────────────────────────────────
+
+export class SwapTxState extends TxStateBase {
+	readonly kind = 'swap' as const
+	expectedOutput: string | undefined = $state(undefined)
+	slippageBps: number | undefined = $state(100)
+	minAmountOut: string | undefined = $state(undefined)
+	swapBaseFee: string | undefined = $state(undefined)
+	swapClpFee: string | undefined = $state(undefined)
+	swapTotalFee: string | undefined = $state(undefined)
+	swapHop1Fee: { asset: string; totalFee: string } | undefined = $state(undefined)
+}
+
+// ─── Transfer (QuickSend dialog, /transfer page) ──────────────────────────────
+
+export class TransferTxState extends TxStateBase {
+	readonly kind = 'transfer' as const
+	toDisplayName: string = $state('')
+	memo: string = $state('')
+}
+
+// ─── Deposit (L1 → Magi) ─────────────────────────────────────────────────────
+
+export class DepositTxState extends TxStateBase {
+	readonly kind = 'deposit' as const
+}
+
+// ─── Withdraw (Magi → L1) ────────────────────────────────────────────────────
+
+export class WithdrawTxState extends TxStateBase {
+	readonly kind = 'withdraw' as const
+}
+
+// ─── Union & context ─────────────────────────────────────────────────────────
+
+export type TxState = SwapTxState | TransferTxState | DepositTxState | WithdrawTxState
+
+const TX_STATE_KEY = Symbol('txState')
+
+export function provideTxState(state: TxState) {
+	setContext(TX_STATE_KEY, state)
+}
+
+export function useTxState(): TxState {
+	return getContext<TxState>(TX_STATE_KEY)
+}
+
+export function useSwapState(): SwapTxState {
+	return getContext<SwapTxState>(TX_STATE_KEY)
+}
+
+export function useTransferState(): TransferTxState {
+	return getContext<TransferTxState>(TX_STATE_KEY)
+}
+
+export function useDepositState(): DepositTxState {
+	return getContext<DepositTxState>(TX_STATE_KEY)
+}
+
+export function useWithdrawState(): WithdrawTxState {
+	return getContext<WithdrawTxState>(TX_STATE_KEY)
+}

--- a/src/lib/sendswap/utils/txState.svelte.ts
+++ b/src/lib/sendswap/utils/txState.svelte.ts
@@ -67,21 +67,41 @@ export function provideTxState(state: TxState) {
 }
 
 export function useTxState(): TxState {
-	return getContext<TxState>(TX_STATE_KEY)
+	const state = getContext<unknown>(TX_STATE_KEY)
+	if (!(state instanceof TxStateBase)) {
+		throw new Error(`useTxState() called outside a TxState provider (got ${typeof state})`)
+	}
+	return state as TxState
 }
 
 export function useSwapState(): SwapTxState {
-	return getContext<SwapTxState>(TX_STATE_KEY)
+	const state = getContext<unknown>(TX_STATE_KEY)
+	if (!(state instanceof SwapTxState)) {
+		throw new Error(`useSwapState() called with unexpected context value (got ${state?.constructor?.name ?? typeof state})`)
+	}
+	return state
 }
 
 export function useTransferState(): TransferTxState {
-	return getContext<TransferTxState>(TX_STATE_KEY)
+	const state = getContext<unknown>(TX_STATE_KEY)
+	if (!(state instanceof TransferTxState)) {
+		throw new Error(`useTransferState() called with unexpected context value (got ${state?.constructor?.name ?? typeof state})`)
+	}
+	return state
 }
 
 export function useDepositState(): DepositTxState {
-	return getContext<DepositTxState>(TX_STATE_KEY)
+	const state = getContext<unknown>(TX_STATE_KEY)
+	if (!(state instanceof DepositTxState)) {
+		throw new Error(`useDepositState() called with unexpected context value (got ${state?.constructor?.name ?? typeof state})`)
+	}
+	return state
 }
 
 export function useWithdrawState(): WithdrawTxState {
-	return getContext<WithdrawTxState>(TX_STATE_KEY)
+	const state = getContext<unknown>(TX_STATE_KEY)
+	if (!(state instanceof WithdrawTxState)) {
+		throw new Error(`useWithdrawState() called with unexpected context value (got ${state?.constructor?.name ?? typeof state})`)
+	}
+	return state
 }


### PR DESCRIPTION
## Problem

All transaction flows (swap, send, deposit, withdraw) shared a single global
`SendTxDetails` writable store. Components on the same page — `QuickSwap` and
`QuickSend` on the dashboard — would cross-contaminate each other's state.

Concrete bug: `QuickSwap` auto-fills `toUsername` with the signed-in user as the
swap destination. `QuickSend` would read the same store and pre-select that user
as the recipient — which is explicitly not allowed (no self-sends on internal transfers).

## Changes

- **Replaced global store** with per-flow `$state` class instances scoped via Svelte
  context (`provideTxState` / `useTxState`). Each flow owns its own private state;
  siblings on the same page cannot read or write each other's fields.
- **Split `SendDetails`** into a discriminated union:
  `SwapTxState | TransferTxState | DepositTxState | WithdrawTxState`.
  Each flow only carries the fields it actually needs.
- **Removed snapshot/restore hacks** in `Deposit` and `Withdraw` that existed solely
  to work around the shared store.
- **Fixed secondary bug**: `StepsMachine` was gating `btcDeductFee`/`btcMaxFee` behind
  `kind === 'withdraw'`, silently dropping those fields for external BTC transfers
  from the transfer flow. Fixed and covered by a test.
- **Deleted dead code**: flat `SendDetails` type, unused `accountCardSnippet` with an
  invalid `getContext()` call inside a snippet body.

## Tests

18 new unit tests covering:
- State isolation (the original bug reproduced and verified fixed)
- Correct defaults per class
- Payload field correctness per flow kind
- BTC fee fields passing through for both withdraw and transfer flows