### PR TITLE
feat(dashboard): UI polish, popup redesign, widget order, asset modal fixes

### DIFF
--- a/src/lib/cards/QuickSwap.svelte
+++ b/src/lib/cards/QuickSwap.svelte
@@ -1276,6 +1276,8 @@
 		</div>
 	</div>
 
+	<!-- Variable content: grows to fill space, content anchored to bottom so button never moves -->
+	<div class="swap-middle">
 	<!-- Swap Details -->
 	{#if txState.fromCoin && txState.toCoin}
 		<div class="swap-details">
@@ -1362,6 +1364,7 @@
 	{:else if exceedsPoolDepth}
 		<p class="swap-status error">Amount exceeds 50% of pool depth — reduce the amount.</p>
 	{/if}
+	</div><!-- end .swap-middle -->
 
 	<!-- Exchange -->
 	<PillButton
@@ -1489,6 +1492,25 @@
 		border-radius: 27px;
 		padding: 1.25rem;
 		box-shadow: var(--dash-card-shadow);
+		/* Fill the fixed-height container set by the dashboard grid. */
+		height: 100%;
+		box-sizing: border-box;
+		overflow: hidden;
+		/* Flex column so .swap-middle grows and the button stays pinned. */
+		display: flex;
+		flex-direction: column;
+	}
+
+	/* Grows to fill space between slippage and the button.
+	   Content stacks from the top (flex-start); blank space sits below
+	   warnings so the Swap button stays pinned and nothing shifts. */
+	.swap-middle {
+		flex: 1;
+		min-height: 0;
+		display: flex;
+		flex-direction: column;
+		justify-content: flex-start;
+		overflow: hidden;
 	}
 
 	/* Header */

--- a/src/lib/components/SidePopup.svelte
+++ b/src/lib/components/SidePopup.svelte
@@ -2,8 +2,9 @@
 	import Card from '$lib/cards/Card.svelte';
 	import PillButton from '$lib/PillButton.svelte';
 	import { X } from '@lucide/svelte';
-	import { onMount, untrack, type Snippet } from 'svelte';
-	import { fly } from 'svelte/transition';
+	import { untrack, type Snippet } from 'svelte';
+	import { fly, fade } from 'svelte/transition';
+	import { portal } from '@zag-js/svelte';
 
 	type Props = {
 		content: (() => ReturnType<Snippet>) | undefined;
@@ -13,9 +14,6 @@
 		toggle: () => void;
 		defaultOpen?: boolean;
 		open?: boolean;
-		position?: 'left' | 'right' | 'top' | 'bottom';
-		width?: string;
-		height?: string;
 	};
 
 	let {
@@ -25,97 +23,17 @@
 		description,
 		toggle,
 		defaultOpen = false,
-		open = $bindable(),
-		position = 'right',
-		width = '400px',
-		height = 'auto'
+		open = $bindable()
 	}: Props = $props();
 
 	open = !!untrack(() => defaultOpen);
 
-	let remValue = $state(0);
-	onMount(() => {
-		const rootStyle = getComputedStyle(document.documentElement);
-		remValue = parseFloat(rootStyle.fontSize);
-	});
-
-	let scrollY = $state(0);
-	let windowWidth = $state(0);
-	const visibleHeaderHeight = $derived(Math.max(0, 50 - scrollY));
-	// width of popup * 2 + 64rem (max content width) + width of left side panel
-	// if windowWidth is greater than this the popup fits to the right of header
-	const mustAvoidHeader = $derived(windowWidth < 400 * 2 + 64 * remValue + 205);
-	// console.log("mustAvoidHeader")
-
-	// Handle escape key
 	function handleKeydown(event: KeyboardEvent) {
-		if (event.key === 'Escape' && open) {
-			toggle();
-		}
-	}
-
-	// Get transition parameters based on position
-	function getTransition() {
-		switch (position) {
-			case 'left':
-				return { x: -300, duration: 300 };
-			case 'right':
-				return { x: 300, duration: 300 };
-			case 'top':
-				return { y: -300, duration: 300 };
-			case 'bottom':
-				return { y: 300, duration: 300 };
-			default:
-				return { x: 300, duration: 300 };
-		}
-	}
-
-	// Get positioning styles
-	function getPositionStyles() {
-		const baseStyles = {
-			position: 'fixed',
-			zIndex: 12,
-			width: position === 'left' || position === 'right' ? width : '100%',
-			height: position === 'top' || position === 'bottom' ? height : '100%',
-			maxHeight: '100vh',
-			overflow: 'auto',
-			margin: '0.5rem'
-		};
-
-		switch (position) {
-			case 'left':
-				return {
-					...baseStyles,
-					left: '0',
-					top: mustAvoidHeader ? `${visibleHeaderHeight}px` : '0',
-					height: mustAvoidHeader ? `calc(100% - ${visibleHeaderHeight}px - 1rem)` : '100%'
-				};
-			case 'right':
-				return {
-					...baseStyles,
-					right: '0',
-					top: mustAvoidHeader ? `${visibleHeaderHeight}px` : '0',
-					height: mustAvoidHeader ? `calc(100% - ${visibleHeaderHeight}px - 1rem)` : '100%'
-				};
-			case 'top':
-				return { ...baseStyles, top: '0', left: '0', width: '100%' };
-			case 'bottom':
-				return { ...baseStyles, bottom: '0', left: '0', width: '100%' };
-			default:
-				return { ...baseStyles, right: '0', top: '0', height: '100%' };
-		}
+		if (event.key === 'Escape' && open) toggle();
 	}
 </script>
 
-<svelte:window
-	on:keydown={handleKeydown}
-	bind:scrollY
-	bind:innerWidth={windowWidth}
-	on:resize={() => {
-		const rootStyle = getComputedStyle(document.documentElement);
-		remValue = parseFloat(rootStyle.fontSize);
-	}}
-/>
+<svelte:window onkeydown={handleKeydown} />
 
 {#if children}
 	<PillButton onclick={() => (open = true)} styleType="outline">
@@ -124,26 +42,20 @@
 {/if}
 
 {#if open}
-	<div
-		class="popup-container"
-		style={Object.entries(getPositionStyles())
-			.map(([key, value]) => `${key.replace(/([A-Z])/g, '-$1').toLowerCase()}: ${value}`)
-			.join('; ')}
-		transition:fly={getTransition()}
-		role="dialog"
-		aria-modal="false"
-		tabindex="-1"
-	>
-		<Card opaque style="height: calc(100% - 3.5rem);">
-			<div class="close-button">
-				<PillButton onclick={toggle} styleType="icon-subtle">
-					<X size="32" />
-				</PillButton>
-			</div>
+	<!-- Teleported to document.body so it escapes any overflow/stacking constraints -->
+	<div use:portal class="popup-backdrop" transition:fade={{ duration: 200 }} onclick={toggle} role="presentation"></div>
+
+	<div use:portal class="popup-container" transition:fly={{ y: 24, duration: 250 }} role="dialog" aria-modal="true" tabindex="-1">
+		<Card opaque style="flex: 1; min-height: 0; overflow: hidden; box-sizing: border-box;">
 			<div class="popup-content">
-				{#if title}
-					<h2 class="popup-title">{@render title()}</h2>
-				{/if}
+				<div class="popup-header">
+					{#if title}
+						<h2 class="popup-title">{@render title()}</h2>
+					{/if}
+					<PillButton onclick={toggle} styleType="icon-subtle">
+						<X size="32" />
+					</PillButton>
+				</div>
 
 				{#if description}
 					<div class="popup-description">
@@ -162,46 +74,51 @@
 {/if}
 
 <style lang="scss">
+	.popup-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.6);
+		z-index: 49;
+		cursor: pointer;
+	}
+
 	.popup-container {
-		/* Allows clicks to pass through to background */
-		pointer-events: auto;
-
-		/* Smooth scrolling */
-		scroll-behavior: smooth;
-
-		/* Ensure proper stacking */
-		isolation: isolate;
-	}
-
-	.background {
-		background: linear-gradient(135deg, #0000001a, #ffffff0d);
-		backdrop-filter: blur(25px);
-		border: 1px solid var(--dash-card-border);
-		border-radius: 27px;
-		padding: 0.5rem;
-		overflow: auto;
-		position: relative;
-		height: calc(100% - 2.1rem);
-		display: flex;
-		box-shadow: var(--dash-card-shadow);
-	}
-
-	.close-button {
-		position: absolute;
-		top: 0.75rem;
-		right: 0.75rem;
-		height: fit-content;
-	}
-
-	.popup-content {
-		padding: 1rem;
+		position: fixed;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		z-index: 55;
+		width: 480px;
+		max-width: calc(100vw - 2rem);
+		max-height: calc(100dvh - 4rem);
 		display: flex;
 		flex-direction: column;
+	}
+
+	/*
+	 * Card is display:grid — its single child (popup-content) stretches to fill it.
+	 * popup-content uses flex-column so the header is pinned and the body scrolls.
+	 */
+	.popup-content {
+		display: flex;
+		flex-direction: column;
+		/* fills the Card grid cell */
+		align-self: stretch;
+		min-height: 0;
+		overflow: hidden;
 		gap: 1rem;
-		flex: 1;
+	}
+
+	.popup-header {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		justify-content: flex-end;
+		flex-shrink: 0;
 	}
 
 	.popup-title {
+		flex: 1;
 		font-size: var(--text-3xl);
 		font-family: 'Nunito Sans', sans-serif;
 		font-weight: 600;
@@ -218,16 +135,11 @@
 
 	.popup-body {
 		flex: 1;
-		overflow: auto;
+		min-height: 0;
+		overflow-y: auto;
+		overflow-x: hidden;
 		display: flex;
 		flex-direction: column;
-	}
-
-	/* Responsive adjustments */
-	@media screen and (max-width: 630px) {
-		.popup-container {
-			width: 100% !important;
-			max-width: 100% !important;
-		}
+		gap: 0.75rem;
 	}
 </style>

--- a/src/lib/currency/CoinAmount.ts
+++ b/src/lib/currency/CoinAmount.ts
@@ -57,6 +57,9 @@ export class CoinAmount<C extends Coin> {
 			if (zeroes.length != 0) decimal = decimal.slice(0, -zeroes.length);
 			if (decimal.length == 0) return integer;
 		}
+		// Zero-decimal coins (e.g. sats) produce an empty decimal string — never
+		// emit a trailing dot regardless of keepTrailingZeroes.
+		if (decimal.length === 0) return `${isNegative ? '-' : ''}${integer || '0'}`;
 		const out = `${isNegative ? '-' : ''}${integer || '0'}.${decimal}`;
 		return out;
 	}

--- a/src/lib/sendswap/StepsMachine.svelte
+++ b/src/lib/sendswap/StepsMachine.svelte
@@ -172,6 +172,7 @@
 
 	// START TRANSACTION
 	function initSend() {
+		if (!txState) return new Error('initSend() called without a TxState provider');
 		// For deposit/withdraw: toCoin mirrors fromCoin; toNetwork defaults based on txType.
 		// Write resolved values back so send() can read them directly from txState.
 		txState.toCoin = txState.toCoin ?? txState.fromCoin;

--- a/src/lib/sendswap/components/assetSelection/AssetList.svelte
+++ b/src/lib/sendswap/components/assetSelection/AssetList.svelte
@@ -127,7 +127,19 @@
 				</li>
 			{/if}
 			{#each groupItems as item (item.value ?? item.label)}
-				<li {...api.getItemProps({ item })} class="real-item">
+				{@const itemProps = api.getItemProps({ item })}
+				<li
+					{...itemProps}
+					class="real-item"
+					onclick={(e) => {
+						// Call Zag's handler first (handles new selections + keyboard nav state).
+						itemProps.onclick?.(e);
+						// Zag's onSelect only fires when selection changes — manually
+						// close when the user re-clicks the already-selected item.
+						const itemVal = item.value ?? item.label;
+						if (itemVal === value) clickAsset(itemVal);
+					}}
+				>
 					{#if item.snippet}
 						{@render item.snippet(item.snippetData ?? item)}
 					{:else}

--- a/src/lib/sendswap/utils/txState.svelte.ts
+++ b/src/lib/sendswap/utils/txState.svelte.ts
@@ -66,12 +66,10 @@ export function provideTxState(state: TxState) {
 	setContext(TX_STATE_KEY, state)
 }
 
-export function useTxState(): TxState {
+export function useTxState(): TxState | undefined {
 	const state = getContext<unknown>(TX_STATE_KEY)
-	if (!(state instanceof TxStateBase)) {
-		throw new Error(`useTxState() called outside a TxState provider (got ${typeof state})`)
-	}
-	return state as TxState
+	if (state instanceof TxStateBase) return state as TxState
+	return undefined
 }
 
 export function useSwapState(): SwapTxState {

--- a/src/lib/zag/Dialog.svelte
+++ b/src/lib/zag/Dialog.svelte
@@ -198,6 +198,14 @@
 	.title-and-close.no-title {
 		height: 0;
 		margin-bottom: 0;
+		// Lift the X button out of the collapsed row so it sits at the same
+		// visual level as the back-arrow button when a title is present.
+		.close {
+			position: absolute;
+			right: 0;
+			top: 0;
+			margin-left: 0;
+		}
 	}
 
 	@media screen and (max-width: 36rem) {

--- a/src/routes/(authed)/+page.svelte
+++ b/src/routes/(authed)/+page.svelte
@@ -22,32 +22,27 @@
 </document:head>
 
 <div class="dashboard-wrapper">
-	<!-- Row 1: Balance + Portfolio/Staking -->
-	<div class="top-row">
-		<div class="balance-col">
-			<Balance />
-		</div>
-		<div class="right-col">
-			<PortfolioValue />
-			<StakingEarnings onStake={() => toggleStake(true)} />
-		</div>
+	<div class="area-balance">
+		<Balance />
 	</div>
 
-	<!-- Row 2: Cross-chain swap | Market prices + RC -->
-	<div class="widgets-row">
-		<div class="quickswap-col">
-			<QuickSwap />
-		</div>
-		<div class="market-rc-stack">
-			<MarketPrices />
-			{#if auth.value}
-				<ResourceCredits {username} />
-			{/if}
-		</div>
+	<div class="area-portfolio">
+		<PortfolioValue />
+		<StakingEarnings onStake={() => toggleStake(true)} />
 	</div>
 
-	<!-- Row 3: Transactions — always last -->
-	<div class="transactions-section">
+	<div class="area-rc-market">
+		{#if auth.value}
+			<ResourceCredits {username} />
+		{/if}
+		<MarketPrices />
+	</div>
+
+	<div class="area-quickswap">
+		<QuickSwap />
+	</div>
+
+	<div class="area-transactions">
 		<div class="card transactions-card">
 			<div class="card-header">
 				<h4>Transaction</h4>
@@ -55,9 +50,11 @@
 					All <span class="dropdown-arrow">&#9662;</span>
 				</button>
 			</div>
-			{#if auth.value}
-				<Table did={auth.value.did} allowPopup={false} limit={10} size="small" />
-			{/if}
+			<div class="table-body">
+				{#if auth.value}
+					<Table did={auth.value.did} allowPopup={false} limit={12} size="small" />
+				{/if}
+			</div>
 		</div>
 	</div>
 </div>
@@ -67,12 +64,9 @@
 {/if}
 
 <style lang="scss">
+	/* ── Shared card chrome (scoped to dashboard wrapper only) ──────────── */
+
 	.dashboard-wrapper {
-		display: flex;
-		flex-direction: column;
-		gap: 16px;
-		width: 100%;
-		padding-bottom: 2rem;
 		:global(.dashboard-card),
 		:global(.card) {
 			border-color: rgba(255, 255, 255, 0.12) !important;
@@ -81,51 +75,6 @@
 				transform: translateY(-1px);
 			}
 		}
-	}
-
-	/* Row 1 — Balance (left) + Portfolio/Staking (right) */
-	.top-row {
-		display: grid;
-		grid-template-columns: 37fr 63fr;
-		gap: 16px;
-		align-items: stretch;
-	}
-
-	.balance-col {
-		min-width: 0;
-	}
-
-	.right-col {
-		display: flex;
-		flex-direction: column;
-		gap: 16px;
-		min-width: 0;
-	}
-
-	/* Row 2 — QuickSwap (left) | MarketPrices + RC stacked (right) */
-	.widgets-row {
-		display: flex;
-		flex-direction: row;
-		gap: 16px;
-		align-items: flex-start;
-	}
-
-	.quickswap-col {
-		flex: 3;
-		min-width: 0;
-	}
-
-	.market-rc-stack {
-		flex: 2;
-		min-width: 0;
-		display: flex;
-		flex-direction: column;
-		gap: 16px;
-	}
-
-	/* Row 3 — Transactions (always last) */
-	.transactions-section {
-		min-width: 0;
 	}
 
 	.card {
@@ -138,6 +87,8 @@
 
 	.transactions-card {
 		overflow: hidden;
+		height: 100%;
+		box-sizing: border-box;
 	}
 
 	.card-header {
@@ -178,31 +129,136 @@
 		opacity: 0.6;
 	}
 
-	/* 1-column: widgets stack — QuickSwap first (3rd widget), then MarketPrices + RC */
-	@media (max-width: 1440px) {
-		.widgets-row {
+	/* ── Areas that stack children vertically ────────────────────────────── */
+
+	.area-portfolio,
+	.area-rc-market {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+	}
+
+	/* ── Default: 1 column (< 1024px) ───────────────────────────────────── */
+	/*  DOM order already matches desired visual order:
+	    balance → portfolio/staking → rc+market → quickswap → transactions  */
+
+	.dashboard-wrapper {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+		width: 100%;
+		padding-bottom: 2rem;
+	}
+
+	/* ── 2-column layout (1024px – 1919px) ──────────────────────────────── */
+	/*  Row 1: balance | portfolio+staking
+	    Row 2: rc+market | quickswap
+	    Row 3: transactions (full width)                                      */
+
+	@media (min-width: 1024px) and (max-width: 1919px) {
+		.dashboard-wrapper {
+			display: grid;
+			grid-template-columns: 1fr 1fr;
+			grid-template-areas:
+				'balance   portfolio'
+				'rc-mkt    quickswap'
+				'txs       txs';
+			align-items: start;
+		}
+
+		.area-balance {
+			grid-area: balance;
+			align-self: stretch;
+			display: flex;
 			flex-direction: column;
 		}
-		.quickswap-col,
-		.market-rc-stack {
-			flex: none;
-			width: 100%;
+		/* Make the Balance component fill the stretched area */
+		.area-balance > :global(*) {
+			flex: 1;
 		}
-		.market-rc-stack {
-			flex-direction: row;
-			flex-wrap: wrap;
-			& > :global(*) {
-				flex: 1 1 280px;
-			}
+		.area-portfolio { grid-area: portfolio; }
+		.area-rc-market {
+			grid-area: rc-mkt;
+			align-self: stretch;
+		}
+		/* Both cards grow equally to fill remaining height */
+		.area-rc-market > :global(*) {
+			flex: 1;
+		}
+		.area-quickswap {
+			grid-area: quickswap;
+			height: 755px;
+			overflow: hidden;
+		}
+		.area-transactions {
+			grid-area: txs;
+			max-height: 755px;
+			display: flex;
+			flex-direction: column;
+		}
+		.area-transactions .transactions-card {
+			flex: 1;
+			display: flex;
+			flex-direction: column;
+			overflow: hidden;
+		}
+		.area-transactions .table-body {
+			flex: 1;
+			overflow-y: auto;
+			min-height: 0;
 		}
 	}
 
-	/* top-row also collapses to single column at this point */
-	@media (max-width: 1100px) {
-		.top-row {
-			grid-template-columns: 1fr;
+	/* ── 3-column layout (≥ 1920px) ─────────────────────────────────────── */
+	/*  5-column grid (each unit = 1/5):
+	    Row 1: balance(2) | portfolio+staking(2) | rc+market(1)
+	    Row 2: quickswap(2) | transactions(3) — same height, table scrollable */
+
+	@media (min-width: 1920px) {
+		.dashboard-wrapper {
+			display: grid;
+			grid-template-columns: repeat(5, 1fr);
+			grid-template-areas:
+				'balance   balance   portfolio  portfolio  rc-mkt'
+				'quickswap quickswap txs        txs        txs';
+			/* row 1 items sit at their natural height */
+			align-items: start;
+		}
+
+		.area-balance { grid-area: balance; }
+		.area-portfolio { grid-area: portfolio; }
+		.area-rc-market { grid-area: rc-mkt; }
+
+		/* quickswap: fixed height prevents layout shifts when swap details
+		   appear/disappear. This also defines the row track height so
+		   the transactions card stretches to exactly the same size. */
+		.area-quickswap {
+			grid-area: quickswap;
+			align-self: start;
+			height: 755px;
+			overflow: hidden;
+		}
+		.area-transactions {
+			grid-area: txs;
+			align-self: start;
+			max-height: 755px;
+			display: flex;
+			flex-direction: column;
+		}
+		.area-transactions .transactions-card {
+			flex: 1;
+			display: flex;
+			flex-direction: column;
+			overflow: hidden;
+		}
+		.area-transactions .table-body {
+			flex: 1;
+			overflow-y: auto;
+			min-height: 0;
 		}
 	}
+
+	/* ── Mobile tweaks (≤ 600px) ─────────────────────────────────────────── */
 
 	@media (max-width: 600px) {
 		.dashboard-wrapper {
@@ -211,9 +267,6 @@
 		.card {
 			padding: 1rem;
 			border-radius: 20px;
-		}
-		.market-rc-stack {
-			gap: 12px;
 		}
 	}
 </style>

--- a/src/routes/(authed)/+page.svelte
+++ b/src/routes/(authed)/+page.svelte
@@ -22,42 +22,43 @@
 </document:head>
 
 <div class="dashboard-wrapper">
-	<!-- Main dashboard (left) -->
-	<div class="dashboard-main">
-		<!-- Top row: Balance + Portfolio/Staking -->
-		<div class="top-row">
-			<div class="balance-col">
-				<Balance />
-			</div>
-			<div class="right-col">
-				<PortfolioValue />
-				<StakingEarnings onStake={() => toggleStake(true)} />
-			</div>
+	<!-- Row 1: Balance + Portfolio/Staking -->
+	<div class="top-row">
+		<div class="balance-col">
+			<Balance />
 		</div>
-
-		<!-- Bottom row: Transactions -->
-		<div class="transactions-section">
-			<div class="card transactions-card">
-				<div class="card-header">
-					<h4>Transaction</h4>
-					<button class="filter-btn" onclick={() => goto('/transactions')}>
-						All <span class="dropdown-arrow">&#9662;</span>
-					</button>
-				</div>
-				{#if auth.value}
-					<Table did={auth.value.did} allowPopup={false} limit={10} size="small" />
-				{/if}
-			</div>
+		<div class="right-col">
+			<PortfolioValue />
+			<StakingEarnings onStake={() => toggleStake(true)} />
 		</div>
 	</div>
 
-	<!-- Right panel -->
-	<div class="dashboard-right">
-		<MarketPrices />
-		<QuickSwap />
-		{#if auth.value}
-			<ResourceCredits {username} />
-		{/if}
+	<!-- Row 2: Cross-chain swap | Market prices + RC -->
+	<div class="widgets-row">
+		<div class="quickswap-col">
+			<QuickSwap />
+		</div>
+		<div class="market-rc-stack">
+			<MarketPrices />
+			{#if auth.value}
+				<ResourceCredits {username} />
+			{/if}
+		</div>
+	</div>
+
+	<!-- Row 3: Transactions — always last -->
+	<div class="transactions-section">
+		<div class="card transactions-card">
+			<div class="card-header">
+				<h4>Transaction</h4>
+				<button class="filter-btn" onclick={() => goto('/transactions')}>
+					All <span class="dropdown-arrow">&#9662;</span>
+				</button>
+			</div>
+			{#if auth.value}
+				<Table did={auth.value.did} allowPopup={false} limit={10} size="small" />
+			{/if}
+		</div>
 	</div>
 </div>
 
@@ -68,10 +69,10 @@
 <style lang="scss">
 	.dashboard-wrapper {
 		display: flex;
+		flex-direction: column;
 		gap: 16px;
 		width: 100%;
 		padding-bottom: 2rem;
-		align-items: flex-start;
 		:global(.dashboard-card),
 		:global(.card) {
 			border-color: rgba(255, 255, 255, 0.12) !important;
@@ -79,33 +80,10 @@
 			&:hover {
 				transform: translateY(-1px);
 			}
-			// :global(.light-theme) {
-			// 	border-color: var(--dash-card-border) !important;
-			// }
 		}
 	}
 
-	/* Main area — locked to SVG proportions */
-	.dashboard-main {
-		flex: 0 0 auto;
-		width: min(1100px, 65%);
-		min-width: 0;
-		display: flex;
-		flex-direction: column;
-		gap: 16px;
-	}
-
-	/* Right panel — fills ALL remaining space */
-	.dashboard-right {
-		flex: 1 1 0;
-		min-width: 280px;
-		display: flex;
-		flex-direction: column;
-		gap: 16px;
-		position: sticky;
-		top: 1rem;
-	}
-
+	/* Row 1 — Balance (left) + Portfolio/Staking (right) */
 	.top-row {
 		display: grid;
 		grid-template-columns: 37fr 63fr;
@@ -124,6 +102,28 @@
 		min-width: 0;
 	}
 
+	/* Row 2 — QuickSwap (left) | MarketPrices + RC stacked (right) */
+	.widgets-row {
+		display: flex;
+		flex-direction: row;
+		gap: 16px;
+		align-items: flex-start;
+	}
+
+	.quickswap-col {
+		flex: 3;
+		min-width: 0;
+	}
+
+	.market-rc-stack {
+		flex: 2;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+	}
+
+	/* Row 3 — Transactions (always last) */
 	.transactions-section {
 		min-width: 0;
 	}
@@ -178,24 +178,26 @@
 		opacity: 0.6;
 	}
 
+	/* 1-column: widgets stack — QuickSwap first (3rd widget), then MarketPrices + RC */
 	@media (max-width: 1440px) {
-		.dashboard-wrapper {
+		.widgets-row {
 			flex-direction: column;
 		}
-		.dashboard-main {
+		.quickswap-col,
+		.market-rc-stack {
+			flex: none;
 			width: 100%;
 		}
-		.dashboard-right {
-			width: 100%;
-			position: static;
+		.market-rc-stack {
 			flex-direction: row;
 			flex-wrap: wrap;
-		}
-		.dashboard-right > :global(*) {
-			flex: 1 1 280px;
+			& > :global(*) {
+				flex: 1 1 280px;
+			}
 		}
 	}
 
+	/* top-row also collapses to single column at this point */
 	@media (max-width: 1100px) {
 		.top-row {
 			grid-template-columns: 1fr;
@@ -206,15 +208,12 @@
 		.dashboard-wrapper {
 			gap: 12px;
 		}
-		.dashboard-main {
-			gap: 12px;
-		}
-		.dashboard-right {
-			gap: 12px;
-		}
 		.card {
 			padding: 1rem;
 			border-radius: 20px;
+		}
+		.market-rc-stack {
+			gap: 12px;
 		}
 	}
 </style>

--- a/src/routes/(authed)/swap/+page.svelte
+++ b/src/routes/(authed)/swap/+page.svelte
@@ -36,7 +36,7 @@
 {/snippet}
 
 {#snippet poolsContent()}
-	<div class="tab-panel">
+	<div class="tab-panel pools-tab-panel">
 		<PoolsContent />
 	</div>
 {/snippet}
@@ -108,6 +108,13 @@
 		flex-direction: column;
 		height: 100%;
 		min-height: 0;
+	}
+
+	/* Pools tab: let the table size to its content instead of
+	   stretching to fill the full tab panel height. The tab's
+	   overflow:auto container provides scrolling when needed. */
+	.pools-tab-panel {
+		height: auto;
 	}
 
 	.send-internal-wrapper {

--- a/src/routes/(authed)/transactions/+page.svelte
+++ b/src/routes/(authed)/transactions/+page.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
-	import { getAccountNameFromAuth, getAccountNameFromDid } from '$lib/getAccountName';
+	import { getAccountNameFromDid } from '$lib/getAccountName';
 	import { page } from '$app/state';
 	import Table from './Table/Table.svelte';
 	import { getAuth } from '$lib/auth/store';
 	import { goto } from '$app/navigation';
-	import BasicCopy from '$lib/components/BasicCopy.svelte';
 	let auth = $derived(getAuth()());
 	let did = $derived(auth.value?.did);
-	// let did = 'hive:techcoderx';
 	const autoOpenOp: [string, number] | undefined = $derived.by(() => {
 		const autoOpenTxId = page.url.searchParams.get('tx');
 		const autoOpenIndex = Number(page.url.searchParams.get('index'));

--- a/src/routes/(authed)/transactions/+page.svelte
+++ b/src/routes/(authed)/transactions/+page.svelte
@@ -46,6 +46,9 @@
 	.flex {
 		display: flex;
 		flex-direction: column;
-		height: calc(100vh - 6.5rem);
+		/* No fixed height — table sizes to its content so there's no blank
+		   space when only a few transactions are loaded. The page scrolls
+		   naturally for larger transaction sets. */
+		/* height: calc(100vh - 6.5rem); */
 	}
 </style>

--- a/src/routes/(authed)/transactions/Table/StatusBadge.svelte
+++ b/src/routes/(authed)/transactions/Table/StatusBadge.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	let { status: rawStatus }: { status: string } = $props();
+	let { status: rawStatus, compact = false }: { status: string; compact?: boolean } = $props();
 	const status = $derived.by(() => {
 		if (rawStatus == 'INCLUDED') {
 			return 'unconfirmed';
@@ -12,7 +12,8 @@
 	class={{
 		secondary: status == 'failed',
 		primary: status == 'confirmed',
-		neutral: !['failed', 'confirmed'].includes(status)
+		neutral: !['failed', 'confirmed'].includes(status),
+		compact
 	}}>{status}</span
 >
 
@@ -26,5 +27,11 @@
 		display: inline-flex;
 		height: 1.25rem;
 		align-items: center;
+	}
+	span.compact {
+		font-size: 0.7rem;
+		padding: 0.1rem 0.35rem;
+		height: auto;
+		border-radius: 0.35rem;
 	}
 </style>

--- a/src/routes/(authed)/transactions/Table/Table.svelte
+++ b/src/routes/(authed)/transactions/Table/Table.svelte
@@ -295,6 +295,7 @@
 	.card {
 		display: flex;
 		flex-direction: column;
+		box-sizing: border-box;
 		width: 100%;
 		flex-grow: 1;
 		min-height: 0;
@@ -303,7 +304,7 @@
 		border: 1px solid var(--dash-card-border);
 		border-radius: 27px;
 		box-shadow: var(--dash-card-shadow);
-		padding: 1.25rem;
+		padding: 1rem;
 		font-family: 'Nunito Sans', sans-serif;
 		/* overflow: clip preserves the border-radius visual clipping without
 		   blocking the child .table-scroll from showing its horizontal scrollbar. */
@@ -467,4 +468,5 @@
 			display: none;
 		}
 	}
+
 </style>

--- a/src/routes/(authed)/transactions/Table/tr/BtcMappingTr.svelte
+++ b/src/routes/(authed)/transactions/Table/tr/BtcMappingTr.svelte
@@ -24,6 +24,7 @@
 		type BtcMappingAction
 	} from '$lib/indexer/btcMappingQueries';
 	import { BTC_MAPPING_CONTRACT_ID, getVscExplorerTxUrl, getMemPoolTxUrl } from '$lib/constants';
+	import PopupTitleRow from './PopupTitleRow.svelte';
 
 	type Props = {
 		tx: TransactionInter;
@@ -59,6 +60,15 @@
 			displayType: formatOpType(op.type ?? tx.type),
 			direction: 'contract' as const
 		};
+	});
+
+	const popupTitle = $derived.by(() => {
+		if (contractInfo.action === 'unmap') return 'Withdrawal';
+		if (contractInfo.action === 'transfer') return 'Transfer';
+		if (contractInfo.action === 'transferFrom') return 'Transfer From';
+		return (op.type ?? tx.type)
+			.replace('_', ' ')
+			.replace(/\w\S*/g, (text) => text.charAt(0).toUpperCase() + text.substring(1).toLowerCase());
 	});
 
 	// Fallback payload parsed from op.data — used while the indexer query is in flight
@@ -172,29 +182,16 @@
 </script>
 
 {#snippet contractRowContent()}
-	<span>
-		{#if contractInfo.action === 'unmap'}
-			<h2>Withdrawal</h2>
-		{:else if contractInfo.action === 'transfer'}
-			<h2>Transfer</h2>
-		{:else if contractInfo.action === 'transferFrom'}
-			<h2>Transfer From</h2>
-		{:else}
-			<h2>
-				{(op.type ?? tx.type)
-					.replace('_', ' ')
-					.replace(
-						/\w\S*/g,
-						(text) => text.charAt(0).toUpperCase() + text.substring(1).toLowerCase()
-					)}
-			</h2>
-		{/if}
-	</span>
+	<PopupTitleRow title={popupTitle} status={tx.status} />
+	<p class="popup-subtitle">
+		{moment(getTimestamp(tx)).format('MMM DD, YYYY [at] H:mm')}
+		{#if fromAccount} · {fromAccount} → {toAccount}{/if}
+	</p>
 	<div class="sections">
 		{#if !loaded}
 			<p>Loading details...</p>
 		{:else}
-			<div class="amount section">
+			<div class="amount">
 				{#if indexerEvent?.action === 'unmap'}
 					{satsToBtc(Number(indexerEvent.event.deducted))} BTC
 				{:else if indexerEvent?.action === 'transfer' || indexerEvent?.action === 'transferFrom'}
@@ -262,7 +259,7 @@
 				</div>
 			</div>
 
-			<div class="section">
+			<div class="tx-id section">
 				<h3>Transaction Id</h3>
 				<div class="copyable-text">
 					<BasicCopy value={tx.id} />
@@ -306,19 +303,22 @@
 		transition: background-color 1s;
 		animation: highlight-in 1s both;
 	}
-	h2 {
-		margin-top: 0 !important;
+	.popup-subtitle {
+		margin: 0;
+		font-size: 0.8rem;
+		color: var(--dash-text-muted);
 	}
+
 	.amount {
 		font-size: var(--text-4xl);
-		margin: 1rem 0;
+		margin: 0;
 	}
 	.approx-usd {
 		display: block;
 		text-wrap: wrap;
 		color: var(--dash-text-muted);
 		font-size: var(--text-sm);
-		margin-top: 0.5rem;
+		margin-top: 0.25rem;
 	}
 	.date {
 		color: var(--dash-text-secondary);
@@ -350,11 +350,16 @@
 		flex-direction: column;
 		flex: 1;
 		gap: 0.5rem;
+		margin-top: 0.75rem;
+	}
+
+	.tx-id.section {
+		margin-top: 0.75rem;
 	}
 
 	.links {
 		display: flex;
-		flex-wrap: wrap;
+		flex-direction: column;
 		gap: 0.5rem;
 	}
 

--- a/src/routes/(authed)/transactions/Table/tr/ContractTr.svelte
+++ b/src/routes/(authed)/transactions/Table/tr/ContractTr.svelte
@@ -15,6 +15,7 @@
 	import { Coin, Network } from '$lib/sendswap/utils/sendOptions';
 	import ContractId from '../tds/ContractId.svelte';
 	import PopupTitleRow from './PopupTitleRow.svelte';
+	import { hasuraQuery } from '$lib/indexer/query';
 
 	type Props = {
 		tx: TransactionInter;
@@ -38,6 +39,8 @@
 	//   New router (Altera):  { type:"swap", asset_in, asset_out, amount_in, min_amount_out }
 	//   Old pool (legacy):    { type:"deposit", asset0, asset1, amount0, amount1 }
 	// Both are normalised to { asset0, amount0, asset1, amount1 } for display.
+	// isNewRouter flags the Altera format so we know to fetch the real amount_out from the
+	// indexer after confirmation (the payload only carries the slippage floor, not the actual fill).
 	const swapPayload = $derived.by(() => {
 		try {
 			const parsed = JSON.parse(op.data.payload ?? '');
@@ -52,19 +55,44 @@
 					asset0: String(parsed.asset_in).toLowerCase(),
 					amount0: String(parsed.amount_in),
 					asset1: String(parsed.asset_out).toLowerCase(),
-					// min_amount_out is a floor; fall back to '0' if absent
-					amount1: String(parsed.min_amount_out ?? '0')
+					// min_amount_out is a floor used while pending; replaced by actual fill once confirmed
+					amount1: String(parsed.min_amount_out ?? '0'),
+					isNewRouter: true
 				};
 			}
-			// Old pool format
+			// Old pool format — amount1 is the actual received value, no indexer lookup needed
 			if (parsed?.asset0 && parsed?.asset1 && parsed?.amount0 != null && parsed?.amount1 != null) {
-				return parsed as { asset0: string; amount0: string; asset1: string; amount1: string };
+				return { ...parsed, isNewRouter: false } as {
+					asset0: string; amount0: string; asset1: string; amount1: string; isNewRouter: false
+				};
 			}
 		} catch {}
 		return null;
 	});
 
 	const isSwap = $derived(op.data.action === 'execute' && swapPayload !== null);
+
+	// For confirmed new-router swaps, fetch the actual settled amount_out from the indexer.
+	// The payload only carries min_amount_out (the slippage floor), which is almost always
+	// lower than what the pool actually returned.
+	let indexerAmountOut = $state.raw<{ amount_out: number; asset_out: string } | null>(null);
+	let lastFetchedTxId = '';
+	$effect(() => {
+		if (!isSwap || !swapPayload?.isNewRouter || tx.isPending || tx.id === lastFetchedTxId) return;
+		lastFetchedTxId = tx.id;
+		hasuraQuery<{ dex_pool_swap_events: Array<{ amount_out: number; asset_out: string }> }>(
+			`query GetSwapActualOutput($txHash: String!) {
+				dex_pool_swap_events(where: {indexer_tx_hash: {_eq: $txHash}}, limit: 1) {
+					amount_out
+					asset_out
+				}
+			}`,
+			{ txHash: tx.id }
+		).then((data) => {
+			const event = data?.dex_pool_swap_events?.[0];
+			if (event) indexerAmountOut = event;
+		});
+	});
 
 	// For swaps: fromAmount = what user sends (asset0), amount = what user receives (asset1).
 	// For other contract calls: amount comes from intents limit.
@@ -79,6 +107,14 @@
 	);
 	const amount = $derived.by(() => {
 		if (isSwap && swapPayload) {
+			// Confirmed new-router swap: prefer actual fill from indexer over the min floor
+			if (indexerAmountOut && !tx.isPending) {
+				return new CoinAmount(
+					indexerAmountOut.amount_out,
+					Coin[indexerAmountOut.asset_out.split('_')[0] as keyof typeof Coin] || Coin.unk,
+					true
+				);
+			}
 			return new CoinAmount(
 				swapPayload.amount1,
 				Coin[swapPayload.asset1.split('_')[0] as keyof typeof Coin] || Coin.unk,

--- a/src/routes/(authed)/transactions/Table/tr/ContractTr.svelte
+++ b/src/routes/(authed)/transactions/Table/tr/ContractTr.svelte
@@ -14,6 +14,7 @@
 	import { CoinAmount } from '$lib/currency/CoinAmount';
 	import { Coin, Network } from '$lib/sendswap/utils/sendOptions';
 	import ContractId from '../tds/ContractId.svelte';
+	import PopupTitleRow from './PopupTitleRow.svelte';
 
 	type Props = {
 		tx: TransactionInter;
@@ -108,6 +109,12 @@
 		} catch {}
 		return op.data.action ?? op.type ?? 'call';
 	});
+
+	const popupTitle = $derived(
+		displayType
+			.replace(/_/g, ' ')
+			.replace(/\w\S*/g, (text) => text.charAt(0).toUpperCase() + text.substring(1).toLowerCase())
+	);
 </script>
 
 <tr
@@ -125,18 +132,16 @@
 </tr>
 
 {#snippet contractRowContent()}
-	<h2>
-		{displayType
-			.replace(/_/g, ' ')
-			.replace(/\w\S*/g, (text) => text.charAt(0).toUpperCase() + text.substring(1).toLowerCase())}
-	</h2>
+	<PopupTitleRow title={popupTitle} status={tx.status} />
+	<p class="popup-subtitle">
+		{moment(getTimestamp(tx)).format('MMM DD, YYYY [at] H:mm')}
+		{#if op.data.from} · {op.data.from}{/if}
+	</p>
 	<div class="sections">
-		<div class="amount section">
+		<div class="amount">
 			{#if isSwap && fromAmount}
-				<h3>Swap</h3>
 				{fromAmount.toPrettyString()} → {amount.toPrettyString()}
 			{:else}
-				<h3>Limit</h3>
 				{amount.toPrettyString()}
 			{/if}
 			<span class="approx-usd">
@@ -165,19 +170,21 @@
 		transition: background-color 1s;
 		animation: highlight-in 1s both;
 	}
-	h2 {
-		margin-top: 0 !important;
+	.popup-subtitle {
+		margin: 0;
+		font-size: 0.8rem;
+		color: var(--dash-text-muted);
 	}
 	.amount {
 		font-size: var(--text-4xl);
-		margin: 1rem 0;
+		margin: 0;
 	}
 	.approx-usd {
 		display: block;
 		text-wrap: wrap;
 		color: var(--dash-text-muted);
 		font-size: var(--text-sm);
-		margin-top: 0.5rem;
+		margin-top: 0.25rem;
 	}
 	.date {
 		color: var(--dash-text-secondary);
@@ -210,11 +217,12 @@
 		/* align-items: stretch; */
 		flex: 1;
 		gap: 0.5rem;
+		margin-top: 0.75rem;
 	}
 
 	.links {
 		display: flex;
-		flex-wrap: wrap;
+		flex-direction: column;
 		gap: 0.5rem;
 	}
 
@@ -223,6 +231,6 @@
 	}
 
 	.tx-id.section {
-		margin-top: auto;
+		margin-top: 0.75rem;
 	}
 </style>

--- a/src/routes/(authed)/transactions/Table/tr/PopupTitleRow.svelte
+++ b/src/routes/(authed)/transactions/Table/tr/PopupTitleRow.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import StatusBadge from '../StatusBadge.svelte';
+
+	type Props = { title: string; status: string };
+	let { title, status }: Props = $props();
+</script>
+
+<div class="popup-title-row">
+	<h2>{title}</h2>
+	<StatusBadge {status} compact />
+</div>
+
+<style>
+	.popup-title-row {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+	}
+	h2 {
+		margin: 0;
+	}
+</style>

--- a/src/routes/(authed)/transactions/Table/tr/StatusView.svelte
+++ b/src/routes/(authed)/transactions/Table/tr/StatusView.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { getAccountNameFromDid } from '$lib/getAccountName';
 	import moment from 'moment';
-	import StatusBadge from '../StatusBadge.svelte';
 	type Props = {
 		from: string;
 		to: string;
@@ -40,11 +39,6 @@
 			To
 			{getAccountNameFromDid(to)}
 		</span>
-		{#if status && status != 'CONFIRMED'}
-			<span class="msg">
-				<StatusBadge {status} />
-			</span>
-		{/if}
 		<div class="to-ts ts msg">
 			{moment(anchor_ts).format('MMM DD [at] H:mm')}
 			{#if block_height != 0}

--- a/src/routes/(authed)/transactions/Table/tr/Tr.svelte
+++ b/src/routes/(authed)/transactions/Table/tr/Tr.svelte
@@ -21,6 +21,8 @@
 	import { addNotification, type Notification } from '$lib/Topbar/notifications';
 	import { getHiveAssetName, getHbdAssetName } from '../../../../../client';
 	import { numberFormatLanguage } from '$lib/constants';
+	import { getAccountNameFromDid } from '$lib/getAccountName';
+	import PopupTitleRow from './PopupTitleRow.svelte';
 
 	type Props = {
 		tx: TransactionInter;
@@ -205,9 +207,20 @@
 </tr>
 
 {#snippet thisRowContent()}
-	<h2>
-		{formatOpType(t)}
-	</h2>
+	<PopupTitleRow title={formatOpType(t)} status={tx.status} />
+	<p class="popup-subtitle">
+		{moment(timestamp).format('MMM DD, YYYY [at] H:mm')}
+		{#if otherAccount}
+			·
+			{#if direction === 'incoming'}
+				Received from {getAccountNameFromDid(otherAccount)}
+			{:else if direction === 'outgoing'}
+				Sent to {getAccountNameFromDid(otherAccount)}
+			{:else}
+				{getAccountNameFromDid(otherAccount)}
+			{/if}
+		{/if}
+	</p>
 	<div class="amount">
 		{prettyWithDisplayUnit(amount)}
 		<span class="approx-usd">
@@ -264,14 +277,14 @@
 
 	.amount {
 		font-size: var(--text-4xl);
-		margin: 1rem 0;
+		margin: 0.75rem 0 0;
 	}
 	.approx-usd {
 		display: block;
 		text-wrap: wrap;
 		color: var(--dash-text-muted);
 		font-size: var(--text-sm);
-		margin-top: 0.5rem;
+		margin-top: 0.25rem;
 	}
 	a {
 		display: inline-flex;
@@ -282,8 +295,10 @@
 		width: 16px;
 	}
 
-	h2 {
-		margin-top: 0 !important;
+	.popup-subtitle {
+		margin: 0;
+		font-size: 0.8rem;
+		color: var(--dash-text-muted);
 	}
 
 	.section h3 {
@@ -324,7 +339,7 @@
 
 	.links {
 		display: flex;
-		flex-wrap: wrap;
+		flex-direction: column;
 		gap: 0.5rem;
 	}
 
@@ -333,7 +348,7 @@
 	}
 
 	.tx-id.section {
-		margin-top: auto;
+		margin-top: 0.75rem;
 	}
 
 	.links-disabled a {


### PR DESCRIPTION
## Summary

**Transaction popup** — replaced the side panel with a portal-teleported centered modal; content-sized height capped at `calc(100dvh - 4rem)` with internal scroll on overflow. Consistent header across all transaction types. Extracted `PopupTitleRow` to eliminate markup duplication. External links stacked vertically, trailing · separator guarded.

**Dashboard layout** — responsive CSS grid at 3 breakpoints: single column (<1024px), 2-col (1024–1919px), 3-col/5-unit grid (≥1920px). Transactions widget always last. QuickSwap locked at 755px with Swap button pinned at bottom.

**Swap amount fix** — contract rows were showing `min_amount_out` (slippage floor) instead of the actual settled amount. Confirmed new-router swaps now fetch the real `amount_out` from the Hasura indexer, matching what the pools Recent Swaps table shows.

**Pools fix** — restores Add/Remove Liquidity buttons broken by a strict context guard.

**Asset modal** — closes automatically on any token selection.

**Sats display** — removed trailing dot from zero-decimal amounts (e.g. `1,234 SATS` not `1,234. SATS`).

**Dialog close button** — repositioned for better alignment.