### PR TITLE
Dashboard redesign, swap fixes, EVM balance fix, and routing improvements

### DIFF
--- a/src/lib/AccBalance.svelte
+++ b/src/lib/AccBalance.svelte
@@ -48,10 +48,6 @@
 </script>
 
 <div class="balances-list">
-	<div class="balances-header">
-		<span class="balances-title">Balances</span>
-	</div>
-
 	<div class="balance-row">
 		<div class="row-icon hbd"><img src={Coin.hbd.icon} alt="" /></div>
 		<div class="row-info">

--- a/src/lib/auth/reown/index.ts
+++ b/src/lib/auth/reown/index.ts
@@ -82,7 +82,7 @@ export function initModal() {
 										? BTC_TESTNET_CAIP
 										: BTC_MAINNET_CAIP
 								}:${value.address!}`
-							: `did:pkh:eip155:1:${value.address!}`,
+							: `did:pkh:eip155:1:${value.address!.toLowerCase()}`,
 						openSettings: () => modal!.open()
 					}
 				});

--- a/src/lib/cards/Balance/Balance.svelte
+++ b/src/lib/cards/Balance/Balance.svelte
@@ -84,6 +84,7 @@
 		</div>
 
 		{#if did}
+			<span class="balances-title">Balances</span>
 			<div class="balances-section">
 				<AccBalance {did} />
 			</div>
@@ -205,11 +206,20 @@
 		box-shadow: 0 0 16px -4px rgba(111, 106, 248, 0.2);
 	}
 
+	.balances-title {
+		display: block;
+		font-size: 0.85rem;
+		font-weight: 600;
+		color: var(--dash-text-primary);
+		margin-bottom: 0.625rem;
+		flex-shrink: 0;
+	}
+
 	.balances-section {
 		flex: 1;
 		min-height: 0;
-		overflow: auto;
-		margin-top: 0.25rem;
+		overflow-y: auto;
+		padding-bottom: 0.5rem;
 	}
 
 	@media (max-width: 480px) {

--- a/src/lib/cards/MarketPrices.svelte
+++ b/src/lib/cards/MarketPrices.svelte
@@ -55,7 +55,9 @@
 				getCryptoPrices(),
 				fetch(
 					'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd&include_24hr_change=true'
-				).then((r) => r.json())
+				)
+					.then((r) => r.json())
+					.catch(() => null)
 			]);
 
 			const ethPrice: number = ethRes?.ethereum?.usd ?? 0;

--- a/src/lib/cards/MarketPrices.svelte
+++ b/src/lib/cards/MarketPrices.svelte
@@ -10,6 +10,7 @@
 		price: string;
 		change: string;
 		changePositive: boolean;
+		comingSoon?: boolean;
 	};
 
 	let items: MarketItem[] = $state([
@@ -36,12 +37,30 @@
 			price: '--',
 			change: '--',
 			changePositive: true
+		},
+		{
+			symbol: 'Ξ',
+			name: 'Ethereum',
+			icon: '/eth/eth.svg',
+			price: '--',
+			change: '--',
+			changePositive: true,
+			comingSoon: true
 		}
 	]);
 
 	async function fetchPrices() {
 		try {
-			const prices = await getCryptoPrices();
+			const [prices, ethRes] = await Promise.all([
+				getCryptoPrices(),
+				fetch(
+					'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd&include_24hr_change=true'
+				).then((r) => r.json())
+			]);
+
+			const ethPrice: number = ethRes?.ethereum?.usd ?? 0;
+			const ethChange: number = ethRes?.ethereum?.usd_24h_change ?? 0;
+
 			items = [
 				{
 					symbol: 'B',
@@ -66,6 +85,15 @@
 					price: `$${prices.hive_dollar.usd.toFixed(2)}`,
 					change: `0.1%`,
 					changePositive: false
+				},
+				{
+					symbol: 'Ξ',
+					name: 'Ethereum',
+					icon: '/eth/eth.svg',
+					price: ethPrice ? `$${ethPrice.toLocaleString(undefined, { maximumFractionDigits: 1 })}` : '--',
+					change: ethChange ? `${ethChange.toFixed(1)}%` : '--',
+					changePositive: ethChange >= 0,
+					comingSoon: true
 				}
 			];
 		} catch (e) {
@@ -84,7 +112,7 @@
 	<h4 class="section-title">Market Prices</h4>
 	<div class="price-list">
 		{#each items as item}
-			<div class="price-item">
+			<div class={['price-item', { 'coming-soon': item.comingSoon }]}>
 				<div class="coin-info">
 					<span class="coin-badge">
 						{#if item.icon}
@@ -94,9 +122,20 @@
 						{/if}
 					</span>
 					<div class="coin-details">
-						<span class="coin-symbol"
-							>{item.name === 'Bitcoin' ? 'BTC' : item.name === 'Hive' ? 'HIVE' : 'HBD'}</span
-						>
+						<div class="coin-symbol-row">
+							<span class="coin-symbol">
+								{item.name === 'Bitcoin'
+									? 'BTC'
+									: item.name === 'Hive'
+										? 'HIVE'
+										: item.name === 'Hive Dollar'
+											? 'HBD'
+											: 'ETH'}
+							</span>
+							{#if item.comingSoon}
+								<span class="soon-pill">Soon</span>
+							{/if}
+						</div>
 						<span class="coin-name">{item.name}</span>
 					</div>
 				</div>
@@ -201,5 +240,25 @@
 	}
 	.change.negative {
 		color: var(--dash-accent-red);
+	}
+	.coin-symbol-row {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+	}
+	.soon-pill {
+		font-size: 0.6rem;
+		font-weight: 600;
+		letter-spacing: 0.03em;
+		color: var(--dash-text-muted);
+		border: 1px solid var(--dash-card-border);
+		border-radius: 4px;
+		padding: 0.05rem 0.3rem;
+		line-height: 1.4;
+		opacity: 0.8;
+	}
+	.coming-soon {
+		opacity: 0.4;
+		pointer-events: none;
 	}
 </style>

--- a/src/lib/getAccountName.ts
+++ b/src/lib/getAccountName.ts
@@ -54,7 +54,7 @@ export const getDidFromUsername = (username: string) => {
 		return `hive:${username}`;
 	}
 	if (username.startsWith('0x')) {
-		return `did:pkh:eip155:1:${username}`;
+		return `did:pkh:eip155:1:${username.toLowerCase()}`;
 	}
 	// Strip chain hash prefix if present (e.g. "000...e93:bc1q...")
 	const rawAddr = username.includes(':') ? username.split(':').at(-1)! : username;

--- a/src/lib/pools/PoolDetail.svelte
+++ b/src/lib/pools/PoolDetail.svelte
@@ -9,6 +9,9 @@
 	import AddLiquidityPopup from './AddLiquidityPopup.svelte';
 	import RemoveLiquidityPopup from './RemoveLiquidityPopup.svelte';
 	import { untrack } from 'svelte';
+	import SidePopup from '$lib/components/SidePopup.svelte';
+	import { ExternalLink } from '@lucide/svelte';
+	import { getVscExplorerTxUrl } from '$lib/constants';
 
 	let {
 		pool,
@@ -221,6 +224,23 @@
 		const display = addr.startsWith('hive:') ? addr.slice(5) : addr;
 		return display.length > 14 ? `${display.slice(0, 6)}...${display.slice(-4)}` : display;
 	}
+
+	type PoolEvent =
+		| { kind: 'swap'; data: SwapEvent }
+		| { kind: 'add'; data: AddLiqEvent }
+		| { kind: 'remove'; data: RemoveLiqEvent };
+
+	let selectedEvent = $state<PoolEvent | null>(null);
+	let popupOpen = $state(false);
+
+	function openEvent(event: PoolEvent) {
+		selectedEvent = event;
+		popupOpen = true;
+	}
+	function closeEvent() {
+		popupOpen = false;
+		selectedEvent = null;
+	}
 </script>
 
 <div class="pool-detail">
@@ -338,7 +358,7 @@
 				<tbody>
 					{#if swaps.length > 0}
 						{#each swaps as s}
-							<tr class="data-row">
+							<tr class="data-row clickable-row" onclick={() => openEvent({ kind: 'swap', data: s })}>
 								<td class="date-cell">{fmtDate(s.indexer_ts)}</td>
 								<td class="addr-cell">
 									<span class="addr" title={s.recipient}>{shortAddr(s.recipient)}</span>
@@ -347,7 +367,7 @@
 								<td class="token-cell">{s.asset_in?.toUpperCase() ?? '-'}</td>
 								<td class="amount-cell mono">{fmtAmt(s.amount_out, decimalsForAsset(s.asset_out))}</td>
 								<td class="token-cell">{s.asset_out?.toUpperCase() ?? '-'}</td>
-								<td class="tx-cell">
+								<td class="tx-cell" onclick={(e) => e.stopPropagation()}>
 									<Clipboard value={s.indexer_tx_hash} label="" disabled={false} />
 								</td>
 							</tr>
@@ -382,7 +402,7 @@
 				<tbody>
 					{#if adds.length > 0}
 						{#each adds as a}
-							<tr class="data-row">
+							<tr class="data-row clickable-row" onclick={() => openEvent({ kind: 'add', data: a })}>
 								<td class="date-cell">{fmtDate(a.indexer_ts)}</td>
 								<td class="addr-cell">
 									<span class="addr" title={a.provider}>{shortAddr(a.provider)}</span>
@@ -390,7 +410,7 @@
 								<td class="amount-cell mono">{fmtAmt(a.amount0, decimalsForAsset(sym0))}</td>
 								<td class="amount-cell mono">{fmtAmt(a.amount1, decimalsForAsset(sym1))}</td>
 								<td class="amount-cell mono">{fmtAmt(a.lp_minted)}</td>
-								<td class="tx-cell">
+								<td class="tx-cell" onclick={(e) => e.stopPropagation()}>
 									<Clipboard value={a.indexer_tx_hash} label="" disabled={false} />
 								</td>
 							</tr>
@@ -425,7 +445,7 @@
 				<tbody>
 					{#if removes.length > 0}
 						{#each removes as r}
-							<tr class="data-row">
+							<tr class="data-row clickable-row" onclick={() => openEvent({ kind: 'remove', data: r })}>
 								<td class="date-cell">{fmtDate(r.indexer_ts)}</td>
 								<td class="addr-cell">
 									<span class="addr" title={r.provider}>{shortAddr(r.provider)}</span>
@@ -433,7 +453,7 @@
 								<td class="amount-cell mono">{fmtAmt(r.amount0, decimalsForAsset(sym0))} {sym0}</td>
 								<td class="amount-cell mono">{fmtAmt(r.amount1, decimalsForAsset(sym1))} {sym1}</td>
 								<td class="amount-cell mono">{fmtAmt(r.lp_burned)}</td>
-								<td class="tx-cell">
+								<td class="tx-cell" onclick={(e) => e.stopPropagation()}>
 									<Clipboard value={r.indexer_tx_hash} label="" disabled={false} />
 								</td>
 							</tr>
@@ -450,6 +470,94 @@
 		</div>
 	</div>
 {/snippet}
+
+{#snippet poolEventContent()}
+	{#if selectedEvent}
+		{@const e = selectedEvent}
+		{@const txHash = e.data.indexer_tx_hash}
+		<p class="popup-subtitle">{moment(e.data.indexer_ts).format('MMM DD, YYYY [at] H:mm')}</p>
+
+		{#if e.kind === 'swap'}
+			<div class="popup-amounts">
+				<div class="popup-amount-row">
+					<span class="popup-label">Amount In</span>
+					<span class="mono">{fmtAmt(e.data.amount_in, decimalsForAsset(e.data.asset_in))} {e.data.asset_in?.toUpperCase() ?? ''}</span>
+				</div>
+				<div class="popup-amount-row">
+					<span class="popup-label">Amount Out</span>
+					<span class="mono">{fmtAmt(e.data.amount_out, decimalsForAsset(e.data.asset_out))} {e.data.asset_out?.toUpperCase() ?? ''}</span>
+				</div>
+				<div class="popup-amount-row">
+					<span class="popup-label">Recipient</span>
+					<span class="mono addr" title={e.data.recipient}>{shortAddr(e.data.recipient)}</span>
+				</div>
+			</div>
+		{:else if e.kind === 'add'}
+			<div class="popup-amounts">
+				<div class="popup-amount-row">
+					<span class="popup-label">{sym0}</span>
+					<span class="mono">{fmtAmt(e.data.amount0, decimalsForAsset(sym0))}</span>
+				</div>
+				<div class="popup-amount-row">
+					<span class="popup-label">{sym1}</span>
+					<span class="mono">{fmtAmt(e.data.amount1, decimalsForAsset(sym1))}</span>
+				</div>
+				<div class="popup-amount-row">
+					<span class="popup-label">LP Minted</span>
+					<span class="mono">{fmtAmt(e.data.lp_minted)}</span>
+				</div>
+				<div class="popup-amount-row">
+					<span class="popup-label">Provider</span>
+					<span class="mono addr" title={e.data.provider}>{shortAddr(e.data.provider)}</span>
+				</div>
+			</div>
+		{:else}
+			<div class="popup-amounts">
+				<div class="popup-amount-row">
+					<span class="popup-label">{sym0}</span>
+					<span class="mono">{fmtAmt(e.data.amount0, decimalsForAsset(sym0))}</span>
+				</div>
+				<div class="popup-amount-row">
+					<span class="popup-label">{sym1}</span>
+					<span class="mono">{fmtAmt(e.data.amount1, decimalsForAsset(sym1))}</span>
+				</div>
+				<div class="popup-amount-row">
+					<span class="popup-label">LP Burned</span>
+					<span class="mono">{fmtAmt(e.data.lp_burned)}</span>
+				</div>
+				<div class="popup-amount-row">
+					<span class="popup-label">Provider</span>
+					<span class="mono addr" title={e.data.provider}>{shortAddr(e.data.provider)}</span>
+				</div>
+			</div>
+		{/if}
+
+		<div class="popup-section">
+			<h3>Transaction ID</h3>
+			<Clipboard value={txHash} label="" disabled={false} />
+		</div>
+		<div class="popup-section">
+			<h3>External Links</h3>
+			<a href={getVscExplorerTxUrl(txHash)} target="_blank" rel="noreferrer">
+				VSC Block Explorer <ExternalLink size={14} />
+			</a>
+		</div>
+	{/if}
+{/snippet}
+
+{#snippet poolEventTitle()}
+	{#if selectedEvent}
+		{selectedEvent.kind === 'swap' ? 'Swap' : selectedEvent.kind === 'add' ? 'Add Liquidity' : 'Remove Liquidity'}
+	{/if}
+{/snippet}
+
+<SidePopup
+	toggle={closeEvent}
+	content={popupOpen ? poolEventContent : undefined}
+	open={popupOpen}
+>
+	{#snippet title()}{@render poolEventTitle()}{/snippet}
+</SidePopup>
 
 <style lang="scss">
 	.pool-detail {
@@ -599,6 +707,10 @@
 		&:hover {
 			background-color: var(--dash-surface-alt);
 		}
+
+		&.clickable-row {
+			cursor: pointer;
+		}
 	}
 
 	.date-cell {
@@ -694,6 +806,45 @@
 		}
 		50% {
 			opacity: 0.5;
+		}
+	}
+
+	.popup-subtitle {
+		margin: 0 0 1rem;
+		font-size: 0.8rem;
+		color: var(--dash-text-muted);
+	}
+	.popup-amounts {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		margin-bottom: 1rem;
+	}
+	.popup-amount-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		font-size: 0.875rem;
+	}
+	.popup-label {
+		color: var(--dash-text-secondary);
+	}
+	.popup-section {
+		padding: 0.5rem;
+		border-radius: 12px;
+		margin-top: 0.5rem;
+		h3 {
+			font-size: var(--text-sm);
+			font-weight: 600;
+			margin: 0 0 0.4rem;
+			color: var(--dash-text-secondary);
+		}
+		a {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.25rem;
+			font-size: 0.875rem;
+			color: var(--dash-text-primary);
 		}
 	}
 </style>

--- a/src/lib/pools/PoolDetail.svelte
+++ b/src/lib/pools/PoolDetail.svelte
@@ -287,6 +287,18 @@
 		<div class="stat">
 			<span class="stat-label">Fees</span>
 			<span class="stat-value">{pool.feeEarnedUsd}</span>
+			<div class="stat-fee-breakdown">
+				<span class="stat-fee-row">
+					<span class="stat-fee-label">LP</span>
+					<span>{pool.feeEarnedAssets[0]}</span>
+					<span class="stat-fee-usd">{pool.feeEarnedUsdBreakdown[0]}</span>
+				</span>
+				<span class="stat-fee-row">
+					<span class="stat-fee-label">Protocol</span>
+					<span>{pool.feeEarnedAssets[1]}</span>
+					<span class="stat-fee-usd">{pool.feeEarnedUsdBreakdown[1]}</span>
+				</span>
+			</div>
 		</div>
 	</div>
 
@@ -646,6 +658,32 @@
 				font-weight: 600;
 				color: var(--dash-text-primary);
 				font-size: var(--text-sm);
+			}
+
+			.stat-fee-breakdown {
+				display: flex;
+				flex-direction: column;
+				gap: 0.15rem;
+				margin-top: 0.35rem;
+			}
+			.stat-fee-row {
+				display: flex;
+				align-items: baseline;
+				gap: 0.25rem;
+				font-size: var(--text-xs);
+				color: var(--dash-text-muted);
+			}
+			.stat-fee-label {
+				font-size: 0.6rem;
+				font-weight: 700;
+				letter-spacing: 0.04em;
+				text-transform: uppercase;
+				opacity: 0.7;
+				flex-shrink: 0;
+			}
+			.stat-fee-usd {
+				opacity: 0.6;
+				font-size: 0.6rem;
 			}
 		}
 	}

--- a/src/lib/pools/PoolsContent.svelte
+++ b/src/lib/pools/PoolsContent.svelte
@@ -281,8 +281,14 @@
 						<td class="col-fee">
 							<div class="amount-cell">
 								<span class="total">{pool.feeEarnedUsd}</span>
-								<span class="breakdown">{pool.feeEarnedAssets[0]}</span>
-								<span class="breakdown">{pool.feeEarnedAssets[1]}</span>
+								<span class="breakdown fee-row">
+									<span class="fee-label">LP</span>{pool.feeEarnedAssets[0]}
+									<span class="fee-sub">{pool.feeEarnedUsdBreakdown[0]}</span>
+								</span>
+								<span class="breakdown fee-row">
+									<span class="fee-label">Protocol</span>{pool.feeEarnedAssets[1]}
+									<span class="fee-sub">{pool.feeEarnedUsdBreakdown[1]}</span>
+								</span>
 							</div>
 						</td>
 						<td class="col-volume">
@@ -581,6 +587,27 @@
 	.amount-cell .total {
 		color: var(--dash-text-primary);
 		font-weight: 500;
+	}
+
+	.fee-row {
+		display: flex;
+		align-items: baseline;
+		gap: 0.25rem;
+		flex-wrap: wrap;
+	}
+	.fee-label {
+		font-size: 0.6rem;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--dash-text-muted);
+		opacity: 0.7;
+		flex-shrink: 0;
+	}
+	.fee-sub {
+		color: var(--dash-text-muted);
+		font-size: 0.6rem;
+		opacity: 0.6;
 	}
 
 	.placeholder-text {

--- a/src/lib/pools/PoolsContent.svelte
+++ b/src/lib/pools/PoolsContent.svelte
@@ -251,12 +251,12 @@
 									{#if getCoinIcon(pool.pairSymbols[0])}
 										<img class="coin-icon icon-a" src={getCoinIcon(pool.pairSymbols[0])} alt={pool.pairSymbols[0]} />
 									{:else}
-										<span class="icon icon-a"></span>
+										<span class="icon icon-a">{pool.pairSymbols[0].slice(0, 3)}</span>
 									{/if}
 									{#if getCoinIcon(pool.pairSymbols[1])}
 										<img class="coin-icon icon-b" src={getCoinIcon(pool.pairSymbols[1])} alt={pool.pairSymbols[1]} />
 									{:else}
-										<span class="icon icon-b"></span>
+										<span class="icon icon-b">{pool.pairSymbols[1].slice(0, 3)}</span>
 									{/if}
 								</span>
 								<span class="pair-label">{pool.pair}</span>
@@ -361,12 +361,12 @@
 									{#if getCoinIcon(row.pairSymbols[0])}
 										<img class="coin-icon icon-a" src={getCoinIcon(row.pairSymbols[0])} alt={row.pairSymbols[0]} />
 									{:else}
-										<span class="icon icon-a"></span>
+										<span class="icon icon-a">{row.pairSymbols[0].slice(0, 3)}</span>
 									{/if}
 									{#if getCoinIcon(row.pairSymbols[1])}
 										<img class="coin-icon icon-b" src={getCoinIcon(row.pairSymbols[1])} alt={row.pairSymbols[1]} />
 									{:else}
-										<span class="icon icon-b"></span>
+										<span class="icon icon-b">{row.pairSymbols[1].slice(0, 3)}</span>
 									{/if}
 								</span>
 								<span class="pair-label">{row.pair}</span>
@@ -546,6 +546,13 @@
 	}
 	.pair-icons .icon {
 		background-color: var(--dash-surface-alt);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 0.5rem;
+		font-weight: 600;
+		color: var(--dash-text-secondary);
+		letter-spacing: 0.02em;
 	}
 	.pair-icons .icon:first-child,
 	.pair-icons .coin-icon:first-child {

--- a/src/lib/pools/poolsData.ts
+++ b/src/lib/pools/poolsData.ts
@@ -340,8 +340,16 @@ export async function fetchPools(range: TimeRange = '30d'): Promise<PoolRow[]> {
 			return [];
 		}
 
+		// Deduplicate registry entries by contractId (testnet can return duplicates)
+		const seen = new Set<string>();
+		const uniqueRegistry = registry.filter((entry) => {
+			if (seen.has(entry.contractId)) return false;
+			seen.add(entry.contractId);
+			return true;
+		});
+
 		const poolRows = await Promise.all(
-			registry.map((entry) =>
+			uniqueRegistry.map((entry) =>
 				fetchSinglePool(entry.contractId, entry.symbols, range, usdPrices)
 			)
 		);

--- a/src/lib/pools/poolsData.ts
+++ b/src/lib/pools/poolsData.ts
@@ -27,6 +27,7 @@ export interface PoolRow {
 	totalLiquidityAssets: [string, string];
 	feeEarnedUsd: string;
 	feeEarnedAssets: [string, string];
+	feeEarnedUsdBreakdown: [string, string]; // [LP fee USD, Protocol fee USD]
 	volumeUsd: string;
 	volumeAssets: [string, string];
 	// Raw chain-state values used by per-user computations (My Pools).
@@ -206,6 +207,10 @@ function mapStateToPoolRow(
 	// Compute USD totals
 	const totalLiquidityUsd = liqAmt0 * usd0 + liqAmt1 * usd1;
 	const feeEarnedUsdTotal = feeTotal * usd0;
+	const feeEarnedUsdBreakdown: [string, string] = [
+		formatNum(feeLp * usd0, '$', 2),
+		formatNum(feeMagi * usd0, '$', 2)
+	];
 	const volumeUsdTotal = volIn * usd0 + volOut * usd1;
 
 	return {
@@ -220,6 +225,7 @@ function mapStateToPoolRow(
 		totalLiquidityAssets,
 		feeEarnedUsd: formatNum(feeEarnedUsdTotal, '$', 2),
 		feeEarnedAssets,
+		feeEarnedUsdBreakdown,
 		volumeUsd: formatNum(volumeUsdTotal, '$', 2),
 		volumeAssets,
 		reserve0Raw,

--- a/src/lib/sendswap/stages/Complete.svelte
+++ b/src/lib/sendswap/stages/Complete.svelte
@@ -210,7 +210,7 @@
 		{#snippet content()}
 			{@render completeBody()}
 			<div class="popup-buttons">
-				<PillButton onclick={() => onClose()} theme="accent" styleType="invert">Done</PillButton>
+				<PillButton onclick={() => { dialogToggle?.(false); onClose(); }} theme="accent" styleType="invert">Done</PillButton>
 			</div>
 		{/snippet}
 	</Dialog>

--- a/src/lib/sendswap/stages/ReviewSwap.svelte
+++ b/src/lib/sendswap/stages/ReviewSwap.svelte
@@ -531,7 +531,9 @@
 									<td class="icon"><Dot size="32" /></td>
 									<td class="sm-caption label">Min amount received</td>
 									<td class="content">
-										{#if asSwap.minAmountOut && txState.toCoin}
+										{#if asSwap.swapCalcPending}
+											<div class="fee-loading"><WaveLoading size={16} /></div>
+										{:else if asSwap.minAmountOut && txState.toCoin}
 											{@const minRaw = alteraFeeApplies
 												? Math.floor(
 														(Number(asSwap.minAmountOut) * (10000 - ALTERA_FEE_BPS)) / 10000

--- a/src/lib/sendswap/stages/SwapOptions.svelte
+++ b/src/lib/sendswap/stages/SwapOptions.svelte
@@ -624,6 +624,8 @@
 			if (amt !== txState.toAmount) txState.toAmount = amt;
 		} else {
 			inputAmount.convertTo(txState.toCoin.coin, Network.lightning).then((amt) => {
+				// Discard stale exchange-rate estimate if pool calc resolved while we waited
+				if (swapResult) return;
 				if (txState.toAmount !== amt.toAmountString()) {
 					txState.toAmount = amt.toAmountString();
 				}

--- a/src/lib/sendswap/stages/SwapOptions.svelte
+++ b/src/lib/sendswap/stages/SwapOptions.svelte
@@ -995,7 +995,9 @@
 				</div>
 				<div class="section-input-row">
 					<div class="to-amount-display">
-						{#if formattedToAmount}
+						{#if txState.swapCalcPending}
+							<WaveLoading size={18} />
+						{:else if formattedToAmount}
 							<span class="to-amount-value">{formattedToAmount}</span>
 						{:else}
 							<span class="to-amount-placeholder">0</span>

--- a/src/lib/sendswap/stages/SwapOptions.svelte
+++ b/src/lib/sendswap/stages/SwapOptions.svelte
@@ -592,6 +592,14 @@
 			snippetData: { fromOpt: opt, net: txState.toNetwork, size: 'medium' }
 		}))
 	);
+
+	function isFromTokenAllowed(value: string): boolean {
+		return value !== txState.toCoin?.coin.value;
+	}
+
+	function isToTokenAllowed(value: string): boolean {
+		return value !== txState.fromCoin?.coin.value;
+	}
 	// Only the from coin for the amount input – no dropdown; from is changed only via the left card.
 	let amountInputCoinOpts: CoinOnNetwork[] = $derived(
 		txState.fromCoin && txState.fromNetwork
@@ -752,6 +760,8 @@
 	}
 
 	function selectToken(token: AssetObject) {
+		if (currentlyOpen === 'from' && !isFromTokenAllowed(token.value)) return;
+		if (currentlyOpen === 'to' && !isToTokenAllowed(token.value)) return;
 		const source = currentlyOpen === 'from' ? swapOptions.from.coins : swapOptions.to.coins;
 		const coinOpt = source.find((opt) => opt.coin.value === token.value);
 		if (!coinOpt) return;
@@ -818,7 +828,16 @@
 				</div>
 				<div class="token-chip-grid">
 					{#each getFilteredTokens(currentlyOpen === 'from' ? fromAssetObjs : toAssetObjs) as token (token.value)}
-						<button class="token-chip" onclick={() => selectToken(token)}>
+						{@const disabled = currentlyOpen === 'from'
+							? !isFromTokenAllowed(token.value)
+							: !isToTokenAllowed(token.value)}
+						<button
+							class="token-chip"
+							class:disabled
+							{disabled}
+							title={disabled ? 'Already selected on the other side' : undefined}
+							onclick={() => selectToken(token)}
+						>
 							<img src={token.icon} alt={token.label} class="chip-icon" />
 							<span>{coinDisplayLabel(token)}</span>
 						</button>
@@ -832,8 +851,13 @@
 			<div class="dialog-content">
 				<div class="token-chip-grid">
 					{#each getFilteredTokens(currentlyOpen === 'from' ? fromAssetObjs : toAssetObjs) as token (token.value)}
+						{@const disabled = currentlyOpen === 'from'
+							? !isFromTokenAllowed(token.value)
+							: !isToTokenAllowed(token.value)}
 						<button
-							class={['token-chip', { active: token.value === tempCoinOpt.coin.value }]}
+							class={['token-chip', { active: token.value === tempCoinOpt.coin.value, disabled }]}
+							{disabled}
+							title={disabled ? 'Already selected on the other side' : undefined}
 							onclick={() => selectToken(token)}
 						>
 							<img src={token.icon} alt={token.label} class="chip-icon" />
@@ -1973,6 +1997,12 @@
 	.token-chip.active {
 		border-color: var(--dash-accent-purple);
 		background-color: rgba(111, 106, 248, 0.15);
+	}
+	.token-chip.disabled,
+	.token-chip:disabled {
+		opacity: 0.35;
+		cursor: not-allowed;
+		pointer-events: none;
 	}
 
 	/* ── Dialog: Network Cards (Source) ── */

--- a/src/lib/sendswap/stages/SwapOptions.svelte
+++ b/src/lib/sendswap/stages/SwapOptions.svelte
@@ -57,24 +57,48 @@
 
 	const txState = useSwapState();
 
-	onMount(() => {
-		// Resolve each swap-eligible pool dynamically so calls are
-		// network-aware (mainnet vs testnet). Both are loaded in
-		// parallel — the swap-calc effect picks whichever it needs
-		// based on the user's selected pair.
-		(async () => {
+	// Pool depths and swap calculation state
+	let hiveHbdPool = $state.raw<TypedPoolDepths | null>(null);
+	let btcHbdPool = $state.raw<TypedPoolDepths | null>(null);
+	/** True when all pool-fetch retries have been exhausted without success. */
+	let poolLoadFailed = $state(false);
+	/** True while a retry round is in progress (disables the retry button). */
+	let poolLoadingRetry = $state(false);
+
+	// Resolve each swap-eligible pool dynamically so calls are
+	// network-aware (mainnet vs testnet). Both are loaded in
+	// parallel — the swap-calc effect picks whichever it needs
+	// based on the user's selected pair.
+	// Retries up to 3 times with exponential backoff if the
+	// indexer/chain-state is momentarily unreachable.
+	async function loadPoolsWithRetry(maxAttempts = 3) {
+		if (poolLoadingRetry) return; // prevent concurrent retry cycles
+		poolLoadFailed = false;
+		poolLoadingRetry = true;
+		for (let attempt = 0; attempt < maxAttempts; attempt++) {
 			const [hiveHbd, btcHbd] = await Promise.all([
-				fetchTypedPoolDepths('HIVE', 'HBD'),
-				fetchTypedPoolDepths('BTC', 'HBD')
+				hiveHbdPool ? null : fetchTypedPoolDepths('HIVE', 'HBD'),
+				btcHbdPool ? null : fetchTypedPoolDepths('BTC', 'HBD')
 			]);
 			if (hiveHbd) hiveHbdPool = hiveHbd;
 			if (btcHbd) btcHbdPool = btcHbd;
-		})();
+			if (hiveHbdPool && btcHbdPool) {
+				poolLoadingRetry = false;
+				return;
+			}
+			// Wait before retrying (1s, 2s, 4s)
+			if (attempt < maxAttempts - 1) {
+				await new Promise((r) => setTimeout(r, 1000 * 2 ** attempt));
+			}
+		}
+		poolLoadFailed = true;
+		poolLoadingRetry = false;
+	}
+
+	onMount(() => {
+		loadPoolsWithRetry();
 	});
 
-	// Pool depths and swap calculation state
-	let hiveHbdPool = $state<TypedPoolDepths | null>(null);
-	let btcHbdPool = $state<TypedPoolDepths | null>(null);
 	let swapResult: SwapCalcResult | null = $state(null);
 	let slippageBps = $state(100); // default 1%
 	const slippageOptions = [50, 100, 200, 300]; // 0.5%, 1%, 2%, 3%
@@ -455,11 +479,18 @@
 		);
 	});
 
-	// Combined: enable button when swap fields valid, destination valid, not same coin, and has balance
+	// Combined: enable button when swap fields valid, destination valid, not same coin, has balance,
+	// and pool-based swap calc has completed (swapResult non-null). Without swapResult the fee
+	// details aren't available and the tx would be built with stale/missing min_amount_out.
 	$effect(() => {
 		if (!isActive) return;
 		editStage(
-			swapFieldsValid && destValid && !sameCoinError && !insufficientBalance && !exceedsPoolDepth
+			swapFieldsValid &&
+				destValid &&
+				!sameCoinError &&
+				!insufficientBalance &&
+				!exceedsPoolDepth &&
+				!!swapResult
 		);
 	});
 
@@ -1303,6 +1334,18 @@
 							</span>
 						</div>
 					</div>
+				{:else if (poolLoadFailed || poolLoadingRetry) && txState.fromAmount && txState.fromAmount !== '0'}
+					<div class="pool-warning">
+						<TriangleAlert size={14} />
+						{#if poolLoadingRetry}
+							<span>Loading pool data...</span>
+						{:else}
+							<span>Unable to load pool data.</span>
+							<button type="button" class="pool-retry-btn" onclick={() => loadPoolsWithRetry()}>
+								Retry
+							</button>
+						{/if}
+					</div>
 				{/if}
 			</div>
 		{/if}
@@ -1659,6 +1702,39 @@
 		font-size: var(--text-xs);
 		color: var(--dash-text-muted);
 		font-family: 'Noto Sans Mono Variable', monospace;
+	}
+	.pool-warning {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
+		font-size: var(--text-sm);
+		color: #f59e0b;
+		margin: 0.5rem;
+		padding: 0.5rem 0.75rem;
+		border: 1px solid rgba(245, 158, 11, 0.25);
+		border-radius: 12px;
+		background: rgba(245, 158, 11, 0.06);
+	}
+	.pool-retry-btn {
+		padding: 0.2rem 0.6rem;
+		border: 1px solid rgba(111, 106, 248, 0.35);
+		border-radius: 12px;
+		background: transparent;
+		color: var(--dash-text-secondary);
+		font-size: var(--text-xs);
+		font-weight: 600;
+		font-style: normal;
+		cursor: pointer;
+		transition:
+			background-color 0.15s ease,
+			border-color 0.15s ease,
+			color 0.15s ease;
+		&:hover {
+			background: rgba(111, 106, 248, 0.15);
+			color: var(--dash-text-primary);
+			border-color: var(--dash-accent-purple);
+		}
 	}
 	.price-unavailable {
 		font-size: var(--text-xs);

--- a/src/lib/sendswap/stages/SwapOptions.svelte
+++ b/src/lib/sendswap/stages/SwapOptions.svelte
@@ -134,6 +134,7 @@
 		const fromAmount = txState.fromAmount;
 		if (!fromCoin || !toCoin || !fromAmount || fromAmount === '0') {
 			swapResult = null;
+			txState.swapCalcPending = false;
 			return;
 		}
 
@@ -144,12 +145,14 @@
 			fromCoin.coin.value !== toCoin.coin.value;
 		if (!isSwap) {
 			swapResult = null;
+			txState.swapCalcPending = false;
 			return;
 		}
 
 		const fromAmountInt = new CoinAmount(fromAmount, fromCoin.coin).amount;
 		if (!Number.isFinite(fromAmountInt) || fromAmountInt <= 0) {
 			swapResult = null;
+			txState.swapCalcPending = false;
 			return;
 		}
 
@@ -167,11 +170,13 @@
 		if (!involvesBtc) {
 			if (!hiveHbdPool) {
 				swapResult = null;
+				txState.swapCalcPending = true;
 				return;
 			}
 			const depths = getOrderedDepthsFor(hiveHbdPool, assetIn);
 			if (!depths) {
 				swapResult = null;
+				txState.swapCalcPending = false;
 				return;
 			}
 			result = calculateSwap(x, depths.X, depths.Y, slippageBps);
@@ -181,11 +186,13 @@
 		) {
 			if (!btcHbdPool) {
 				swapResult = null;
+				txState.swapCalcPending = true;
 				return;
 			}
 			const depths = getOrderedDepthsFor(btcHbdPool, assetIn);
 			if (!depths) {
 				swapResult = null;
+				txState.swapCalcPending = false;
 				return;
 			}
 			result = calculateSwap(x, depths.X, depths.Y, slippageBps);
@@ -195,6 +202,7 @@
 			// the output asset.
 			if (!btcHbdPool || !hiveHbdPool) {
 				swapResult = null;
+				txState.swapCalcPending = true;
 				return;
 			}
 			const pool1 = assetIn === Coin.btc.value ? btcHbdPool : hiveHbdPool;
@@ -204,11 +212,13 @@
 
 		if (!result) {
 			swapResult = null;
+			txState.swapCalcPending = false;
 			return;
 		}
 		swapResult = result;
 
 		untrack(() => {
+			txState.swapCalcPending = false;
 			const expectedOutput = result.expectedOutput.toString();
 			const minAmountOut = result.minAmountOut.toString();
 			const swapBaseFee = result.baseFee.toString();

--- a/src/lib/sendswap/stages/SwapOptions.svelte
+++ b/src/lib/sendswap/stages/SwapOptions.svelte
@@ -653,12 +653,17 @@
 
 	let fromPriceUsdRaw = $state(0);
 	let toPriceUsdRaw = $state(0);
+	let pricesFailed = $state(false);
 	$effect(() => {
 		if (txState.fromCoin) {
 			new CoinAmount(1, txState.fromCoin.coin)
 				.convertTo(Coin.usd, Network.lightning)
 				.then((amt) => {
 					fromPriceUsdRaw = amt.toNumber();
+					pricesFailed = false;
+				})
+				.catch(() => {
+					pricesFailed = true;
 				});
 		}
 		if (txState.toCoin) {
@@ -666,6 +671,10 @@
 				.convertTo(Coin.usd, Network.lightning)
 				.then((amt) => {
 					toPriceUsdRaw = amt.toNumber();
+					pricesFailed = false;
+				})
+				.catch(() => {
+					pricesFailed = true;
 				});
 		}
 	});
@@ -947,7 +956,11 @@
 				</div>
 				<div class="section-usd-row">
 					<span class="section-usd-approx">
-						{#if inputAmountUsd !== null}≈ ${formatUsd(inputAmountUsd)}{/if}
+						{#if inputAmountUsd !== null}
+							≈ ${formatUsd(inputAmountUsd)}
+						{:else if pricesFailed && txState.fromCoin && txState.fromAmount && txState.fromAmount !== '0'}
+							<span class="price-unavailable">Price unavailable</span>
+						{/if}
 					</span>
 					{#if sameCoinError}
 						<span class="section-error-inline">Select a different token</span>
@@ -1004,7 +1017,11 @@
 				</div>
 				<div class="section-usd-row">
 					<span class="section-usd-approx">
-						{#if expectedOutputUsd !== null}≈ ${formatUsd(expectedOutputUsd)}{/if}
+						{#if expectedOutputUsd !== null}
+							≈ ${formatUsd(expectedOutputUsd)}
+						{:else if pricesFailed && txState.toCoin && txState.toAmount && txState.toAmount !== '0'}
+							<span class="price-unavailable">Price unavailable</span>
+						{/if}
 					</span>
 				</div>
 			</div>
@@ -1640,6 +1657,12 @@
 		font-size: var(--text-xs);
 		color: var(--dash-text-muted);
 		font-family: 'Noto Sans Mono Variable', monospace;
+	}
+	.price-unavailable {
+		font-size: var(--text-xs);
+		color: var(--dash-text-muted);
+		font-style: italic;
+		font-family: inherit;
 	}
 	.section-error-inline {
 		font-size: var(--text-xs);

--- a/src/lib/sendswap/utils/txState.svelte.ts
+++ b/src/lib/sendswap/utils/txState.svelte.ts
@@ -1,105 +1,114 @@
-import { getContext, setContext } from 'svelte'
-import type { CoinAmount } from '$lib/currency/CoinAmount'
-import type { Coin } from './sendOptions'
-import type { CoinOptions, Network, TransferMethod, SendAccount } from './sendOptions'
+import { getContext, setContext } from 'svelte';
+import type { CoinAmount } from '$lib/currency/CoinAmount';
+import type { Coin } from './sendOptions';
+import type { CoinOptions, Network, TransferMethod, SendAccount } from './sendOptions';
 
 // ─── Base (fields every flow shares) ─────────────────────────────────────────
 
 export class TxStateBase {
-	fromCoin: CoinOptions['coins'][number] | undefined = $state(undefined)
-	fromNetwork: Network | undefined = $state(undefined)
-	fromAmount: string = $state('0')
-	enteredAmount: string = $state('0')
-	toCoin: CoinOptions['coins'][number] | undefined = $state(undefined)
-	toNetwork: Network | undefined = $state(undefined)
-	toAmount: string = $state('0')
-	toUsername: string = $state('')
-	fee: CoinAmount<Coin> | undefined = $state(undefined)
-	method: TransferMethod | undefined = $state(undefined)
-	account: SendAccount | undefined = $state(undefined)
+	fromCoin: CoinOptions['coins'][number] | undefined = $state(undefined);
+	fromNetwork: Network | undefined = $state(undefined);
+	fromAmount: string = $state('0');
+	enteredAmount: string = $state('0');
+	toCoin: CoinOptions['coins'][number] | undefined = $state(undefined);
+	toNetwork: Network | undefined = $state(undefined);
+	toAmount: string = $state('0');
+	toUsername: string = $state('');
+	fee: CoinAmount<Coin> | undefined = $state(undefined);
+	method: TransferMethod | undefined = $state(undefined);
+	account: SendAccount | undefined = $state(undefined);
 	/** Whether to deduct the BTC network fee from the output (BTC unmap flows). */
-	btcDeductFee: boolean = $state(false)
+	btcDeductFee: boolean = $state(false);
 	/** Sat cap on the BTC network fee (BTC unmap flows). */
-	btcMaxFee: number | undefined = $state(undefined)
+	btcMaxFee: number | undefined = $state(undefined);
 }
 
 // ─── Swap (QuickSwap card, /swap page) ───────────────────────────────────────
 
 export class SwapTxState extends TxStateBase {
-	readonly kind = 'swap' as const
-	expectedOutput: string | undefined = $state(undefined)
-	slippageBps: number | undefined = $state(100)
-	minAmountOut: string | undefined = $state(undefined)
-	swapBaseFee: string | undefined = $state(undefined)
-	swapClpFee: string | undefined = $state(undefined)
-	swapTotalFee: string | undefined = $state(undefined)
-	swapHop1Fee: { asset: string; totalFee: string } | undefined = $state(undefined)
+	readonly kind = 'swap' as const;
+	expectedOutput: string | undefined = $state(undefined);
+	slippageBps: number | undefined = $state(100);
+	minAmountOut: string | undefined = $state(undefined);
+	swapBaseFee: string | undefined = $state(undefined);
+	swapClpFee: string | undefined = $state(undefined);
+	swapTotalFee: string | undefined = $state(undefined);
+	swapHop1Fee: { asset: string; totalFee: string } | undefined = $state(undefined);
+	swapCalcPending: boolean = $state(false);
 }
 
 // ─── Transfer (QuickSend dialog, /transfer page) ──────────────────────────────
 
 export class TransferTxState extends TxStateBase {
-	readonly kind = 'transfer' as const
-	toDisplayName: string = $state('')
-	memo: string = $state('')
+	readonly kind = 'transfer' as const;
+	toDisplayName: string = $state('');
+	memo: string = $state('');
 }
 
 // ─── Deposit (L1 → Magi) ─────────────────────────────────────────────────────
 
 export class DepositTxState extends TxStateBase {
-	readonly kind = 'deposit' as const
+	readonly kind = 'deposit' as const;
 }
 
 // ─── Withdraw (Magi → L1) ────────────────────────────────────────────────────
 
 export class WithdrawTxState extends TxStateBase {
-	readonly kind = 'withdraw' as const
+	readonly kind = 'withdraw' as const;
 }
 
 // ─── Union & context ─────────────────────────────────────────────────────────
 
-export type TxState = SwapTxState | TransferTxState | DepositTxState | WithdrawTxState
+export type TxState = SwapTxState | TransferTxState | DepositTxState | WithdrawTxState;
 
-const TX_STATE_KEY = Symbol('txState')
+const TX_STATE_KEY = Symbol('txState');
 
 export function provideTxState(state: TxState) {
-	setContext(TX_STATE_KEY, state)
+	setContext(TX_STATE_KEY, state);
 }
 
 export function useTxState(): TxState | undefined {
-	const state = getContext<unknown>(TX_STATE_KEY)
-	if (state instanceof TxStateBase) return state as TxState
-	return undefined
+	const state = getContext<unknown>(TX_STATE_KEY);
+	if (state instanceof TxStateBase) return state as TxState;
+	return undefined;
 }
 
 export function useSwapState(): SwapTxState {
-	const state = getContext<unknown>(TX_STATE_KEY)
+	const state = getContext<unknown>(TX_STATE_KEY);
 	if (!(state instanceof SwapTxState)) {
-		throw new Error(`useSwapState() called with unexpected context value (got ${state?.constructor?.name ?? typeof state})`)
+		throw new Error(
+			`useSwapState() called with unexpected context value (got ${state?.constructor?.name ?? typeof state})`
+		);
 	}
-	return state
+	return state;
 }
 
 export function useTransferState(): TransferTxState {
-	const state = getContext<unknown>(TX_STATE_KEY)
+	const state = getContext<unknown>(TX_STATE_KEY);
 	if (!(state instanceof TransferTxState)) {
-		throw new Error(`useTransferState() called with unexpected context value (got ${state?.constructor?.name ?? typeof state})`)
+		throw new Error(
+			`useTransferState() called with unexpected context value (got ${state?.constructor?.name ?? typeof state})`
+		);
 	}
-	return state
+	return state;
 }
 
 export function useDepositState(): DepositTxState {
-	const state = getContext<unknown>(TX_STATE_KEY)
+	const state = getContext<unknown>(TX_STATE_KEY);
 	if (!(state instanceof DepositTxState)) {
-		throw new Error(`useDepositState() called with unexpected context value (got ${state?.constructor?.name ?? typeof state})`)
+		throw new Error(
+			`useDepositState() called with unexpected context value (got ${state?.constructor?.name ?? typeof state})`
+		);
 	}
-	return state
+	return state;
 }
 
 export function useWithdrawState(): WithdrawTxState {
-	const state = getContext<unknown>(TX_STATE_KEY)
+	const state = getContext<unknown>(TX_STATE_KEY);
 	if (!(state instanceof WithdrawTxState)) {
-		throw new Error(`useWithdrawState() called with unexpected context value (got ${state?.constructor?.name ?? typeof state})`)
+		throw new Error(
+			`useWithdrawState() called with unexpected context value (got ${state?.constructor?.name ?? typeof state})`
+		);
 	}
-	return state
+	return state;
 }

--- a/src/lib/sendswap/v4v/api-types/query.ts
+++ b/src/lib/sendswap/v4v/api-types/query.ts
@@ -4,52 +4,64 @@ export function getQuerier<ReturnType>(url: string, keepAlive: seconds = 30) {
 	let cached: ReturnType | undefined = undefined;
 	let cachedAt = 0;
 	let isFetching = false;
-	let awaitingCache: ((value: ReturnType | PromiseLike<ReturnType>) => void)[] = [];
+	let awaitingResolve: ((value: ReturnType) => void)[] = [];
+	let awaitingReject: ((reason?: unknown) => void)[] = [];
 
 	return async function getReturnType(options?: { signal?: AbortSignal }): Promise<ReturnType> {
-		let now = Date.now();
-		if (cached != undefined) {
-			return cached;
-		}
-		if (cachedAt > now - keepAlive * 1000 && cached != undefined) {
+		const now = Date.now();
+
+		// Return cached value if it's still within the TTL window.
+		if (cached !== undefined && cachedAt > now - keepAlive * 1000) {
 			return cached;
 		}
 
+		// A fetch is already in flight — queue up and wait for it.
 		if (isFetching) {
-			return new Promise((resolve) => {
-				awaitingCache.push(resolve);
+			return new Promise<ReturnType>((resolve, reject) => {
+				awaitingResolve.push(resolve);
+				awaitingReject.push(reject);
 			});
 		}
 
 		isFetching = true;
-		let req = fetch(url, {
-			signal: options?.signal
-		});
-		if (cached != undefined) {
-			req.then(async (res) => {
-				if (res.ok) {
-					let out = await res.json();
+
+		// Stale cache available — return it immediately and refresh in background.
+		if (cached !== undefined) {
+			fetch(url, { signal: options?.signal })
+				.then(async (res) => {
+					if (!res.ok) throw new Error('Fetch failed.');
+					const out = (await res.json()) as ReturnType;
 					cached = out;
-					cachedAt = now;
-					for (const res of awaitingCache) {
-						res(out);
-					}
-				}
-			});
-			// return stale cache for this req,
-			// fetch fresh data for the next one
+					cachedAt = Date.now();
+					for (const resolve of awaitingResolve) resolve(out);
+				})
+				.catch((err) => {
+					for (const reject of awaitingReject) reject(err);
+				})
+				.finally(() => {
+					isFetching = false;
+					awaitingResolve = [];
+					awaitingReject = [];
+				});
 			return cached;
 		}
-		let res = await req;
-		if (res.ok) {
-			let out = await res.json();
+
+		// First fetch — must await the result.
+		try {
+			const res = await fetch(url, { signal: options?.signal });
+			if (!res.ok) throw new Error('Fetch failed.');
+			const out = (await res.json()) as ReturnType;
 			cached = out;
-			cachedAt = now;
-			for (const res of awaitingCache) {
-				res(out);
-			}
+			cachedAt = Date.now();
+			for (const resolve of awaitingResolve) resolve(out);
 			return out;
+		} catch (err) {
+			for (const reject of awaitingReject) reject(err);
+			throw err;
+		} finally {
+			isFetching = false;
+			awaitingResolve = [];
+			awaitingReject = [];
 		}
-		throw new Error('Fetch failed.');
 	};
 }

--- a/src/routes/(authed)/+page.svelte
+++ b/src/routes/(authed)/+page.svelte
@@ -26,20 +26,24 @@
 		<Balance />
 	</div>
 
+	<div class="area-quickswap">
+		<QuickSwap />
+	</div>
+
 	<div class="area-portfolio">
 		<PortfolioValue />
 		<StakingEarnings onStake={() => toggleStake(true)} />
 	</div>
 
 	<div class="area-rc-market">
-		{#if auth.value}
-			<ResourceCredits {username} />
-		{/if}
-		<MarketPrices />
-	</div>
-
-	<div class="area-quickswap">
-		<QuickSwap />
+		<div class="area-rc-inner">
+			{#if auth.value}
+				<ResourceCredits {username} />
+			{/if}
+		</div>
+		<div class="area-market-inner">
+			<MarketPrices />
+		</div>
 	</div>
 
 	<div class="area-transactions">
@@ -161,7 +165,7 @@
 			grid-template-columns: 1fr 1fr;
 			grid-template-areas:
 				'balance   portfolio'
-				'rc-mkt    quickswap'
+				'quickswap rc-mkt'
 				'txs       txs';
 			align-items: start;
 		}
@@ -180,9 +184,17 @@
 		.area-rc-market {
 			grid-area: rc-mkt;
 			align-self: stretch;
+			display: flex;
+			flex-direction: column;
 		}
-		/* Both cards grow equally to fill remaining height */
+		/* Both inner wrappers grow equally */
 		.area-rc-market > :global(*) {
+			flex: 1;
+			display: flex;
+			flex-direction: column;
+		}
+		/* Child components fill their wrapper */
+		.area-rc-market > :global(*) > :global(*) {
 			flex: 1;
 		}
 		.area-quickswap {
@@ -210,32 +222,45 @@
 	}
 
 	/* ── 3-column layout (≥ 1920px) ─────────────────────────────────────── */
-	/*  5-column grid (each unit = 1/5):
-	    Row 1: balance(2) | portfolio+staking(2) | rc+market(1)
-	    Row 2: quickswap(2) | transactions(3) — same height, table scrollable */
+	/*  3-column grid:
+	    Row 1: balance(1) | portfolio+staking(1) | quickswap(1, spans rows 1-2)
+	    Row 2: rc(1)      | market(1)            | quickswap (continued)
+	    Row 3: txs(3)                                                          */
 
 	@media (min-width: 1920px) {
 		.dashboard-wrapper {
 			display: grid;
-			grid-template-columns: repeat(5, 1fr);
+			grid-template-columns: repeat(3, 1fr);
 			grid-template-areas:
-				'balance   balance   portfolio  portfolio  rc-mkt'
-				'quickswap quickswap txs        txs        txs';
-			/* row 1 items sit at their natural height */
+				'balance   portfolio  quickswap'
+				'rc        market     quickswap'
+				'txs       txs        txs';
 			align-items: start;
 		}
 
 		.area-balance { grid-area: balance; }
 		.area-portfolio { grid-area: portfolio; }
-		.area-rc-market { grid-area: rc-mkt; }
 
-		/* quickswap: fixed height prevents layout shifts when swap details
-		   appear/disappear. This also defines the row track height so
-		   the transactions card stretches to exactly the same size. */
+		/* Wrapper becomes transparent — children are placed individually */
+		.area-rc-market { display: contents; }
+		.area-rc-inner {
+			grid-area: rc;
+			align-self: stretch;
+			display: flex;
+			flex-direction: column;
+		}
+		.area-rc-inner > :global(*) { flex: 1; }
+		.area-market-inner {
+			grid-area: market;
+			align-self: stretch;
+			display: flex;
+			flex-direction: column;
+		}
+		.area-market-inner > :global(*) { flex: 1; }
+
 		.area-quickswap {
 			grid-area: quickswap;
-			align-self: start;
-			height: 755px;
+			align-self: stretch;
 			overflow: hidden;
 		}
 		.area-transactions {

--- a/src/routes/(authed)/+page.svelte
+++ b/src/routes/(authed)/+page.svelte
@@ -15,13 +15,14 @@
 	let username: string | undefined = $derived(getAccountNameFromAuth(auth));
 	let stakeOpen = $state(false);
 	let toggleStake = $state<(open?: boolean) => void>(() => {});
+	let portfolioHeight = $state(0);
 </script>
 
 <document:head>
 	<title>Dashboard</title>
 </document:head>
 
-<div class="dashboard-wrapper">
+<div class="dashboard-wrapper" style:--portfolio-h="{portfolioHeight}px">
 	<div class="area-balance">
 		<Balance />
 	</div>
@@ -30,7 +31,7 @@
 		<QuickSwap />
 	</div>
 
-	<div class="area-portfolio">
+	<div class="area-portfolio" bind:clientHeight={portfolioHeight}>
 		<PortfolioValue />
 		<StakingEarnings onStake={() => toggleStake(true)} />
 	</div>
@@ -154,6 +155,19 @@
 		padding-bottom: 2rem;
 	}
 
+	/* In single-column, cap the balance card so tokens scroll */
+	@media (max-width: 1023px) {
+		.area-balance {
+			max-height: 600px;
+			display: flex;
+			flex-direction: column;
+		}
+		.area-balance > :global(*) {
+			flex: 1;
+			min-height: 0;
+		}
+	}
+
 	/* ── 2-column layout (1024px – 1919px) ──────────────────────────────── */
 	/*  Row 1: balance | portfolio+staking
 	    Row 2: rc+market | quickswap
@@ -172,15 +186,17 @@
 
 		.area-balance {
 			grid-area: balance;
-			align-self: stretch;
+			height: var(--portfolio-h);
 			display: flex;
 			flex-direction: column;
 		}
-		/* Make the Balance component fill the stretched area */
 		.area-balance > :global(*) {
 			flex: 1;
+			min-height: 0;
 		}
-		.area-portfolio { grid-area: portfolio; }
+		.area-portfolio {
+			grid-area: portfolio;
+		}
 		.area-rc-market {
 			grid-area: rc-mkt;
 			align-self: stretch;
@@ -238,25 +254,42 @@
 			align-items: start;
 		}
 
-		.area-balance { grid-area: balance; }
-		.area-portfolio { grid-area: portfolio; }
+		.area-balance {
+			grid-area: balance;
+			height: var(--portfolio-h);
+			display: flex;
+			flex-direction: column;
+		}
+		.area-balance > :global(*) {
+			flex: 1;
+			min-height: 0;
+		}
+		.area-portfolio {
+			grid-area: portfolio;
+		}
 
 		/* Wrapper becomes transparent — children are placed individually */
-		.area-rc-market { display: contents; }
+		.area-rc-market {
+			display: contents;
+		}
 		.area-rc-inner {
 			grid-area: rc;
 			align-self: stretch;
 			display: flex;
 			flex-direction: column;
 		}
-		.area-rc-inner > :global(*) { flex: 1; }
+		.area-rc-inner > :global(*) {
+			flex: 1;
+		}
 		.area-market-inner {
 			grid-area: market;
 			align-self: stretch;
 			display: flex;
 			flex-direction: column;
 		}
-		.area-market-inner > :global(*) { flex: 1; }
+		.area-market-inner > :global(*) {
+			flex: 1;
+		}
 
 		.area-quickswap {
 			grid-area: quickswap;

--- a/src/routes/(authed)/transactions/Table/tds/Amount.svelte
+++ b/src/routes/(authed)/transactions/Table/tds/Amount.svelte
@@ -5,27 +5,44 @@
 
 	type Props = {
 		amount: UnkCoinAmount;
-		direction?: 'incoming' | 'outgoing' | 'swap' | 'contract';
+		direction?: 'incoming' | 'outgoing' | 'swap' | 'contract' | 'add-liquidity' | 'remove-liquidity';
 		fromAmount?: UnkCoinAmount | null;
+		secondAmount?: UnkCoinAmount | null;
+		lpInfo?: string | null;
 	};
-	let { amount, direction = 'incoming', fromAmount = null }: Props = $props();
+	let { amount, direction = 'incoming', fromAmount = null, secondAmount = null, lpInfo = null }: Props = $props();
 
-	const displayUnit = $derived(
-		amount?.coin.value === Coin.hive.value
-			? getHiveAssetName()
-			: amount?.coin.value === Coin.hbd.value
-				? getHbdAssetName()
-				: amount?.coin.unit ?? ''
-	);
+	function unitFor(coin: UnkCoinAmount['coin']): string {
+		if (coin.value === Coin.hive.value) return getHiveAssetName();
+		if (coin.value === Coin.hbd.value) return getHbdAssetName();
+		return coin.unit ?? '';
+	}
+
+	const displayUnit = $derived(unitFor(amount?.coin));
 </script>
 
 <td>
 	{#if direction === 'swap' && fromAmount}
 		<span class="amount outgoing">{fromAmount.toPrettyAmountString()}</span>
-		<span class="token outgoing">{fromAmount.coin.unit}</span>
+		<span class="token outgoing">{unitFor(fromAmount.coin)}</span>
 		<span class="swap-arrow">→</span>
 		<span class="amount green">{amount.toPrettyAmountString()}</span>
 		<span class="token green">{displayUnit}</span>
+	{:else if direction === 'add-liquidity' && secondAmount}
+		<span class="amount">{amount.toPrettyAmountString()}</span>
+		<span class="token">{displayUnit}</span>
+		<span class="swap-arrow">+</span>
+		<span class="amount">{secondAmount.toPrettyAmountString()}</span>
+		<span class="token">{unitFor(secondAmount.coin)}</span>
+	{:else if direction === 'remove-liquidity' && secondAmount}
+		<span class="amount green">{amount.toPrettyAmountString()}</span>
+		<span class="token green">{displayUnit}</span>
+		<span class="swap-arrow">+</span>
+		<span class="amount green">{secondAmount.toPrettyAmountString()}</span>
+		<span class="token green">{unitFor(secondAmount.coin)}</span>
+	{:else if direction === 'remove-liquidity' && lpInfo}
+		<span class="amount outgoing">{lpInfo}</span>
+		<span class="token outgoing">LP</span>
 	{:else}
 		{#if direction === 'contract'}
 			<span class="sm-caption">Limit:</span>

--- a/src/routes/(authed)/transactions/Table/tds/Type.svelte
+++ b/src/routes/(authed)/transactions/Table/tds/Type.svelte
@@ -1,19 +1,20 @@
 <script lang="ts">
-	let { direction, t }: { direction: 'incoming' | 'outgoing' | 'swap' | 'contract'; t: string } = $props();
+	let { direction, t }: { direction: 'incoming' | 'outgoing' | 'swap' | 'contract' | 'add-liquidity' | 'remove-liquidity'; t: string } = $props();
+
+	const badgeClass = $derived.by(() => {
+		if (direction === 'incoming') return 'deposit';
+		if (direction === 'swap') return 'swap';
+		if (direction === 'add-liquidity') return 'liquidity';
+		if (direction === 'remove-liquidity') return 'liquidity';
+		if (t.includes('withdraw')) return 'withdraw';
+		if (t.includes('stake')) return 'stake';
+		if (t.includes('reward')) return 'reward';
+		return 'default';
+	});
 </script>
 
 <td class="type-cell">
-	<span class={['badge', direction === 'incoming'
-			? 'deposit'
-			: direction === 'swap'
-				? 'swap'
-				: t.includes('withdraw')
-					? 'withdraw'
-					: t.includes('stake')
-						? 'stake'
-						: t.includes('reward')
-							? 'reward'
-							: 'default']}>
+	<span class={['badge', badgeClass]}>
 		{t.replaceAll('_', ' ')}
 	</span>
 </td>
@@ -48,6 +49,10 @@
 	.badge.stake {
 		background: rgba(111, 106, 248, 0.15);
 		color: #6f6af8;
+	}
+	.badge.liquidity {
+		background: rgba(59, 186, 220, 0.15);
+		color: #3bbad4;
 	}
 	.badge.reward {
 		background: var(--dash-badge-green-bg);

--- a/src/routes/(authed)/transactions/Table/tr/ContractTr.svelte
+++ b/src/routes/(authed)/transactions/Table/tr/ContractTr.svelte
@@ -34,47 +34,77 @@
 		}
 	}
 
-	// Parse the swap payload from call/execute ops.
-	// Two formats exist:
-	//   New router (Altera):  { type:"swap", asset_in, asset_out, amount_in, min_amount_out }
-	//   Old pool (legacy):    { type:"deposit", asset0, asset1, amount0, amount1 }
-	// Both are normalised to { asset0, amount0, asset1, amount1 } for display.
-	// isNewRouter flags the Altera format so we know to fetch the real amount_out from the
-	// indexer after confirmation (the payload only carries the slippage floor, not the actual fill).
-	const swapPayload = $derived.by(() => {
+	// ── Payload parsing ─────────────────────────────────────────────────────
+	// Parsed once and reused by swap / liquidity / fallback logic below.
+	const parsedPayload = $derived.by(() => {
 		try {
-			const parsed = JSON.parse(op.data.payload ?? '');
-			// New router format
-			if (
-				parsed?.type === 'swap' &&
-				parsed?.asset_in &&
-				parsed?.asset_out &&
-				parsed?.amount_in != null
-			) {
-				return {
-					asset0: String(parsed.asset_in).toLowerCase(),
-					amount0: String(parsed.amount_in),
-					asset1: String(parsed.asset_out).toLowerCase(),
-					// min_amount_out is a floor used while pending; replaced by actual fill once confirmed
-					amount1: String(parsed.min_amount_out ?? '0'),
-					isNewRouter: true
-				};
-			}
-			// Old pool format — amount1 is the actual received value, no indexer lookup needed
-			if (parsed?.asset0 && parsed?.asset1 && parsed?.amount0 != null && parsed?.amount1 != null) {
-				return { ...parsed, isNewRouter: false } as {
-					asset0: string; amount0: string; asset1: string; amount1: string; isNewRouter: false
-				};
-			}
-		} catch {}
+			return JSON.parse(op.data.payload ?? '') as Record<string, unknown>;
+		} catch {
+			return null;
+		}
+	});
+
+	// ── Operation classification ────────────────────────────────────────────
+	// Classify this contract call into one of: swap | add-liquidity | remove-liquidity | generic.
+	// The classification drives which amount/label/direction is used for both the
+	// table row and the side-popup detail view.
+	type OpKind = 'swap' | 'add-liquidity' | 'remove-liquidity' | 'generic';
+
+	const opKind: OpKind = $derived.by(() => {
+		if (op.data.action !== 'execute' || !parsedPayload) return 'generic';
+		const p = parsedPayload;
+
+		// Add liquidity: payload type="deposit" + 2 intents (both assets sent in)
+		if (
+			p.type === 'deposit' &&
+			p.asset0 && p.asset1 && p.amount0 != null && p.amount1 != null &&
+			(op.data.intents?.length ?? 0) >= 2
+		) return 'add-liquidity';
+
+		// Remove liquidity: payload type="withdrawal" + lp_amount present
+		if (p.type === 'withdrawal' && p.lp_amount != null) return 'remove-liquidity';
+
+		return 'generic';
+	});
+
+	// ── Swap detection ──────────────────────────────────────────────────────
+	// Two swap formats:
+	//   New router (Altera):  { type:"swap", asset_in, asset_out, amount_in, min_amount_out }
+	//   Old pool (legacy):    { type:"deposit", asset0, asset1, amount0, amount1 } (0-1 intents)
+	// Both normalised to { asset0, amount0, asset1, amount1 } for display.
+	const swapPayload = $derived.by(() => {
+		if (opKind !== 'generic' || op.data.action !== 'execute' || !parsedPayload) return null;
+		const p = parsedPayload;
+
+		// New router format
+		if (
+			p.type === 'swap' &&
+			p.asset_in && p.asset_out && p.amount_in != null
+		) {
+			return {
+				asset0: String(p.asset_in).toLowerCase(),
+				amount0: String(p.amount_in),
+				asset1: String(p.asset_out).toLowerCase(),
+				amount1: String(p.min_amount_out ?? '0'),
+				isNewRouter: true
+			};
+		}
+		// Old pool format — amount1 is the settled value. Only match when intent
+		// count ≤ 1 (add-liquidity has ≥ 2 intents and is already classified above).
+		if (
+			p.asset0 && p.asset1 && p.amount0 != null && p.amount1 != null &&
+			(!p.type || p.type === 'swap' || p.type === 'deposit')
+		) {
+			return { ...p, isNewRouter: false } as {
+				asset0: string; amount0: string; asset1: string; amount1: string; isNewRouter: false
+			};
+		}
 		return null;
 	});
 
-	const isSwap = $derived(op.data.action === 'execute' && swapPayload !== null);
+	const isSwap = $derived(swapPayload !== null);
 
 	// For confirmed new-router swaps, fetch the actual settled amount_out from the indexer.
-	// The payload only carries min_amount_out (the slippage floor), which is almost always
-	// lower than what the pool actually returned.
 	let indexerAmountOut = $state.raw<{ amount_out: number; asset_out: string } | null>(null);
 	let lastFetchedTxId = '';
 	$effect(() => {
@@ -94,33 +124,65 @@
 		});
 	});
 
-	// For swaps: fromAmount = what user sends (asset0), amount = what user receives (asset1).
-	// For other contract calls: amount comes from intents limit.
+	// ── Liquidity amounts ───────────────────────────────────────────────────
+	function coinFromAsset(asset: string): typeof Coin[keyof typeof Coin] {
+		return Coin[asset.split('_')[0] as keyof typeof Coin] || Coin.unk;
+	}
+
+	// Add-liquidity: both token amounts the user deposited into the pool.
+	const liqAmount0 = $derived(
+		opKind === 'add-liquidity' && parsedPayload
+			? new CoinAmount(String(parsedPayload.amount0), coinFromAsset(String(parsedPayload.asset0)), true)
+			: null
+	);
+	const liqAmount1 = $derived(
+		opKind === 'add-liquidity' && parsedPayload
+			? new CoinAmount(String(parsedPayload.amount1), coinFromAsset(String(parsedPayload.asset1)), true)
+			: null
+	);
+
+	// Remove-liquidity: the ledger contains the actual amounts the user received back.
+	// Fall back to LP token count from the payload when ledger is unavailable (pending tx).
+	const removeLiqAmount0 = $derived.by(() => {
+		if (opKind !== 'remove-liquidity') return null;
+		const entry = tx.ledger?.[0];
+		if (entry) return new CoinAmount(entry.amount, coinFromAsset(entry.asset), true);
+		return null;
+	});
+	const removeLiqAmount1 = $derived.by(() => {
+		if (opKind !== 'remove-liquidity') return null;
+		const entry = tx.ledger?.[1];
+		if (entry) return new CoinAmount(entry.amount, coinFromAsset(entry.asset), true);
+		return null;
+	});
+	const lpAmount = $derived(
+		opKind === 'remove-liquidity' && parsedPayload
+			? String(parsedPayload.lp_amount)
+			: null
+	);
+
+	// ── Swap amounts ────────────────────────────────────────────────────────
 	const fromAmount = $derived(
 		isSwap && swapPayload
-			? new CoinAmount(
-					swapPayload.amount0,
-					Coin[swapPayload.asset0.split('_')[0] as keyof typeof Coin] || Coin.unk,
-					true
-				)
+			? new CoinAmount(swapPayload.amount0, coinFromAsset(swapPayload.asset0), true)
 			: null
 	);
 	const amount = $derived.by(() => {
 		if (isSwap && swapPayload) {
-			// Confirmed new-router swap: prefer actual fill from indexer over the min floor
 			if (indexerAmountOut && !tx.isPending) {
 				return new CoinAmount(
 					indexerAmountOut.amount_out,
-					Coin[indexerAmountOut.asset_out.split('_')[0] as keyof typeof Coin] || Coin.unk,
+					coinFromAsset(indexerAmountOut.asset_out),
 					true
 				);
 			}
-			return new CoinAmount(
-				swapPayload.amount1,
-				Coin[swapPayload.asset1.split('_')[0] as keyof typeof Coin] || Coin.unk,
-				true
-			);
+			return new CoinAmount(swapPayload.amount1, coinFromAsset(swapPayload.asset1), true);
 		}
+		// Add-liquidity: show first token amount as the primary display
+		if (opKind === 'add-liquidity' && liqAmount0) return liqAmount0;
+		// Remove-liquidity: show first received amount from ledger
+		if (opKind === 'remove-liquidity' && removeLiqAmount0) return removeLiqAmount0;
+		// Generic: fall back to first intent limit
 		const intents = op.data.intents;
 		const amt = intents?.[0]?.args?.limit ?? '0';
 		const coinVal = intents?.[0]?.args?.token ?? Coin.hive.value;
@@ -134,16 +196,20 @@
 		});
 	});
 
+	// ── Display type & direction ────────────────────────────────────────────
 	const displayType: string = $derived.by(() => {
 		if (isSwap) return 'swap';
-		try {
-			const payloadStr = op.data.payload;
-			if (typeof payloadStr === 'string') {
-				const parsed = JSON.parse(payloadStr);
-				if (parsed?.type) return parsed.type.replace(/_/g, ' ');
-			}
-		} catch {}
+		if (opKind === 'add-liquidity') return 'add liquidity';
+		if (opKind === 'remove-liquidity') return 'remove liquidity';
+		if (parsedPayload?.type) return String(parsedPayload.type).replace(/_/g, ' ');
 		return op.data.action ?? op.type ?? 'call';
+	});
+
+	const direction: 'swap' | 'add-liquidity' | 'remove-liquidity' | 'contract' = $derived.by(() => {
+		if (isSwap) return 'swap';
+		if (opKind === 'add-liquidity') return 'add-liquidity';
+		if (opKind === 'remove-liquidity') return 'remove-liquidity';
+		return 'contract';
 	});
 
 	const popupTitle = $derived(
@@ -163,8 +229,14 @@
 	<td class="date">{moment(getTimestamp(tx)).format('MMM DD')}</td>
 	<ContractId address={op.data.contract_id ?? ''} />
 	<Status status={tx.status} />
-	<Amount {amount} {fromAmount} direction={isSwap ? 'swap' : 'contract'} />
-	<Type direction={isSwap ? 'swap' : 'contract'} t={displayType} />
+	<Amount
+		{amount}
+		{fromAmount}
+		{direction}
+		secondAmount={opKind === 'add-liquidity' ? liqAmount1 : removeLiqAmount1}
+		lpInfo={lpAmount}
+	/>
+	<Type {direction} t={displayType} />
 </tr>
 
 {#snippet contractRowContent()}
@@ -177,6 +249,15 @@
 		<div class="amount">
 			{#if isSwap && fromAmount}
 				{fromAmount.toPrettyString()} → {amount.toPrettyString()}
+			{:else if opKind === 'add-liquidity' && liqAmount0 && liqAmount1}
+				{liqAmount0.toPrettyString()} + {liqAmount1.toPrettyString()}
+			{:else if opKind === 'remove-liquidity' && removeLiqAmount0 && removeLiqAmount1}
+				{removeLiqAmount0.toPrettyString()} + {removeLiqAmount1.toPrettyString()}
+				{#if lpAmount}
+					<span class="approx-usd">Burned {lpAmount} LP tokens</span>
+				{/if}
+			{:else if opKind === 'remove-liquidity' && lpAmount}
+				{lpAmount} LP tokens
 			{:else}
 				{amount.toPrettyString()}
 			{/if}

--- a/src/routes/(authed)/transactions/mock/+page.svelte
+++ b/src/routes/(authed)/transactions/mock/+page.svelte
@@ -52,8 +52,8 @@
 		toTx(sampleSwapNewHbdToHive),
 		toTx(sampleSwapNewBtcToHbd),
 		toTx(sampleSwapOld),
-		toTx(sampleAddLiquidity, '2026-01-02T10:00:00'),
-		toTx(sampleRemoveLiquidity, '2026-01-01T10:00:00'),
+		toTx(sampleAddLiquidity),
+		toTx(sampleRemoveLiquidity),
 		toTx(sampleBtcTransferToHive),
 		toTx(sampleBtcTransferToEvm),
 		toTx(sampleBtcUnmap),
@@ -115,8 +115,8 @@
 			<span class="tag verified">✅ Swap HBD→HIVE (new router)</span>
 			<span class="tag verified">✅ Swap BTC→HBD (old pool)</span>
 			<span class="tag verified">✅ Swap old pool format</span>
-			<span class="tag constructed">🔧 Add Liquidity</span>
-			<span class="tag constructed">🔧 Remove Liquidity</span>
+			<span class="tag verified">✅ Add Liquidity</span>
+			<span class="tag verified">✅ Remove Liquidity</span>
 			<span class="tag verified">✅ BTC Transfer → Hive acct</span>
 			<span class="tag verified">✅ BTC Transfer → EVM addr</span>
 			<span class="tag verified">✅ BTC Unmap (withdraw)</span>

--- a/src/routes/(authed)/transactions/mockUp.ts
+++ b/src/routes/(authed)/transactions/mockUp.ts
@@ -501,20 +501,20 @@ export const sampleSwapOld = {
 	]
 };
 
-// ─── 10. ADD LIQUIDITY 🔧 ───────────────────────────────────────────────────
-// Deposit both sides of a pool pair via the DEX router.
-// payload.type = "deposit" on DEX_ROUTER — same key as old swap (#9) but on the router.
-// Both amount0 + amount1 are sent IN (no output amount in the payload).
+// ─── 10. ADD LIQUIDITY ✅ ────────────────────────────────────────────────────
+// Deposit both sides of a pool pair into the AMM pool.
+// payload.type = "deposit" — same key as old swap (#9) but distinguished by
+// having 2 intents (both assets sent in) vs 0-1 for swaps.
+// Verified from hive:risingstarhub tx feb435c8917709863e9254b0249f8210579beb08.
 //
-// Distinguish from old swap: contract_id === DEX_ROUTER and payload.type === "deposit".
-//
-// TR component : ContractTr.svelte (currently shows as generic contract op)
-// Current display: first intent amount as "limit" → not ideal
-// Ideal display: amount0 asset0 + amount1 asset1 | Add Liquidity
+// TR component : ContractTr.svelte
+// Table display:
+//   Date    | pool addr (short) | Status | 7.038 HBD + 100.000 HIVE | Add Liquidity
 export const sampleAddLiquidity = {
-	id: 'sample-add-liquidity',
+	id: 'feb435c8917709863e9254b0249f8210579beb08',
 	type: 'hive',
 	status: 'CONFIRMED',
+	anchr_ts: '2026-05-11T10:00:00',
 	rc_limit: 0,
 	ledger: [],
 	ops: [
@@ -525,37 +525,43 @@ export const sampleAddLiquidity = {
 				action: 'execute',
 				contract_id: DEX_ROUTER,
 				intents: [
-					{ type: 'transfer.allow', args: { limit: '50000', token: 'hbd' } },
-					{ type: 'transfer.allow', args: { limit: '12345', token: 'hive' } }
+					{ type: 'transfer.allow', args: { limit: '7038', token: 'hbd' } },
+					{ type: 'transfer.allow', args: { limit: '100000', token: 'hive' } }
 				],
 				payload: JSON.stringify({
-					type: 'deposit', // "add liquidity" instruction to the router
+					type: 'deposit',
 					version: '1.0.0',
-					asset0: 'hbd',    // alphabetical order enforced by getAddLiquidityOp()
+					asset0: 'hbd',
 					asset1: 'hive',
-					amount0: '50000', // 50.000 HBD
-					amount1: '12345', // 12.345 HIVE
-					recipient: 'hive:milo-hpr'
+					amount0: '7038',   // 7.038 HBD
+					amount1: '100000', // 100.000 HIVE
+					recipient: 'hive:risingstarhub'
 				}),
-				rc_limit: 100000
+				rc_limit: 2000
 			}
 		}
 	]
 };
 
-// ─── 11. REMOVE LIQUIDITY 🔧 ────────────────────────────────────────────────
-// Burn LP tokens to withdraw both underlying assets from a pool via the DEX router.
+// ─── 11. REMOVE LIQUIDITY ✅ ────────────────────────────────────────────────
+// Burn LP tokens to withdraw both underlying assets from the AMM pool.
 // payload.type = "withdrawal". No intents (user is not sending assets in).
-// lp_amount = LP tokens to burn; actual output amounts come from ledger after confirmation.
+// lp_amount = LP tokens burned; actual output amounts come from ledger.
+// Verified from hive:forkyishere tx b5da6afc5089e6d789f1f433cab62a2a3fd6ff13.
 //
-// TR component : ContractTr.svelte (currently shows as generic contract op with 0 amount)
-// Ideal display: lp_amount LP tokens | Remove Liquidity
+// TR component : ContractTr.svelte
+// Table display:
+//   Date    | pool addr (short) | Status | 13.858 HBD + 186.933 HIVE | Remove Liquidity
 export const sampleRemoveLiquidity = {
-	id: 'sample-remove-liquidity',
+	id: 'b5da6afc5089e6d789f1f433cab62a2a3fd6ff13',
 	type: 'hive',
 	status: 'CONFIRMED',
+	anchr_ts: '2026-05-04T10:00:00',
 	rc_limit: 0,
-	ledger: [],
+	ledger: [
+		{ amount: 13858, asset: 'hbd', from: `contract:${DEX_ROUTER}`, to: 'hive:forkyishere', type: 'transfer', memo: '' },
+		{ amount: 186933, asset: 'hive', from: `contract:${DEX_ROUTER}`, to: 'hive:forkyishere', type: 'transfer', memo: '' }
+	],
 	ops: [
 		{
 			index: 0,
@@ -563,16 +569,16 @@ export const sampleRemoveLiquidity = {
 			data: {
 				action: 'execute',
 				contract_id: DEX_ROUTER,
-				intents: [], // no assets sent in
+				intents: [],
 				payload: JSON.stringify({
-					type: 'withdrawal', // "remove liquidity"
+					type: 'withdrawal',
 					version: '1.0.0',
 					asset0: 'hbd',
 					asset1: 'hive',
-					lp_amount: '2594', // LP tokens to burn
-					recipient: 'hive:milo-hpr'
+					lp_amount: '50331', // LP tokens burned
+					recipient: 'hive:forkyishere'
 				}),
-				rc_limit: 100000
+				rc_limit: 2000
 			}
 		}
 	]

--- a/src/routes/[...path]/+page.svelte
+++ b/src/routes/[...path]/+page.svelte
@@ -1,0 +1,2 @@
+<!-- This page is never rendered — the load() in +page.ts always throws a 404.
+     The file must exist for SvelteKit to recognise [...path] as a valid catch-all route. -->

--- a/src/routes/[...path]/+page.ts
+++ b/src/routes/[...path]/+page.ts
@@ -3,5 +3,5 @@ import { error } from '@sveltejs/kit';
 export const prerender = false;
 
 export function load() {
-	error(404, 'Page not found');
+	error(404, { message: 'Page not found' });
 }

--- a/static/eth/eth.svg
+++ b/static/eth/eth.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="16" fill="#627EEA"/>
+  <g fill="#fff" fill-rule="nonzero">
+    <path fill-opacity=".6" d="M16.498 4v8.87l7.497 3.35z"/>
+    <path d="M16.498 4L9 16.22l7.498-3.35z"/>
+    <path fill-opacity=".6" d="M16.498 21.968v6.027L24 17.616z"/>
+    <path d="M16.498 27.995v-6.028L9 17.616z"/>
+    <path fill-opacity=".2" d="M16.498 20.573l7.497-4.353-7.497-3.348z"/>
+    <path fill-opacity=".6" d="M9 16.22l7.498 4.353v-7.701z"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

### Bug Fixes
- **EVM balance**: Reown returns EIP-55 checksummed addresses but the VSC indexer keys DIDs
  lowercase — mismatch caused EVM accounts to show zero balance and no transactions. Fixed by
  normalising to lowercase at both DID construction points
- **Swap amount**: Race condition where a stale exchange-rate async resolved after the pool calc
  and overwrote the correct `toAmount` — fixed with a guard that discards the stale result
- **Swap popup**: "Done" button on the post-broadcast Complete popup was a no-op in the swap
  flow, leaving the dialog open. Fixed to follow the same pattern as the auto-close timer
- **Transactions**: Show actual swap output instead of `min_amount_out`
- **Asset modal**: Modal was not closing on token select; dialog close button repositioned
- **Coin amounts**: Removed trailing dot from zero-decimal amounts (e.g. sats displayed as `1.` → `1`)
- **Swap price fetch**: Currency price queries could hang forever on failure (TTL was dead code,
  `isFetching` never reset). Fixed the querier cache so it retries correctly and shows
  "Price unavailable" when prices can't be loaded
- **Swap loading states**: "You Receive" row and "Min amount received" in the review modal now
  show a loading indicator while pool data is pending, instead of stale or empty values
- **Swap pool data**: Pool fetch could silently fail, leaving fee details (Expected Output,
  Protocol Fee, Min amount received) hidden while Review Swap remained clickable. Now retries
  3× with exponential backoff, gates the Review button on pool data, and shows a warning with
  a Retry button when all attempts fail

### Routing
- Unknown URLs returned 500 on Vercel — `[...path]/+page.svelte` was missing so SvelteKit
  silently ignored the catch-all, bypassing the 404 handler

### Pools
- Clicking a transaction row in the pool detail now opens an inline detail popup with swap
  amounts, provider, TX hash, and a VSC explorer link
- Restored Add/Remove Liquidity buttons broken by a strict context guard regression
- Fee Earned column now labels each row as **LP** or **Protocol**, with per-fee USD breakdown

### Swap
- In the token picker, the token already selected on one side is now shown **disabled** (not
  hidden) in the other side's picker, consistent with the QuickSwap behaviour

### Transactions
- Transaction detail redesigned as a centred modal popup instead of a side drawer

### Dashboard
- Responsive grid restructured: 1-col (mobile), 2-col (1024–1919px), 3-col (≥1920px)
- QuickSwap appears directly below Balance in single-column layout
- RC and Market Prices cards stretch to fill available height in multi-column layouts
- Added Ethereum row to Market Prices (grayed out / coming soon) with live price and 24h
  change from CoinGecko; fetch is isolated so a CoinGecko failure never affects BTC/Hive/HBD