### PR TITLE
multi-node config with health-based auto-selection

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,7 @@
+CMC_API_KEY=placeholder
+COINBASE_ID=placeholder
+COINBASE_PRIVATE_KEY=placeholder
+ALTERA_ORIGIN=https://altera.okinoko.io
+PUBLIC_INDEXER_NODES=https://api.okinoko.io/hasura,https://indexer.magi.milohpr.com
+PUBLIC_VSC_API_NODES=https://api.vsc.eco,https://vsc.techcoderx.com
+PUBLIC_HIVE_RPC_NODES=https://api.hive.blog,https://api.openhive.network,https://techcoderx.com,https://api.deathwing.me

--- a/.env
+++ b/.env
@@ -1,7 +1,0 @@
-CMC_API_KEY=placeholder
-COINBASE_ID=placeholder
-COINBASE_PRIVATE_KEY=placeholder
-ALTERA_ORIGIN=https://altera.okinoko.io
-PUBLIC_INDEXER_NODES=https://api.okinoko.io/hasura,https://indexer.magi.milohpr.com
-PUBLIC_VSC_API_NODES=https://api.vsc.eco,https://vsc.techcoderx.com
-PUBLIC_HIVE_RPC_NODES=https://api.hive.blog,https://api.openhive.network,https://techcoderx.com,https://api.deathwing.me

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Altera are documented here.
 
+## [0.3.3] — 2026-05-19
+
+### Infrastructure
+- Multi-node failover: indexer / VSC API / Hive RPC endpoints are health-checked on app open and the freshest node is auto-selected (5-min cache); optional `PUBLIC_INDEXER_NODES` / `PUBLIC_VSC_API_NODES` / `PUBLIC_HIVE_RPC_NODES` runtime overrides, hardcoded fallbacks otherwise
+- Preferences: per-endpoint "Custom" toggle to pin a specific node (off = automatic, shows the auto-selected node)
+
 ## [0.3.2] — 2026-05-18
 
 ### Swap

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,6 @@
 import { browser } from '$app/environment';
 import { HoudiniClient } from '$houdini';
+import { resolveNodeUrl } from '$lib/nodeSelection/select';
 // const DEFAULT_GQL_URL="http://localhost:8080" // for running backend locally
 export const DEFAULT_GQL_URL = 'https://api.vsc.eco';
 
@@ -27,7 +28,7 @@ export const DEX_ROUTER_CONTRACT_ID = (() => {
 		: 'vsc1Brvi4YZHLkocYNAFd7Gf1JpsPjzNnv4i45';
 })();
 
-export const currentGqlUrl = (browser && localStorage.getItem(keyVscGql)) || DEFAULT_GQL_URL;
+export const currentGqlUrl = browser ? resolveNodeUrl('vsc') : DEFAULT_GQL_URL;
 
 export const vscNetworkId =
 	(browser && localStorage.getItem(keyVscNetworkId)) || DEFAULT_VSC_NET_ID;
@@ -36,10 +37,8 @@ export const vscNetworkId =
 export const isVscTestnet = (): boolean => vscNetworkId === 'vsc-testnet';
 
 /** Configured Magi indexer base URL — falls back to okinoko/prod. */
-export const getMagiIndexerBaseUrl = (): string => {
-	const stored = browser && localStorage.getItem(keyMagiIndexer);
-	return stored || DEFAULT_MAGI_INDEXER_URL;
-};
+export const getMagiIndexerBaseUrl = (): string =>
+	browser ? resolveNodeUrl('indexer') : DEFAULT_MAGI_INDEXER_URL;
 
 /** Fully-qualified Hasura GraphQL URL (base + /v1/graphql).
  *  Use this when you need to issue a query. */

--- a/src/lib/auth/hive/index.ts
+++ b/src/lib/auth/hive/index.ts
@@ -6,6 +6,7 @@ import { goto } from '$app/navigation';
 import { getAccounts } from '@aioha/aioha/build/rpc';
 import { postingMetadataFromString, type Account } from './accountTypes';
 import { vscNetworkId, isVscTestnet } from '../../../client';
+import { resolveNodeUrl } from '$lib/nodeSelection/select';
 
 // Hive L1 chain IDs. Mainnet has the well-known default; testnet uses a
 // different chain ID and MetaMask Snap refuses to sign anything unless the
@@ -18,7 +19,7 @@ const HIVE_TESTNET_CHAIN_ID =
 // Hive L1 RPC endpoints. Testnet must NOT fall through to api.hive.blog or
 // broadcasts get rejected ("missing active authority") because the mainnet
 // node can't verify a testnet-chain-id signature.
-const HIVE_MAINNET_API = 'https://api.hive.blog';
+const HIVE_MAINNET_API = browser ? resolveNodeUrl('hive') : 'https://api.hive.blog';
 const HIVE_TESTNET_API = 'https://testnet.techcoderx.com';
 
 async function getProfilePicUrl(username: string) {

--- a/src/lib/magiTransactions/dhive.ts
+++ b/src/lib/magiTransactions/dhive.ts
@@ -1,5 +1,7 @@
 import { Client, type ClientOptions } from '@hiveio/dhive';
 import { browser } from '$app/environment';
+import { resolveNodeUrl } from '$lib/nodeSelection/select';
+import { hiveRpcNodes } from '$lib/nodeSelection/env';
 
 export const keyHiveApiList = 'hive-api';
 export const keyHiveApiAllowBackups = 'hive-api-allow-backup';
@@ -17,17 +19,11 @@ export const DEFAULT_HIVE_APIS = [
 ];
 
 const urls: string[] = (() => {
-	const storedStr = browser && localStorage.getItem(keyHiveApiList);
+	const primary = browser ? resolveNodeUrl('hive') : 'https://api.hive.blog';
 	const allowBackupStr = browser && localStorage.getItem(keyHiveApiAllowBackups);
-	if (storedStr) {
-		const api: string = storedStr;
-		const allowBackups: boolean = allowBackupStr ? allowBackupStr === 'true' : true;
-		if (!allowBackups) {
-			return [api];
-		}
-		return Array.from(new Set([api, ...DEFAULT_HIVE_APIS]));
-	}
-	return DEFAULT_HIVE_APIS;
+	const allowBackups = allowBackupStr ? allowBackupStr === 'true' : true;
+	if (!allowBackups) return [primary];
+	return Array.from(new Set([primary, ...hiveRpcNodes]));
 })();
 
 const opts: ClientOptions = {

--- a/src/lib/nodeSelection/env.test.ts
+++ b/src/lib/nodeSelection/env.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { parseNodeList } from './env';
+
+describe('parseNodeList', () => {
+	it('splits, trims, drops empties, strips trailing slashes', () => {
+		expect(parseNodeList(' https://a.com/ , https://b.com ,, ', ['x'])).toEqual([
+			'https://a.com',
+			'https://b.com'
+		]);
+	});
+	it('prefixes bare hosts with https://', () => {
+		expect(parseNodeList('vsc.techcoderx.com', ['x'])).toEqual(['https://vsc.techcoderx.com']);
+	});
+	it('keeps indexer base paths intact', () => {
+		expect(parseNodeList('https://api.okinoko.io/hasura', ['x'])).toEqual([
+			'https://api.okinoko.io/hasura'
+		]);
+	});
+	it('falls back when undefined or empty', () => {
+		expect(parseNodeList(undefined, ['f1', 'f2'])).toEqual(['f1', 'f2']);
+		expect(parseNodeList('   ', ['f1'])).toEqual(['f1']);
+	});
+});

--- a/src/lib/nodeSelection/env.ts
+++ b/src/lib/nodeSelection/env.ts
@@ -1,8 +1,7 @@
-import {
-	PUBLIC_INDEXER_NODES,
-	PUBLIC_VSC_API_NODES,
-	PUBLIC_HIVE_RPC_NODES
-} from '$env/static/public';
+// Dynamic (runtime) public env so a missing key is `undefined` instead of a
+// hard build failure — the FALLBACK_* lists below cover the unset case, and
+// production can supply these without committing an .env to the repo.
+import { env } from '$env/dynamic/public';
 
 export const FALLBACK_INDEXER_NODES = [
 	'https://api.okinoko.io/hasura',
@@ -28,6 +27,6 @@ export function parseNodeList(raw: string | undefined, fallback: string[]): stri
 	return list.length > 0 ? list : [...fallback];
 }
 
-export const indexerNodes = parseNodeList(PUBLIC_INDEXER_NODES, FALLBACK_INDEXER_NODES);
-export const vscApiNodes = parseNodeList(PUBLIC_VSC_API_NODES, FALLBACK_VSC_API_NODES);
-export const hiveRpcNodes = parseNodeList(PUBLIC_HIVE_RPC_NODES, FALLBACK_HIVE_RPC_NODES);
+export const indexerNodes = parseNodeList(env.PUBLIC_INDEXER_NODES, FALLBACK_INDEXER_NODES);
+export const vscApiNodes = parseNodeList(env.PUBLIC_VSC_API_NODES, FALLBACK_VSC_API_NODES);
+export const hiveRpcNodes = parseNodeList(env.PUBLIC_HIVE_RPC_NODES, FALLBACK_HIVE_RPC_NODES);

--- a/src/lib/nodeSelection/env.ts
+++ b/src/lib/nodeSelection/env.ts
@@ -1,0 +1,33 @@
+import {
+	PUBLIC_INDEXER_NODES,
+	PUBLIC_VSC_API_NODES,
+	PUBLIC_HIVE_RPC_NODES
+} from '$env/static/public';
+
+export const FALLBACK_INDEXER_NODES = [
+	'https://api.okinoko.io/hasura',
+	'https://indexer.magi.milohpr.com'
+];
+export const FALLBACK_VSC_API_NODES = ['https://api.vsc.eco', 'https://vsc.techcoderx.com'];
+export const FALLBACK_HIVE_RPC_NODES = [
+	'https://api.hive.blog',
+	'https://api.openhive.network',
+	'https://techcoderx.com',
+	'https://api.deathwing.me'
+];
+
+/** Parse a comma-separated node list; bare hosts get https://; trailing
+ *  slashes stripped; falls back to `fallback` when the result is empty. */
+export function parseNodeList(raw: string | undefined, fallback: string[]): string[] {
+	const list = (raw ?? '')
+		.split(',')
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0)
+		.map((s) => (/^https?:\/\//i.test(s) ? s : `https://${s}`))
+		.map((s) => s.replace(/\/+$/, ''));
+	return list.length > 0 ? list : [...fallback];
+}
+
+export const indexerNodes = parseNodeList(PUBLIC_INDEXER_NODES, FALLBACK_INDEXER_NODES);
+export const vscApiNodes = parseNodeList(PUBLIC_VSC_API_NODES, FALLBACK_VSC_API_NODES);
+export const hiveRpcNodes = parseNodeList(PUBLIC_HIVE_RPC_NODES, FALLBACK_HIVE_RPC_NODES);

--- a/src/lib/nodeSelection/probes.test.ts
+++ b/src/lib/nodeSelection/probes.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { probeIndexer, probeVscApi } from './probes';
+
+afterEach(() => vi.unstubAllGlobals());
+
+function mockFetch(handler: (url: string, init?: RequestInit) => unknown) {
+	vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+		const body = handler(url, init);
+		if (body instanceof Error) throw body;
+		return { ok: true, status: 200, json: async () => body } as Response;
+	}));
+}
+
+describe('probeIndexer', () => {
+	it('picks the node with the most recent contract_logs.ts', async () => {
+		mockFetch((url) => {
+			if (url.startsWith('https://old'))
+				return { data: { contract_logs: [{ ts: '2026-05-01T00:00:00Z' }] } };
+			return { data: { contract_logs: [{ ts: '2026-05-19T00:00:00Z' }] } };
+		});
+		const pick = await probeIndexer(['https://old.example', 'https://new.example']);
+		expect(pick).toBe('https://new.example');
+	});
+	it('falls back to first node when all fail', async () => {
+		mockFetch(() => new Error('down'));
+		const pick = await probeIndexer(['https://a', 'https://b']);
+		expect(pick).toBe('https://a');
+	});
+});
+
+describe('probeVscApi', () => {
+	it('picks the node with the highest last_processed_block', async () => {
+		mockFetch((url) => {
+			if (url.startsWith('https://lo'))
+				return { data: { localNodeInfo: { last_processed_block: 100 } } };
+			return { data: { localNodeInfo: { last_processed_block: 999 } } };
+		});
+		const pick = await probeVscApi(['https://lo.example', 'https://hi.example']);
+		expect(pick).toBe('https://hi.example');
+	});
+});

--- a/src/lib/nodeSelection/probes.test.ts
+++ b/src/lib/nodeSelection/probes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { probeIndexer, probeVscApi } from './probes';
+import { probeIndexer, probeVscApi, probeHiveRpc } from './probes';
 
 afterEach(() => vi.unstubAllGlobals());
 
@@ -37,5 +37,26 @@ describe('probeVscApi', () => {
 		});
 		const pick = await probeVscApi(['https://lo.example', 'https://hi.example']);
 		expect(pick).toBe('https://hi.example');
+	});
+});
+
+describe('probeHiveRpc', () => {
+	it('ranks by head_block_number, /health only as tie-breaker', async () => {
+		mockFetch((url, init) => {
+			const isRpc = init?.method === 'POST';
+			if (url.startsWith('https://lo')) {
+				if (!isRpc) return {}; // /health 200 but lower block
+				return { result: { head_block_number: 1000 } };
+			}
+			if (!isRpc) return new Error('no /health'); // hi: no health endpoint
+			return { result: { head_block_number: 9999 } };
+		});
+		const pick = await probeHiveRpc(['https://lo.example', 'https://hi.example']);
+		expect(pick).toBe('https://hi.example'); // higher head wins despite no /health
+	});
+	it('falls back to first node when all fail', async () => {
+		mockFetch(() => new Error('down'));
+		const pick = await probeHiveRpc(['https://h1', 'https://h2']);
+		expect(pick).toBe('https://h1');
 	});
 });

--- a/src/lib/nodeSelection/probes.ts
+++ b/src/lib/nodeSelection/probes.ts
@@ -80,3 +80,36 @@ export async function probeVscApi(nodes: string[]): Promise<string> {
 	);
 	return pickFreshest(nodes, results);
 }
+
+export async function probeHiveRpc(nodes: string[]): Promise<string> {
+	const results = await Promise.allSettled(
+		nodes.map((origin) =>
+			withTimeout(async (signal): Promise<ProbeResult> => {
+				const base = origin.replace(/\/+$/, '');
+				let healthy = false;
+				try {
+					const h = await fetch(base + '/health', { signal });
+					healthy = h.ok;
+				} catch {
+					healthy = false;
+				}
+				const json = (await postJson(
+					base,
+					{
+						jsonrpc: '2.0',
+						method: 'database_api.get_dynamic_global_properties',
+						params: {},
+						id: 1
+					},
+					signal
+				)) as { result?: { head_block_number?: number } };
+				const head = json?.result?.head_block_number;
+				if (head == null) throw new Error('no head_block_number');
+				// Primary rank = head_block_number; /health adds a hair so a
+				// healthy node beats an unhealthy one only at equal height.
+				return { url: origin, freshness: Number(head) * 10 + (healthy ? 1 : 0) };
+			})
+		)
+	);
+	return pickFreshest(nodes, results);
+}

--- a/src/lib/nodeSelection/probes.ts
+++ b/src/lib/nodeSelection/probes.ts
@@ -1,0 +1,82 @@
+const PROBE_TIMEOUT_MS = 3000;
+
+export interface ProbeResult {
+	url: string;
+	freshness: number;
+}
+
+function withTimeout<T>(
+	fn: (signal: AbortSignal) => Promise<T>,
+	ms = PROBE_TIMEOUT_MS
+): Promise<T> {
+	const ctrl = new AbortController();
+	const t = setTimeout(() => ctrl.abort(), ms);
+	return fn(ctrl.signal).finally(() => clearTimeout(t));
+}
+
+async function postJson(
+	url: string,
+	body: unknown,
+	signal: AbortSignal
+): Promise<Record<string, unknown>> {
+	const res = await fetch(url, {
+		method: 'POST',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify(body),
+		signal
+	});
+	if (!res.ok) throw new Error(`HTTP ${res.status}`);
+	return (await res.json()) as Record<string, unknown>;
+}
+
+/** Highest `freshness` among fulfilled probes; `nodes[0]` if none responded. */
+function pickFreshest(
+	nodes: string[],
+	results: PromiseSettledResult<ProbeResult>[]
+): string {
+	let best: ProbeResult | null = null;
+	for (const r of results) {
+		if (r.status === 'fulfilled' && (best === null || r.value.freshness > best.freshness)) {
+			best = r.value;
+		}
+	}
+	return best?.url ?? nodes[0];
+}
+
+export async function probeIndexer(nodes: string[]): Promise<string> {
+	const query = 'query{contract_logs(order_by:{ts:desc},limit:1){id log ts}}';
+	const results = await Promise.allSettled(
+		nodes.map((base) =>
+			withTimeout(async (signal): Promise<ProbeResult> => {
+				const json = (await postJson(
+					base.replace(/\/+$/, '') + '/v1/graphql',
+					{ query },
+					signal
+				)) as { data?: { contract_logs?: Array<{ ts?: string }> } };
+				const ts = json?.data?.contract_logs?.[0]?.ts;
+				if (ts == null) throw new Error('no contract_logs');
+				return { url: base, freshness: new Date(ts).getTime() };
+			})
+		)
+	);
+	return pickFreshest(nodes, results);
+}
+
+export async function probeVscApi(nodes: string[]): Promise<string> {
+	const query = 'query{localNodeInfo{last_processed_block}}';
+	const results = await Promise.allSettled(
+		nodes.map((origin) =>
+			withTimeout(async (signal): Promise<ProbeResult> => {
+				const json = (await postJson(
+					origin.replace(/\/+$/, '') + '/api/v1/graphql',
+					{ query },
+					signal
+				)) as { data?: { localNodeInfo?: { last_processed_block?: number } } };
+				const blk = json?.data?.localNodeInfo?.last_processed_block;
+				if (blk == null) throw new Error('no localNodeInfo');
+				return { url: origin, freshness: Number(blk) };
+			})
+		)
+	);
+	return pickFreshest(nodes, results);
+}

--- a/src/lib/nodeSelection/select.test.ts
+++ b/src/lib/nodeSelection/select.test.ts
@@ -14,7 +14,7 @@ vi.mock('./env', () => ({
 	hiveRpcNodes: ['https://hive-default']
 }));
 
-import { resolveNodeUrl, refreshNode, isManualMode } from './select';
+import { resolveNodeUrl, refreshNode, isManualMode, autoSelectedNodeUrl } from './select';
 
 class MemStorage {
 	m = new Map<string, string>();
@@ -52,6 +52,13 @@ describe('resolveNodeUrl precedence', () => {
 		localStorage.setItem('vsc-gql-url', 'https://legacy-custom');
 		expect(isManualMode('vsc')).toBe(true);
 		expect(resolveNodeUrl('vsc')).toBe('https://legacy-custom');
+	});
+	it('autoSelectedNodeUrl ignores manual override (cache → env first)', () => {
+		expect(autoSelectedNodeUrl('indexer')).toBe('https://idx-default');
+		localStorage.setItem('node-auto-indexer', 'https://cached-idx');
+		localStorage.setItem('node-mode-indexer', 'manual');
+		localStorage.setItem('magi-indexer-url', 'https://my-manual');
+		expect(autoSelectedNodeUrl('indexer')).toBe('https://cached-idx');
 	});
 	it('explicit auto mode is respected even if a legacy key lingers', () => {
 		localStorage.setItem('vsc-gql-url', 'https://legacy-custom');

--- a/src/lib/nodeSelection/select.test.ts
+++ b/src/lib/nodeSelection/select.test.ts
@@ -47,6 +47,19 @@ describe('resolveNodeUrl precedence', () => {
 		expect(isManualMode('indexer')).toBe(true);
 		expect(resolveNodeUrl('indexer')).toBe('https://my-manual');
 	});
+	it('legacy migration: manual key set + no mode key → manual', () => {
+		localStorage.setItem('node-auto-vsc', 'https://cached-vsc');
+		localStorage.setItem('vsc-gql-url', 'https://legacy-custom');
+		expect(isManualMode('vsc')).toBe(true);
+		expect(resolveNodeUrl('vsc')).toBe('https://legacy-custom');
+	});
+	it('explicit auto mode is respected even if a legacy key lingers', () => {
+		localStorage.setItem('vsc-gql-url', 'https://legacy-custom');
+		localStorage.setItem('node-mode-vsc', 'auto');
+		localStorage.setItem('node-auto-vsc', 'https://cached-vsc');
+		expect(isManualMode('vsc')).toBe(false);
+		expect(resolveNodeUrl('vsc')).toBe('https://cached-vsc');
+	});
 });
 
 describe('refreshNode', () => {

--- a/src/lib/nodeSelection/select.test.ts
+++ b/src/lib/nodeSelection/select.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+// $app/environment → pretend we're in the browser
+vi.mock('$app/environment', () => ({ browser: true }));
+// keep probes deterministic
+vi.mock('./probes', () => ({
+	probeIndexer: vi.fn(async () => 'https://picked-indexer'),
+	probeVscApi: vi.fn(async () => 'https://picked-vsc'),
+	probeHiveRpc: vi.fn(async () => 'https://picked-hive')
+}));
+vi.mock('./env', () => ({
+	indexerNodes: ['https://idx-default', 'https://idx-2'],
+	vscApiNodes: ['https://vsc-default'],
+	hiveRpcNodes: ['https://hive-default']
+}));
+
+import { resolveNodeUrl, refreshNode, isManualMode } from './select';
+
+class MemStorage {
+	m = new Map<string, string>();
+	getItem(k: string) { return this.m.has(k) ? this.m.get(k)! : null; }
+	setItem(k: string, v: string) { this.m.set(k, v); }
+	removeItem(k: string) { this.m.delete(k); }
+	clear() { this.m.clear(); }
+	key() { return null; }
+	get length() { return this.m.size; }
+}
+
+beforeEach(() => {
+	vi.stubGlobal('localStorage', new MemStorage());
+	vi.clearAllMocks();
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe('resolveNodeUrl precedence', () => {
+	it('cold start → first env node', () => {
+		expect(resolveNodeUrl('indexer')).toBe('https://idx-default');
+	});
+	it('auto cache wins over env default', () => {
+		localStorage.setItem('node-auto-indexer', 'https://cached-idx');
+		expect(resolveNodeUrl('indexer')).toBe('https://cached-idx');
+	});
+	it('manual mode + manual key beats auto cache', () => {
+		localStorage.setItem('node-auto-indexer', 'https://cached-idx');
+		localStorage.setItem('node-mode-indexer', 'manual');
+		localStorage.setItem('magi-indexer-url', 'https://my-manual');
+		expect(isManualMode('indexer')).toBe(true);
+		expect(resolveNodeUrl('indexer')).toBe('https://my-manual');
+	});
+});
+
+describe('refreshNode', () => {
+	it('probes and writes cache + timestamp when stale', async () => {
+		await refreshNode('vsc');
+		expect(localStorage.getItem('node-auto-vsc')).toBe('https://picked-vsc');
+		expect(Number(localStorage.getItem('node-auto-ts-vsc'))).toBeGreaterThan(0);
+	});
+	it('skips probing when cache is fresh', async () => {
+		const probes = await import('./probes');
+		localStorage.setItem('node-auto-hive', 'https://still-good');
+		localStorage.setItem('node-auto-ts-hive', String(Date.now()));
+		await refreshNode('hive');
+		expect(probes.probeHiveRpc).not.toHaveBeenCalled();
+		expect(localStorage.getItem('node-auto-hive')).toBe('https://still-good');
+	});
+	it('skips probing in manual mode', async () => {
+		const probes = await import('./probes');
+		localStorage.setItem('node-mode-vsc', 'manual');
+		await refreshNode('vsc');
+		expect(probes.probeVscApi).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/nodeSelection/select.ts
+++ b/src/lib/nodeSelection/select.ts
@@ -63,6 +63,15 @@ export function isManualMode(cat: Category): boolean {
 	return false;
 }
 
+/** The node auto-selection currently resolves to, ignoring any manual
+ *  override: auto cache → first env node. Useful for showing the user what
+ *  the dynamic node-finder picked even while a Custom override is active. */
+export function autoSelectedNodeUrl(cat: Category): string {
+	const cached = ls()?.getItem(CACHE_KEY[cat]);
+	if (cached && cached.trim()) return cached.trim();
+	return NODES[cat][0];
+}
+
 /** Synchronous resolution for module-load consumers (client.ts/dhive.ts).
  *  Precedence: manual (if manual mode) → auto cache → first env node. */
 export function resolveNodeUrl(cat: Category): string {
@@ -71,9 +80,7 @@ export function resolveNodeUrl(cat: Category): string {
 		const manual = s.getItem(MANUAL_KEY[cat]);
 		if (manual && manual.trim()) return manual.trim();
 	}
-	const cached = s?.getItem(CACHE_KEY[cat]);
-	if (cached && cached.trim()) return cached.trim();
-	return NODES[cat][0];
+	return autoSelectedNodeUrl(cat);
 }
 
 function isFresh(cat: Category): boolean {

--- a/src/lib/nodeSelection/select.ts
+++ b/src/lib/nodeSelection/select.ts
@@ -1,0 +1,93 @@
+import { browser } from '$app/environment';
+import { indexerNodes, vscApiNodes, hiveRpcNodes } from './env';
+import { probeIndexer, probeVscApi, probeHiveRpc } from './probes';
+
+export type Category = 'indexer' | 'vsc' | 'hive';
+
+const TTL_MS = 5 * 60 * 1000;
+
+const CACHE_KEY: Record<Category, string> = {
+	indexer: 'node-auto-indexer',
+	vsc: 'node-auto-vsc',
+	hive: 'node-auto-hive'
+};
+const CACHE_TS_KEY: Record<Category, string> = {
+	indexer: 'node-auto-ts-indexer',
+	vsc: 'node-auto-ts-vsc',
+	hive: 'node-auto-ts-hive'
+};
+export const MODE_KEY: Record<Category, string> = {
+	indexer: 'node-mode-indexer',
+	vsc: 'node-mode-vsc',
+	hive: 'node-mode-hive'
+};
+/** Existing manual-override localStorage keys (keyMagiIndexer / keyVscGql /
+ *  keyHiveApiList). Kept in sync with src/client.ts + dhive.ts. */
+const MANUAL_KEY: Record<Category, string> = {
+	indexer: 'magi-indexer-url',
+	vsc: 'vsc-gql-url',
+	hive: 'hive-api'
+};
+const NODES: Record<Category, string[]> = {
+	indexer: indexerNodes,
+	vsc: vscApiNodes,
+	hive: hiveRpcNodes
+};
+const PROBE: Record<Category, (n: string[]) => Promise<string>> = {
+	indexer: probeIndexer,
+	vsc: probeVscApi,
+	hive: probeHiveRpc
+};
+
+function ls(): Storage | null {
+	try {
+		if (!browser || typeof localStorage === 'undefined') return null;
+		return localStorage;
+	} catch {
+		return null;
+	}
+}
+
+export function isManualMode(cat: Category): boolean {
+	return ls()?.getItem(MODE_KEY[cat]) === 'manual';
+}
+
+/** Synchronous resolution for module-load consumers (client.ts/dhive.ts).
+ *  Precedence: manual (if manual mode) → auto cache → first env node. */
+export function resolveNodeUrl(cat: Category): string {
+	const s = ls();
+	if (s && isManualMode(cat)) {
+		const manual = s.getItem(MANUAL_KEY[cat]);
+		if (manual && manual.trim()) return manual.trim();
+	}
+	const cached = s?.getItem(CACHE_KEY[cat]);
+	if (cached && cached.trim()) return cached.trim();
+	return NODES[cat][0];
+}
+
+function isFresh(cat: Category): boolean {
+	const raw = ls()?.getItem(CACHE_TS_KEY[cat]);
+	if (!raw) return false;
+	const ts = Number(raw);
+	return Number.isFinite(ts) && Date.now() - ts < TTL_MS;
+}
+
+/** Background probe + cache write. No-op when manual, cache fresh, or no
+ *  storage. Failures leave the previous cache untouched. */
+export async function refreshNode(cat: Category): Promise<void> {
+	const s = ls();
+	if (!s || isManualMode(cat) || isFresh(cat)) return;
+	try {
+		const url = await PROBE[cat](NODES[cat]);
+		s.setItem(CACHE_KEY[cat], url);
+		s.setItem(CACHE_TS_KEY[cat], String(Date.now()));
+	} catch {
+		/* keep previous cache; resolveNodeUrl falls through to env default */
+	}
+}
+
+export function refreshAllNodes(): void {
+	void refreshNode('indexer');
+	void refreshNode('vsc');
+	void refreshNode('hive');
+}

--- a/src/lib/nodeSelection/select.ts
+++ b/src/lib/nodeSelection/select.ts
@@ -49,7 +49,18 @@ function ls(): Storage | null {
 }
 
 export function isManualMode(cat: Category): boolean {
-	return ls()?.getItem(MODE_KEY[cat]) === 'manual';
+	const s = ls();
+	if (!s) return false;
+	const mode = s.getItem(MODE_KEY[cat]);
+	if (mode === 'manual') return true;
+	// Legacy migration: users who set a custom endpoint before this feature
+	// have the manual key populated but no explicit mode key. Treat that as
+	// manual so auto-selection never silently discards their override.
+	if (mode === null) {
+		const legacy = s.getItem(MANUAL_KEY[cat]);
+		return !!(legacy && legacy.trim());
+	}
+	return false;
 }
 
 /** Synchronous resolution for module-load consumers (client.ts/dhive.ts).

--- a/src/routes/(authed)/preferences/+page.svelte
+++ b/src/routes/(authed)/preferences/+page.svelte
@@ -18,11 +18,17 @@
 		keyTbd
 	} from '../../../client';
 	import ToggleTheme from './ToggleTheme.svelte';
-	import { resolveNodeUrl, MODE_KEY, type Category } from '$lib/nodeSelection/select';
+	import {
+		resolveNodeUrl,
+		isManualMode,
+		MODE_KEY,
+		type Category
+	} from '$lib/nodeSelection/select';
 
 	function initAuto(cat: Category): boolean {
 		if (!browser) return true;
-		return (localStorage.getItem(MODE_KEY[cat]) ?? 'auto') !== 'manual';
+		// isManualMode also covers legacy users (custom key set, no mode key).
+		return !isManualMode(cat);
 	}
 	let autoVsc = $state(initAuto('vsc'));
 	let autoIndexer = $state(initAuto('indexer'));

--- a/src/routes/(authed)/preferences/+page.svelte
+++ b/src/routes/(authed)/preferences/+page.svelte
@@ -20,6 +20,7 @@
 	import ToggleTheme from './ToggleTheme.svelte';
 	import {
 		resolveNodeUrl,
+		autoSelectedNodeUrl,
 		isManualMode,
 		MODE_KEY,
 		type Category
@@ -139,6 +140,9 @@
 				: resolveNodeUrl('vsc')}
 			type="url"
 		/>
+		{#if browser}
+			<span class="auto-note">Auto-selected: {autoSelectedNodeUrl('vsc')}</span>
+		{/if}
 		<PillButton
 			styleType="outline"
 			onclick={(e) => {
@@ -168,6 +172,9 @@
 				: resolveNodeUrl('indexer')}
 			type="url"
 		/>
+		{#if browser}
+			<span class="auto-note">Auto-selected: {autoSelectedNodeUrl('indexer')}</span>
+		{/if}
 		<PillButton
 			styleType="outline"
 			onclick={() => {
@@ -195,6 +202,9 @@
 				: resolveNodeUrl('hive')}
 			type="url"
 		/>
+		{#if browser}
+			<span class="auto-note">Auto-selected: {autoSelectedNodeUrl('hive')}</span>
+		{/if}
 		<PillButton
 			styleType="outline"
 			onclick={(e) => {
@@ -340,5 +350,13 @@
 	input[type='url']:disabled {
 		opacity: 0.55;
 		cursor: not-allowed;
+	}
+	.auto-note {
+		display: block;
+		margin-top: 0.15rem;
+		font-size: 0.7rem;
+		color: var(--dash-text-secondary);
+		opacity: 0.75;
+		word-break: break-all;
 	}
 </style>

--- a/src/routes/(authed)/preferences/+page.svelte
+++ b/src/routes/(authed)/preferences/+page.svelte
@@ -19,7 +19,6 @@
 	} from '../../../client';
 	import ToggleTheme from './ToggleTheme.svelte';
 	import {
-		resolveNodeUrl,
 		autoSelectedNodeUrl,
 		isManualMode,
 		MODE_KEY,
@@ -135,9 +134,7 @@
 			id="keyVscApi"
 			bind:this={vscGqlUrlInput}
 			disabled={!customVsc}
-			value={customVsc
-				? (browser && localStorage.getItem(keyVscGql)) || 'https://api.vsc.eco'
-				: resolveNodeUrl('vsc')}
+			value={(browser && localStorage.getItem(keyVscGql)) || 'https://api.vsc.eco'}
 			type="url"
 		/>
 		{#if browser}
@@ -167,9 +164,7 @@
 			id="magi-indexer-url"
 			bind:this={magiIndexerInput}
 			disabled={!customIndexer}
-			value={customIndexer
-				? (browser && localStorage.getItem(keyMagiIndexer)) || DEFAULT_MAGI_INDEXER_URL
-				: resolveNodeUrl('indexer')}
+			value={(browser && localStorage.getItem(keyMagiIndexer)) || DEFAULT_MAGI_INDEXER_URL}
 			type="url"
 		/>
 		{#if browser}
@@ -197,9 +192,7 @@
 			id="vsc-gql-url"
 			bind:this={hiveApiUrlInput}
 			disabled={!customHive}
-			value={customHive
-				? (browser && localStorage.getItem(keyHiveApiList)) || DEFAULT_HIVE_API_URL
-				: resolveNodeUrl('hive')}
+			value={(browser && localStorage.getItem(keyHiveApiList)) || DEFAULT_HIVE_API_URL}
 			type="url"
 		/>
 		{#if browser}

--- a/src/routes/(authed)/preferences/+page.svelte
+++ b/src/routes/(authed)/preferences/+page.svelte
@@ -18,6 +18,15 @@
 		keyTbd
 	} from '../../../client';
 	import ToggleTheme from './ToggleTheme.svelte';
+	import { resolveNodeUrl, MODE_KEY, type Category } from '$lib/nodeSelection/select';
+
+	function initAuto(cat: Category): boolean {
+		if (!browser) return true;
+		return (localStorage.getItem(MODE_KEY[cat]) ?? 'auto') !== 'manual';
+	}
+	let autoVsc = $state(initAuto('vsc'));
+	let autoIndexer = $state(initAuto('indexer'));
+	let autoHive = $state(initAuto('hive'));
 
 	const DEFAULT_HIVE_API_URL = 'https://api.hive.blog';
 	const DEFAULT_VSC_NETWORK_ID = 'vsc-mainnet';
@@ -48,24 +57,47 @@
 				// strip a trailing /v1/graphql (or /v1/graphql/) if the user pasted the full URL
 				.replace(/\/+v1\/graphql\/?$/, '')
 				.replace(/\/+$/, '');
-			const vscUrl = URL.parse(vscUrlStr);
-			if (!vscUrl) {
+			// Only validate a field's URL when it's in manual mode (auto
+			// has no user-entered URL to validate).
+			const vscUrl = autoVsc ? null : URL.parse(vscUrlStr);
+			if (!autoVsc && !vscUrl) {
 				console.error('Unexpected: API URL invalid');
 				return;
 			}
-			const hiveUrl = URL.parse(hiveUrlStr);
-			if (!hiveUrl) {
+			const hiveUrl = autoHive ? null : URL.parse(hiveUrlStr);
+			if (!autoHive && !hiveUrl) {
 				console.error('Unexpected: HIVE API URL invalid');
 				return;
 			}
-			if (!URL.parse(magiIndexerStr)) {
+			if (!autoIndexer && !URL.parse(magiIndexerStr)) {
 				console.error('Unexpected: Magi Indexer URL invalid');
 				return;
 			}
 			const allowBackups = hiveAllowBackupsCheckbox.checked;
-			localStorage.setItem(keyVscGql, vscUrl.origin);
-			localStorage.setItem(keyHiveApiList, hiveUrl.origin);
-			localStorage.setItem(keyMagiIndexer, magiIndexerStr);
+			// VSC
+			if (autoVsc) {
+				localStorage.removeItem(keyVscGql);
+				localStorage.setItem(MODE_KEY.vsc, 'auto');
+			} else {
+				localStorage.setItem(keyVscGql, vscUrl!.origin);
+				localStorage.setItem(MODE_KEY.vsc, 'manual');
+			}
+			// Magi Indexer
+			if (autoIndexer) {
+				localStorage.removeItem(keyMagiIndexer);
+				localStorage.setItem(MODE_KEY.indexer, 'auto');
+			} else {
+				localStorage.setItem(keyMagiIndexer, magiIndexerStr);
+				localStorage.setItem(MODE_KEY.indexer, 'manual');
+			}
+			// Hive
+			if (autoHive) {
+				localStorage.removeItem(keyHiveApiList);
+				localStorage.setItem(MODE_KEY.hive, 'auto');
+			} else {
+				localStorage.setItem(keyHiveApiList, hiveUrl!.origin);
+				localStorage.setItem(MODE_KEY.hive, 'manual');
+			}
 			localStorage.setItem(keyHiveApiAllowBackups, allowBackups.toString());
 			// Advanced inputs are only mounted when advancedOptions is true.
 			if (advancedOptions) {
@@ -87,10 +119,16 @@
 			<InfoTooltip>Edit this to direct queries to a custom Magi node.</InfoTooltip>
 		</span>
 
+		<label class="auto-toggle">
+			<input type="checkbox" bind:checked={autoVsc} /> Automatic node selection
+		</label>
 		<input
 			id="keyVscApi"
 			bind:this={vscGqlUrlInput}
-			value={(browser && localStorage.getItem(keyVscGql)) || 'https://api.vsc.eco'}
+			readonly={autoVsc}
+			value={autoVsc
+				? resolveNodeUrl('vsc')
+				: (browser && localStorage.getItem(keyVscGql)) || 'https://api.vsc.eco'}
 			type="url"
 		/>
 		<PillButton
@@ -110,10 +148,16 @@
 				indexer.
 			</InfoTooltip>
 		</span>
+		<label class="auto-toggle">
+			<input type="checkbox" bind:checked={autoIndexer} /> Automatic node selection
+		</label>
 		<input
 			id="magi-indexer-url"
 			bind:this={magiIndexerInput}
-			value={(browser && localStorage.getItem(keyMagiIndexer)) || DEFAULT_MAGI_INDEXER_URL}
+			readonly={autoIndexer}
+			value={autoIndexer
+				? resolveNodeUrl('indexer')
+				: (browser && localStorage.getItem(keyMagiIndexer)) || DEFAULT_MAGI_INDEXER_URL}
 			type="url"
 		/>
 		<PillButton
@@ -131,10 +175,16 @@
 			<InfoTooltip>Edit this to direct queries to a custom Hive node.</InfoTooltip>
 		</span>
 
+		<label class="auto-toggle">
+			<input type="checkbox" bind:checked={autoHive} /> Automatic node selection
+		</label>
 		<input
 			id="vsc-gql-url"
 			bind:this={hiveApiUrlInput}
-			value={(browser && localStorage.getItem(keyHiveApiList)) || DEFAULT_HIVE_API_URL}
+			readonly={autoHive}
+			value={autoHive
+				? resolveNodeUrl('hive')
+				: (browser && localStorage.getItem(keyHiveApiList)) || DEFAULT_HIVE_API_URL}
 			type="url"
 		/>
 		<PillButton
@@ -271,5 +321,12 @@
 	.backup-box {
 		display: flex;
 		align-items: center;
+	}
+	.auto-toggle {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		color: var(--dash-text-secondary);
+		margin-bottom: 0.3rem;
 	}
 </style>

--- a/src/routes/(authed)/preferences/+page.svelte
+++ b/src/routes/(authed)/preferences/+page.svelte
@@ -147,7 +147,7 @@
 				type="button">Reset</PillButton
 			>
 		{/if}
-		{#if browser}
+		{#if browser && !customVsc}
 			<span class="auto-note">Auto-selected: {autoSelectedNodeUrl('vsc')}</span>
 		{/if}
 		<br />
@@ -179,7 +179,7 @@
 				type="button">Reset</PillButton
 			>
 		{/if}
-		{#if browser}
+		{#if browser && !customIndexer}
 			<span class="auto-note">Auto-selected: {autoSelectedNodeUrl('indexer')}</span>
 		{/if}
 		<br />
@@ -209,7 +209,7 @@
 				type="button">Reset</PillButton
 			>
 		{/if}
-		{#if browser}
+		{#if browser && !customHive}
 			<span class="auto-note">Auto-selected: {autoSelectedNodeUrl('hive')}</span>
 		{/if}
 		<div class="backup-box">

--- a/src/routes/(authed)/preferences/+page.svelte
+++ b/src/routes/(authed)/preferences/+page.svelte
@@ -137,17 +137,19 @@
 			value={(browser && localStorage.getItem(keyVscGql)) || 'https://api.vsc.eco'}
 			type="url"
 		/>
+		{#if customVsc}
+			<PillButton
+				styleType="outline"
+				onclick={(e) => {
+					localStorage.setItem(keyVscGql, DEFAULT_GQL_URL);
+					vscGqlUrlInput.value = DEFAULT_GQL_URL;
+				}}
+				type="button">Reset</PillButton
+			>
+		{/if}
 		{#if browser}
 			<span class="auto-note">Auto-selected: {autoSelectedNodeUrl('vsc')}</span>
 		{/if}
-		<PillButton
-			styleType="outline"
-			onclick={(e) => {
-				localStorage.setItem(keyVscGql, DEFAULT_GQL_URL);
-				vscGqlUrlInput.value = DEFAULT_GQL_URL;
-			}}
-			type="button">Reset</PillButton
-		>
 		<br />
 		<br />
 		<span class="label-tooltip">
@@ -167,17 +169,19 @@
 			value={(browser && localStorage.getItem(keyMagiIndexer)) || DEFAULT_MAGI_INDEXER_URL}
 			type="url"
 		/>
+		{#if customIndexer}
+			<PillButton
+				styleType="outline"
+				onclick={() => {
+					localStorage.setItem(keyMagiIndexer, DEFAULT_MAGI_INDEXER_URL);
+					magiIndexerInput.value = DEFAULT_MAGI_INDEXER_URL;
+				}}
+				type="button">Reset</PillButton
+			>
+		{/if}
 		{#if browser}
 			<span class="auto-note">Auto-selected: {autoSelectedNodeUrl('indexer')}</span>
 		{/if}
-		<PillButton
-			styleType="outline"
-			onclick={() => {
-				localStorage.setItem(keyMagiIndexer, DEFAULT_MAGI_INDEXER_URL);
-				magiIndexerInput.value = DEFAULT_MAGI_INDEXER_URL;
-			}}
-			type="button">Reset</PillButton
-		>
 		<br />
 		<br />
 		<span class="label-tooltip">
@@ -195,17 +199,19 @@
 			value={(browser && localStorage.getItem(keyHiveApiList)) || DEFAULT_HIVE_API_URL}
 			type="url"
 		/>
+		{#if customHive}
+			<PillButton
+				styleType="outline"
+				onclick={(e) => {
+					localStorage.setItem(keyHiveApiList, DEFAULT_HIVE_API_URL);
+					hiveApiUrlInput.value = DEFAULT_HIVE_API_URL;
+				}}
+				type="button">Reset</PillButton
+			>
+		{/if}
 		{#if browser}
 			<span class="auto-note">Auto-selected: {autoSelectedNodeUrl('hive')}</span>
 		{/if}
-		<PillButton
-			styleType="outline"
-			onclick={(e) => {
-				localStorage.setItem(keyHiveApiList, DEFAULT_HIVE_API_URL);
-				hiveApiUrlInput.value = DEFAULT_HIVE_API_URL;
-			}}
-			type="button">Reset</PillButton
-		>
 		<div class="backup-box">
 			<label for="hive-api-allow-backups">
 				<input

--- a/src/routes/(authed)/preferences/+page.svelte
+++ b/src/routes/(authed)/preferences/+page.svelte
@@ -25,14 +25,16 @@
 		type Category
 	} from '$lib/nodeSelection/select';
 
-	function initAuto(cat: Category): boolean {
-		if (!browser) return true;
-		// isManualMode also covers legacy users (custom key set, no mode key).
-		return !isManualMode(cat);
+	// "Custom" = manual override of the dynamic node-finder. Unchecked = auto
+	// selection (textbox disabled). isManualMode also covers legacy users
+	// (custom key set, no explicit mode key).
+	function initCustom(cat: Category): boolean {
+		if (!browser) return false;
+		return isManualMode(cat);
 	}
-	let autoVsc = $state(initAuto('vsc'));
-	let autoIndexer = $state(initAuto('indexer'));
-	let autoHive = $state(initAuto('hive'));
+	let customVsc = $state(initCustom('vsc'));
+	let customIndexer = $state(initCustom('indexer'));
+	let customHive = $state(initCustom('hive'));
 
 	const DEFAULT_HIVE_API_URL = 'https://api.hive.blog';
 	const DEFAULT_VSC_NETWORK_ID = 'vsc-mainnet';
@@ -63,46 +65,46 @@
 				// strip a trailing /v1/graphql (or /v1/graphql/) if the user pasted the full URL
 				.replace(/\/+v1\/graphql\/?$/, '')
 				.replace(/\/+$/, '');
-			// Only validate a field's URL when it's in manual mode (auto
-			// has no user-entered URL to validate).
-			const vscUrl = autoVsc ? null : URL.parse(vscUrlStr);
-			if (!autoVsc && !vscUrl) {
+			// Only validate a field's URL when "Custom" is checked (auto has
+			// no user-entered URL to validate).
+			const vscUrl = customVsc ? URL.parse(vscUrlStr) : null;
+			if (customVsc && !vscUrl) {
 				console.error('Unexpected: API URL invalid');
 				return;
 			}
-			const hiveUrl = autoHive ? null : URL.parse(hiveUrlStr);
-			if (!autoHive && !hiveUrl) {
+			const hiveUrl = customHive ? URL.parse(hiveUrlStr) : null;
+			if (customHive && !hiveUrl) {
 				console.error('Unexpected: HIVE API URL invalid');
 				return;
 			}
-			if (!autoIndexer && !URL.parse(magiIndexerStr)) {
+			if (customIndexer && !URL.parse(magiIndexerStr)) {
 				console.error('Unexpected: Magi Indexer URL invalid');
 				return;
 			}
 			const allowBackups = hiveAllowBackupsCheckbox.checked;
 			// VSC
-			if (autoVsc) {
-				localStorage.removeItem(keyVscGql);
-				localStorage.setItem(MODE_KEY.vsc, 'auto');
-			} else {
+			if (customVsc) {
 				localStorage.setItem(keyVscGql, vscUrl!.origin);
 				localStorage.setItem(MODE_KEY.vsc, 'manual');
+			} else {
+				localStorage.removeItem(keyVscGql);
+				localStorage.setItem(MODE_KEY.vsc, 'auto');
 			}
 			// Magi Indexer
-			if (autoIndexer) {
-				localStorage.removeItem(keyMagiIndexer);
-				localStorage.setItem(MODE_KEY.indexer, 'auto');
-			} else {
+			if (customIndexer) {
 				localStorage.setItem(keyMagiIndexer, magiIndexerStr);
 				localStorage.setItem(MODE_KEY.indexer, 'manual');
+			} else {
+				localStorage.removeItem(keyMagiIndexer);
+				localStorage.setItem(MODE_KEY.indexer, 'auto');
 			}
 			// Hive
-			if (autoHive) {
-				localStorage.removeItem(keyHiveApiList);
-				localStorage.setItem(MODE_KEY.hive, 'auto');
-			} else {
+			if (customHive) {
 				localStorage.setItem(keyHiveApiList, hiveUrl!.origin);
 				localStorage.setItem(MODE_KEY.hive, 'manual');
+			} else {
+				localStorage.removeItem(keyHiveApiList);
+				localStorage.setItem(MODE_KEY.hive, 'auto');
 			}
 			localStorage.setItem(keyHiveApiAllowBackups, allowBackups.toString());
 			// Advanced inputs are only mounted when advancedOptions is true.
@@ -125,16 +127,16 @@
 			<InfoTooltip>Edit this to direct queries to a custom Magi node.</InfoTooltip>
 		</span>
 
-		<label class="auto-toggle">
-			<input type="checkbox" bind:checked={autoVsc} /> Automatic node selection
+		<label class="custom-toggle">
+			<input type="checkbox" bind:checked={customVsc} /> Custom (override auto node selection)
 		</label>
 		<input
 			id="keyVscApi"
 			bind:this={vscGqlUrlInput}
-			readonly={autoVsc}
-			value={autoVsc
-				? resolveNodeUrl('vsc')
-				: (browser && localStorage.getItem(keyVscGql)) || 'https://api.vsc.eco'}
+			disabled={!customVsc}
+			value={customVsc
+				? (browser && localStorage.getItem(keyVscGql)) || 'https://api.vsc.eco'
+				: resolveNodeUrl('vsc')}
 			type="url"
 		/>
 		<PillButton
@@ -154,16 +156,16 @@
 				indexer.
 			</InfoTooltip>
 		</span>
-		<label class="auto-toggle">
-			<input type="checkbox" bind:checked={autoIndexer} /> Automatic node selection
+		<label class="custom-toggle">
+			<input type="checkbox" bind:checked={customIndexer} /> Custom (override auto node selection)
 		</label>
 		<input
 			id="magi-indexer-url"
 			bind:this={magiIndexerInput}
-			readonly={autoIndexer}
-			value={autoIndexer
-				? resolveNodeUrl('indexer')
-				: (browser && localStorage.getItem(keyMagiIndexer)) || DEFAULT_MAGI_INDEXER_URL}
+			disabled={!customIndexer}
+			value={customIndexer
+				? (browser && localStorage.getItem(keyMagiIndexer)) || DEFAULT_MAGI_INDEXER_URL
+				: resolveNodeUrl('indexer')}
 			type="url"
 		/>
 		<PillButton
@@ -181,16 +183,16 @@
 			<InfoTooltip>Edit this to direct queries to a custom Hive node.</InfoTooltip>
 		</span>
 
-		<label class="auto-toggle">
-			<input type="checkbox" bind:checked={autoHive} /> Automatic node selection
+		<label class="custom-toggle">
+			<input type="checkbox" bind:checked={customHive} /> Custom (override auto node selection)
 		</label>
 		<input
 			id="vsc-gql-url"
 			bind:this={hiveApiUrlInput}
-			readonly={autoHive}
-			value={autoHive
-				? resolveNodeUrl('hive')
-				: (browser && localStorage.getItem(keyHiveApiList)) || DEFAULT_HIVE_API_URL}
+			disabled={!customHive}
+			value={customHive
+				? (browser && localStorage.getItem(keyHiveApiList)) || DEFAULT_HIVE_API_URL
+				: resolveNodeUrl('hive')}
 			type="url"
 		/>
 		<PillButton
@@ -328,11 +330,15 @@
 		display: flex;
 		align-items: center;
 	}
-	.auto-toggle {
+	.custom-toggle {
 		display: flex;
 		align-items: center;
 		gap: 0.4rem;
 		color: var(--dash-text-secondary);
 		margin-bottom: 0.3rem;
+	}
+	input[type='url']:disabled {
+		opacity: 0.55;
+		cursor: not-allowed;
 	}
 </style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,6 +9,7 @@
 	import { onMount } from 'svelte';
 	import { themeStore, getInitialTheme, THEMES } from '$lib/theme';
 	import { cleanOldLocalStorage } from '$lib/cleanup';
+	import { refreshAllNodes } from '$lib/nodeSelection/select';
 
 	let { children } = $props();
 	injectAnalytics();
@@ -18,6 +19,7 @@
 		const initialTheme = getInitialTheme();
 		themeStore.set(THEMES[initialTheme]);
 		cleanOldLocalStorage();
+		refreshAllNodes();
 		// window.addEventListener(
 		// 	'keydown',
 		// 	(e) => {


### PR DESCRIPTION
**Env-configurable node lists** — `PUBLIC_INDEXER_NODES`, `PUBLIC_VSC_API_NODES`, `PUBLIC_HIVE_RPC_NODES` (comma-separated, with hardcoded fallbacks).

Optional overrides (defaults shown = the built-in fallbacks; only set these to point at different nodes):
```
PUBLIC_INDEXER_NODES=https://api.okinoko.io/hasura,https://indexer.magi.milohpr.com
PUBLIC_VSC_API_NODES=https://api.vsc.eco,https://vsc.techcoderx.com
PUBLIC_HIVE_RPC_NODES=https://api.hive.blog,https://api.openhive.network,https://techcoderx.com,https://api.deathwing.me
```


**Health-based auto-selection on app open** — probes each list and caches the freshest node (5-min TTL):
- Indexer: most recent contract_logs.ts
- VSC API: highest localNodeInfo.last_processed_block
- Hive: hybrid GET /health → get_dynamic_global_properties head block

**Precedence:** manual override → auto cache → first env node. Background refresh never blocks startup; pre-existing custom endpoints are migrated to manual so they aren't discarded.
**Preferences UI** — per-endpoint **Custom** checkbox: off = auto (textbox disabled, Auto-selected: <url> caption shown); on = manual override (editable + Reset). Defaults to auto for new users.

