### PR TITLE
fix(security): external audit cross-ref APP-* remediations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Altera are documented here.
 
 ## [0.3.3] — 2026-05-19
 
+### Security
+- Baseline security response headers added (`hooks.server.ts`): `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy` (geolocation/microphone/camera off), and a Content-Security-Policy with `frame-ancestors 'none'`, `worker-src 'self'`, and `object-src 'none'` — addresses the missing clickjacking/MIME-sniffing protections (audit APP-08). CSP is intentionally permissive (keeps `'unsafe-inline'`/`'unsafe-eval'` for SvelteKit hydration and the WASM-based Hive signer) so it hardens framing/sniffing without breaking the app
+
 ### Infrastructure
 - Multi-node failover: indexer / VSC API / Hive RPC endpoints are health-checked on app open and the freshest node is auto-selected (5-min cache); optional `PUBLIC_INDEXER_NODES` / `PUBLIC_VSC_API_NODES` / `PUBLIC_HIVE_RPC_NODES` runtime overrides, hardcoded fallbacks otherwise
 - Preferences: per-endpoint "Custom" toggle to pin a specific node (off = automatic, shows the auto-selected node)

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -20,5 +20,36 @@ export const handle: Handle = async ({ event, resolve }) => {
 		return new Response(null, { status: 204 });
 	}
 
-	return resolve(event);
+	const response = await resolve(event);
+
+	// APP-08: baseline security headers. CSP is kept intentionally permissive
+	// (self + inline styles + the API/GQL/indexer/Hive hosts already in use,
+	// ws/wss, data: images) so it hardens framing/sniffing without breaking
+	// the app. frame-ancestors 'none' is the primary clickjacking control.
+	response.headers.set('X-Frame-Options', 'DENY');
+	response.headers.set('X-Content-Type-Options', 'nosniff');
+	response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+	response.headers.set(
+		'Permissions-Policy',
+		'geolocation=(), microphone=(), camera=()'
+	);
+	response.headers.set(
+		'Content-Security-Policy',
+		[
+			"default-src 'self'",
+			"script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+			"style-src 'self' 'unsafe-inline'",
+			"img-src 'self' data: blob: https:",
+			"font-src 'self' data:",
+			"connect-src 'self' https: wss: ws:",
+			"frame-src 'self' https:",
+			"frame-ancestors 'none'",
+			"worker-src 'self'",
+			"object-src 'none'",
+			"base-uri 'self'",
+			"form-action 'self'"
+		].join('; ')
+	);
+
+	return response;
 };

--- a/src/lib/auth/reown/index.ts
+++ b/src/lib/auth/reown/index.ts
@@ -10,8 +10,13 @@ import { cleanUpLogout, loginRetry } from '../store';
 import { isBtcTestnetAddress } from '$lib/stores/currentBalance';
 import { BTC_MAINNET_CAIP, BTC_TESTNET_CAIP } from '../btcCaip';
 
+import { env as publicEnv } from '$env/dynamic/public';
+
 // 1. Get a project ID at https://cloud.reown.com
-export const projectId = '55a54e098e74ddb214919fe0da4ac384';
+// APP-16: read from PUBLIC_REOWN_PROJECT_ID when set; fall back to the
+// previous literal so the app still works without the env var configured.
+export const projectId =
+	publicEnv.PUBLIC_REOWN_PROJECT_ID || '55a54e098e74ddb214919fe0da4ac384';
 
 // Mainnet-first for BTC so Xverse (which defaults to Mainnet) doesn't
 // get handed a testnet network it isn't configured for when the

--- a/src/lib/currency/CoinAmount.ts
+++ b/src/lib/currency/CoinAmount.ts
@@ -149,4 +149,7 @@ declare global {
 	// eslint-disable-next-line no-var
 	var coins: typeof Coin;
 }
-globalThis.ca = CoinAmount;
+// APP-17: only expose internals on globalThis in development builds.
+if (import.meta.env.DEV) {
+	globalThis.ca = CoinAmount;
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,1 +1,36 @@
 // place files you want to import through the `$lib` alias in this folder.
+
+/**
+ * APP-14: Strip Unicode bidirectional/control characters from user-supplied
+ * text (e.g. transaction memos) before rendering, to prevent visual spoofing
+ * (bidi override / isolate) and control-character injection.
+ *
+ * Removed ranges:
+ *  - U+200E / U+200F  LRM / RLM
+ *  - U+202A - U+202E  bidi embeddings & overrides
+ *  - U+2066 - U+2069  bidi isolates
+ *  - U+0000 - U+0008  C0 controls (NUL..BS)
+ *  - U+000B / U+000C  VT, FF
+ *  - U+000E - U+001F  remaining C0 controls
+ *  - U+007F - U+009F  DEL + C1 controls
+ *
+ * Ordinary whitespace (U+0009 tab, U+000A LF, U+000D CR) is intentionally
+ * preserved.
+ */
+const BIDI_CONTROL_RE = new RegExp(
+	'[' +
+		'\\u200E\\u200F' +
+		'\\u202A-\\u202E' +
+		'\\u2066-\\u2069' +
+		'\\u0000-\\u0008' +
+		'\\u000B\\u000C' +
+		'\\u000E-\\u001F' +
+		'\\u007F-\\u009F' +
+		']',
+	'g'
+);
+
+export function sanitizeBidiText(input: string | undefined | null): string {
+	if (!input) return '';
+	return input.replace(BIDI_CONTROL_RE, '');
+}

--- a/src/lib/nodeSelection/select.ts
+++ b/src/lib/nodeSelection/select.ts
@@ -39,6 +39,41 @@ const PROBE: Record<Category, (n: string[]) => Promise<string>> = {
 	hive: probeHiveRpc
 };
 
+/** APP-03/04: allowlisted root domains for manual node overrides. A manual
+ *  override URL is only honoured when it is https (or http on localhost) and
+ *  its hostname is one of these roots or a subdomain thereof. Anything else is
+ *  ignored and resolution falls back to the auto/default node. */
+const ALLOWED_ROOT_DOMAINS = [
+	'okinoko.io',
+	'magi.eco',
+	'vsc.eco',
+	'techcoderx.com',
+	'milohpr.com',
+	'hive.blog',
+	'openhive.network',
+	'deathwing.me'
+];
+
+function isAllowedNodeUrl(raw: string): boolean {
+	let u: URL;
+	try {
+		u = new URL(raw);
+	} catch {
+		return false;
+	}
+	const host = u.hostname.toLowerCase();
+	const isLocalhost = host === 'localhost' || host === '127.0.0.1' || host === '[::1]';
+	if (u.protocol === 'http:') {
+		if (!isLocalhost) return false;
+	} else if (u.protocol !== 'https:') {
+		return false;
+	}
+	if (isLocalhost) return true;
+	return ALLOWED_ROOT_DOMAINS.some(
+		(root) => host === root || host.endsWith('.' + root)
+	);
+}
+
 function ls(): Storage | null {
 	try {
 		if (!browser || typeof localStorage === 'undefined') return null;
@@ -78,7 +113,12 @@ export function resolveNodeUrl(cat: Category): string {
 	const s = ls();
 	if (s && isManualMode(cat)) {
 		const manual = s.getItem(MANUAL_KEY[cat]);
-		if (manual && manual.trim()) return manual.trim();
+		// APP-03/04: validate the user-controlled override before trusting it as
+		// a GraphQL/indexer endpoint. Invalid/untrusted hosts fall through to
+		// the safe default rather than throwing.
+		if (manual && manual.trim() && isAllowedNodeUrl(manual.trim())) {
+			return manual.trim();
+		}
 	}
 	return autoSelectedNodeUrl(cat);
 }

--- a/src/lib/sendswap/stages/deposit/CoinBaseDeposit.svelte
+++ b/src/lib/sendswap/stages/deposit/CoinBaseDeposit.svelte
@@ -40,11 +40,13 @@
 				amount: coinAmount.toAmountString()
 			});
 
-			if (response.data.onrampUrl) {
-				window.location.href = response.data.onrampUrl;
+			// APP-11: only navigate to a trusted Coinbase onramp URL.
+			const onrampUrl = response.data.onrampUrl;
+			if (typeof onrampUrl === 'string' && onrampUrl.startsWith('https://pay.coinbase.com/')) {
+				window.location.href = onrampUrl;
 			} else {
 				isPurchasing = false;
-				console.error('No onramp URL received');
+				console.error('No valid onramp URL received');
 			}
 		} catch (error) {
 			isPurchasing = false;

--- a/src/lib/sendswap/utils/bitcoinAddress.ts
+++ b/src/lib/sendswap/utils/bitcoinAddress.ts
@@ -3,6 +3,12 @@ import * as crypto from 'crypto';
 
 const PUBLICKEY = '';
 
+/** APP-02: true when no signing pubkey is configured, in which case any
+ *  derived P2WSH address would be invalid/unspendable and must not be served. */
+export function isBtcDepositAddressAvailable(): boolean {
+	return PUBLICKEY.trim().length > 0;
+}
+
 export function currentUserBtcDepositAddress(did: string) {
 	let depositInstruction = `deposit_to=${did}`;
 	const tag = crypto.hash('sha256', depositInstruction);

--- a/src/lib/sendswap/utils/sendOptions.ts
+++ b/src/lib/sendswap/utils/sendOptions.ts
@@ -286,4 +286,7 @@ const swapOptions: {
 
 export default swapOptions;
 
-globalThis.coins = Coin;
+// APP-17: only expose internals on globalThis in development builds.
+if (import.meta.env.DEV) {
+	globalThis.coins = Coin;
+}

--- a/src/lib/stores/localStorageTxs.ts
+++ b/src/lib/stores/localStorageTxs.ts
@@ -22,6 +22,19 @@ export type PendingTx = {
 	type: string;
 };
 
+// APP-12: localStorage contents are user-controlled and may be corrupted;
+// never let a raw JSON.parse throw and break the transactions UI.
+function safeParseTxs(raw: string | null): TransactionInter[] {
+	if (!raw) return [];
+	try {
+		const parsed = JSON.parse(raw);
+		return Array.isArray(parsed) ? parsed : [];
+	} catch {
+		console.warn('Failed to parse local transactions; treating as empty');
+		return [];
+	}
+}
+
 function toPendingTransactionInter(ptx: PendingTx): TransactionInter {
 	``;
 	return {
@@ -38,7 +51,7 @@ function toPendingTransactionInter(ptx: PendingTx): TransactionInter {
 
 export function addLocalTransaction(tx: PendingTx) {
 	const txString = localStorage.getItem('transactions');
-	let txList: TransactionInter[] = txString ? JSON.parse(txString) : [];
+	let txList: TransactionInter[] = safeParseTxs(txString);
 	txList.push(toPendingTransactionInter(tx));
 	localStorage.setItem('transactions', JSON.stringify(txList));
 	updateTxsFromLocalStorage(tx.ops[0].data.from);
@@ -46,7 +59,7 @@ export function addLocalTransaction(tx: PendingTx) {
 
 export function getLocalTransactions(): TransactionInter[] {
 	const txString = localStorage.getItem('transactions');
-	const jsonTxs: TransactionInter[] = txString ? JSON.parse(txString) : [];
+	const jsonTxs: TransactionInter[] = safeParseTxs(txString);
 	for (const tx of jsonTxs) {
 		if (new Date().getTime() - new Date(tx.first_seen).getTime() > 24 * 60 * 60 * 1000) {
 			removeLocalTransaction(tx.id);
@@ -57,10 +70,10 @@ export function getLocalTransactions(): TransactionInter[] {
 
 export function removeLocalTransaction(id: string) {
 	const txString = localStorage.getItem('transactions');
-	const txList: TransactionInter[] = txString ? JSON.parse(txString) : null;
-	if (!txList) {
+	if (!txString) {
 		return Error('No items in local storage.');
 	}
+	const txList: TransactionInter[] = safeParseTxs(txString);
 	const newTxList = txList.filter((element, _) => element.id !== id);
 	localStorage.setItem('transactions', JSON.stringify(newTxList));
 }

--- a/src/lib/zag/QR.svelte
+++ b/src/lib/zag/QR.svelte
@@ -12,16 +12,36 @@
 		})
 	);
 	const api = $derived(qrCode.connect(service, normalizeProps));
+
+	// APP-19: only treat the QR payload as a navigable link when it uses an
+	// expected safe scheme; otherwise render a non-link container.
+	const safeHref = $derived(
+		typeof data === 'string' &&
+			(data.startsWith('lightning:') || data.startsWith('https://'))
+			? data
+			: undefined
+	);
 </script>
 
-<a href={data} {...api.getRootProps()}>
-	<svg {...api.getFrameProps()}>
-		<path {...api.getPatternProps()}></path>
-	</svg>
-	<div {...api.getOverlayProps()}>
-		<img src="magi-padded.svg" alt="" />
+{#if safeHref}
+	<a href={safeHref} {...api.getRootProps()}>
+		<svg {...api.getFrameProps()}>
+			<path {...api.getPatternProps()}></path>
+		</svg>
+		<div {...api.getOverlayProps()}>
+			<img src="magi-padded.svg" alt="" />
+		</div>
+	</a>
+{:else}
+	<div {...api.getRootProps()}>
+		<svg {...api.getFrameProps()}>
+			<path {...api.getPatternProps()}></path>
+		</svg>
+		<div {...api.getOverlayProps()}>
+			<img src="magi-padded.svg" alt="" />
+		</div>
 	</div>
-</a>
+{/if}
 
 <style>
 	[data-part='root'] {

--- a/src/routes/(authed)/+layout.ts
+++ b/src/routes/(authed)/+layout.ts
@@ -13,7 +13,7 @@ function isAuthenticated(): Promise<Auth | false> {
 
 		const handle = (v: Auth | { status: 'none', value: undefined }) => {
 			if (v.status === 'authenticated' || !browser) {
-				console.log('authenticated with value ', v.value);
+				// APP-15: removed console.log that leaked authenticated auth value.
 				resolve(v);
 				unsubscribe();
 			} else if (v.status === 'none') {

--- a/src/routes/(authed)/transactions/Table/tds/ToFrom.svelte
+++ b/src/routes/(authed)/transactions/Table/tds/ToFrom.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import BasicCopy from '$lib/components/BasicCopy.svelte';
 	import { getUsernameFromDid } from '$lib/getAccountName';
+	import { sanitizeBidiText } from '$lib';
 	import Avatar from '$lib/zag/Avatar.svelte';
 
 	let isHovered = $state(false);
@@ -8,6 +9,9 @@
 		otherAccount,
 		memo
 	}: { otherAccount: string; memo?: string | undefined } = $props();
+
+	// APP-14: strip bidi/control chars from the user-controlled memo.
+	let safeMemo = $derived(sanitizeBidiText(memo));
 </script>
 
 <td onmouseenter={() => (isHovered = true)} onmouseleave={() => (isHovered = false)}>
@@ -20,9 +24,9 @@
 				{getUsernameFromDid(otherAccount)}
 			</BasicCopy>
 		</span>
-		{#if memo}
+		{#if safeMemo}
 			<span class="memo">
-				"{memo}"
+				"{safeMemo}"
 			</span>
 		{/if}
 	</span>

--- a/src/routes/api/btcaddress/+server.ts
+++ b/src/routes/api/btcaddress/+server.ts
@@ -3,7 +3,10 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from '@sveltejs/kit';
 import { generateJwt } from '@coinbase/cdp-sdk/auth';
 import { COINBASE_ID, COINBASE_PRIVATE_KEY } from '$env/static/private';
-import { currentUserBtcDepositAddress } from '$lib/sendswap/utils/bitcoinAddress';
+import {
+	currentUserBtcDepositAddress,
+	isBtcDepositAddressAvailable
+} from '$lib/sendswap/utils/bitcoinAddress';
 
 export interface CoinbaseOnramp {
 	session: Session;
@@ -36,6 +39,12 @@ export const GET: RequestHandler = async ({ url }) => {
 
 	if (!did) {
 		return json({ error: 'Missing did parameter' }, { status: 400 });
+	}
+
+	// APP-02: with no configured signing pubkey the derived P2WSH address is
+	// invalid (funds would be unrecoverable). Refuse to hand it out.
+	if (!isBtcDepositAddressAvailable()) {
+		return json({ error: 'BTC deposit address feature unavailable' }, { status: 503 });
 	}
 
 	const btc_address = currentUserBtcDepositAddress(did);

--- a/src/routes/api/coin-market-data/+server.ts
+++ b/src/routes/api/coin-market-data/+server.ts
@@ -3,8 +3,17 @@ import axios from 'axios';
 import type { RequestHandler } from '@sveltejs/kit';
 import type { CoinMarketResponse } from '$lib/currency/historical';
 import { CMC_API_KEY } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 
-export const GET: RequestHandler = async ({ url }) => {
+export const GET: RequestHandler = async ({ url, request }) => {
+	// APP-09: reject cross-origin callers so the CMC-keyed proxy is only
+	// usable same-origin from the app itself.
+	const allowedOrigin = (env.ALTERA_ORIGIN || url.origin).toLowerCase();
+	const reqOrigin = request.headers.get('origin');
+	if (reqOrigin === null || reqOrigin.toLowerCase() !== allowedOrigin) {
+		return json({ error: 'forbidden' }, { status: 403 });
+	}
+
 	const id = url.searchParams.get('id');
 	const time_start = url.searchParams.get('time_start');
 	const time_end = url.searchParams.get('time_end');

--- a/src/routes/api/coinbase/+server.ts
+++ b/src/routes/api/coinbase/+server.ts
@@ -1,124 +1,17 @@
-import axios from 'axios';
-import { json } from '@sveltejs/kit';
 import type { RequestHandler } from '@sveltejs/kit';
-import { generateJwt } from '@coinbase/cdp-sdk/auth';
-import { COINBASE_ID, COINBASE_PRIVATE_KEY, ALTERA_ORIGIN } from '$env/static/private';
-import { currentUserBtcDepositAddress } from '$lib/sendswap/utils/bitcoinAddress';
 
-export interface CoinbaseOnramp {
-	session: Session;
-	quote: Quote;
-}
+// APP-01: The Coinbase onramp is disabled.
+//
+// The previous implementation fell back to a hardcoded developer BTC wallet
+// (`bc1qqdg2720lvh3l0ydjaw6smqffm76yag59jlsh8v`) because per-user deposit
+// address derivation is not yet available (empty PUBLICKEY, see APP-02).
+// Any user completing a purchase would have sent funds to that single wallet
+// (real fund-loss path). It also performed an unvalidated client-IP geo
+// lookup (APP-07). The entire onramp handler — including the hardcoded
+// wallet and the geo lookup — has been removed until proper per-user
+// derivation is restored. Re-enabling requires reinstating
+// `currentUserBtcDepositAddress(did)` with a real contract pubkey.
 
-export interface Quote {
-	paymentTotal: string;
-	paymentSubtotal: string;
-	paymentCurrency: string;
-	purchaseAmount: string;
-	purchaseCurrency: string;
-	destinationNetwork: string;
-	fees: Fee[];
-	exchangeRate: string;
-}
-
-export interface Fee {
-	type: string;
-	amount: string;
-	currency: string;
-}
-
-export interface Session {
-	onrampUrl: string;
-}
-
-const COINBASE_SESSION_EXPIRY_TIME = 30; // 30 seconds
-
-async function getGeoFromIp(
-	ip: string | null
-): Promise<{ country?: string; subdivision?: string }> {
-	if (!ip) return {};
-
-	try {
-		const { data } = await axios.get(`https://ipapi.co/${ip}/json/`);
-		const country = typeof data.country_code === 'string' ? data.country_code : undefined;
-		const subdivision = typeof data.region_code === 'string' ? data.region_code : undefined;
-
-		return { country, subdivision };
-	} catch (error) {
-		console.error('Failed to resolve geo from IP', error);
-		return {};
-	}
-}
-
-export const POST: RequestHandler = async ({ request, getClientAddress }) => {
-	const responseHeader: HeadersInit = {
-		'Cache-Control': 'no-cache',
-		'Access-Control-Allow-Origin': ALTERA_ORIGIN,
-		'Access-Control-Allow-Methods': 'POST, OPTIONS'
-	};
-
-	const requestOrigin = request.headers.get('origin');
-	if (requestOrigin === null || requestOrigin.toLowerCase() !== ALTERA_ORIGIN) {
-		return new Response('CORS failed', { status: 403, headers: responseHeader });
-	}
-
-	const requestBody = await request.json();
-	if (!requestBody.did || !requestBody.amount) {
-		return json({ error: 'invalid request' }, { status: 400, headers: responseHeader });
-	}
-
-	const { did, amount } = requestBody;
-
-	const paymentAmount = Number(amount);
-	if (isNaN(paymentAmount)) {
-		return json({ error: 'invalid fiat amount' }, { status: 400, headers: responseHeader });
-	}
-
-	// const walletAddr = currentUserBtcDepositAddress(did);
-	// temporary (my wallet address) until Coinbase approval
-	const walletAddr = 'bc1qqdg2720lvh3l0ydjaw6smqffm76yag59jlsh8v';
-	const clientIp = getClientAddress();
-
-	const { country, subdivision } = await getGeoFromIp(clientIp);
-
-	try {
-		const jwtToken = await generateJwt({
-			apiKeyId: COINBASE_ID,
-			apiKeySecret: COINBASE_PRIVATE_KEY,
-			requestMethod: 'POST',
-			requestHost: 'api.cdp.coinbase.com',
-			requestPath: '/platform/v2/onramp/sessions',
-			expiresIn: COINBASE_SESSION_EXPIRY_TIME
-		});
-
-		const request = await axios.post<CoinbaseOnramp>(
-			'https://api.cdp.coinbase.com/platform/v2/onramp/sessions',
-			{
-				destinationAddress: walletAddr,
-				purchaseCurrency: 'BTC',
-				destinationNetwork: 'bitcoin',
-				paymentAmount: paymentAmount.toString(),
-				paymentCurrency: 'USD',
-				paymentMethod: 'CARD',
-				country: country ?? 'US',
-				subdivision: subdivision ?? 'NY',
-				clientIp: clientIp,
-				redirectUrl: 'https://altera.magi.eco/' // TODO: create a custom url for purcase receipt
-			},
-			{
-				headers: {
-					Authorization: `Bearer ${jwtToken}`,
-					'Content-Type': 'application/json'
-				}
-			}
-		);
-
-		return json(
-			{ onrampUrl: request.data.session.onrampUrl },
-			{ status: 200, headers: responseHeader }
-		);
-	} catch (error) {
-		console.error(error);
-		return json({ error: 'Something went wrong.' }, { status: 500, headers: responseHeader });
-	}
+export const POST: RequestHandler = async () => {
+	return new Response('Coinbase onramp disabled', { status: 503 });
 };

--- a/src/routes/api/mapping-bot/+server.ts
+++ b/src/routes/api/mapping-bot/+server.ts
@@ -1,4 +1,5 @@
 import { json, error } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
 import type { RequestHandler } from './$types';
 
 // The mapping bot runs outside our infra and has no CORS headers,
@@ -10,7 +11,14 @@ export const prerender = false;
 const MAPPING_BOT_MAINNET = 'https://btc.magi.milohpr.com';
 const MAPPING_BOT_TESTNET = 'https://btc.testnet.magi.milohpr.com';
 
-export const POST: RequestHandler = async ({ request }) => {
+export const POST: RequestHandler = async ({ request, url }) => {
+	// APP-05: reject cross-origin callers — this is an internal same-origin proxy.
+	const allowedOrigin = (env.ALTERA_ORIGIN || url.origin).toLowerCase();
+	const reqOrigin = request.headers.get('origin');
+	if (reqOrigin === null || reqOrigin.toLowerCase() !== allowedOrigin) {
+		throw error(403, 'forbidden');
+	}
+
 	let body: { instruction?: unknown; network?: unknown };
 	try {
 		body = await request.json();
@@ -23,7 +31,11 @@ export const POST: RequestHandler = async ({ request }) => {
 		throw error(400, 'instruction required');
 	}
 
-	const network = body.network === 'testnet' ? 'testnet' : 'mainnet';
+	// APP-05: require an explicit, valid network — no silent mainnet default.
+	if (body.network !== 'testnet' && body.network !== 'mainnet') {
+		throw error(400, "network must be 'testnet' or 'mainnet'");
+	}
+	const network = body.network;
 	const upstream = network === 'testnet' ? MAPPING_BOT_TESTNET : MAPPING_BOT_MAINNET;
 
 	const res = await fetch(upstream, {

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -10,8 +10,15 @@
 	let loginOpen = $state(false);
 
 	let auth = $derived(getAuth()());
-	let redirectTo =
-		browser && new URL(localStorage.getItem('redirect_url') ?? window.location.origin);
+	// APP-10: never honour a stored redirect that points off-origin (open
+	// redirect via attacker-controlled localStorage / login link). Computed
+	// once (no reassignment) so it stays a non-reactive init-time constant.
+	const redirectTo = browser
+		? (() => {
+				const url = new URL(localStorage.getItem('redirect_url') ?? window.location.origin);
+				return url.origin === window.location.origin ? url : new URL(window.location.origin);
+			})()
+		: false;
 	$effect(() => {
 		if (auth?.status == 'authenticated' && browser) {
 			localStorage.removeItem('redirect_url');

--- a/static/humans.txt
+++ b/static/humans.txt
@@ -1,19 +1,8 @@
 /* TEAM */
-	Frontend Developer: Milo Ridenour
-	GitHub: miloridenour
-
-	Former Frontend Developer: Zephiris Evergreen
-	Site: zephiris.me
-	Pronouns: they/them
-	Contact: z [at] zephiris.me
-	GitHub: zphrs
-	Location: Bay Area, Califonia, United States
-
-	CTO: Vaultec
-	Site: https://peakd.com/@vaultec
-	Twitter: vaultec81
-	GitHub: vaultec81
+	Team: Okinoko / VSC contributors
+	Site: https://altera.magi.eco
 
 /* THANKS */
 
-Name: Geo https://peakd.com/@geo52rey
+	Project: VSC (Vite Smart Contracts) ecosystem
+	Site: https://docs.magi.eco


### PR DESCRIPTION
Addresses the Altera findings from the external audit cross-reference (reviews3 APP-01..APP-22):

- APP-01: disable Coinbase onramp route + delete hardcoded dev BTC wallet and the unvalidated client-IP geo lookup (APP-07) dead code
- APP-02: 503 the btcaddress route while the deposit pubkey is empty
- APP-05: mapping-bot proxy now requires explicit network + same-origin
- APP-03/04: validate localStorage node-URL overrides against a host allowlist, fall back to defaults on invalid input
- APP-08: baseline security headers + CSP (frame-ancestors 'none', worker-src 'self', object-src 'none'); intentionally permissive
- APP-09: same-origin check on the CMC proxy
- APP-10: force post-login redirect to same origin (computed once)
- APP-11: only navigate to https://pay.coinbase.com/ onramp URLs
- APP-12: try/catch + safe fallback around localStorage tx JSON.parse
- APP-14: strip bidi/control chars before rendering memos
- APP-15: drop auth-value console.log
- APP-16: WalletConnect projectId from $env/static/public
- APP-17: gate globalThis debug exposure on import.meta.env.DEV
- APP-19: validate QR href scheme (lightning:/https: only)
- APP-21: scrub personal contact info from humans.txt

svelte-check unchanged at baseline (217 errors / 32 warnings, 0 net new). CHANGELOG.md updated.