### PR TITLE
fix(prod): allow Vercel Analytics in CSP + prune dead Hive RPC fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Altera are documented here.
 
+## [0.3.6] — 2026-05-20
+
+### Fixes
+- CSP now allows `https://va.vercel-scripts.com` — Vercel Web Analytics was being blocked in prod by the audit-added `script-src`. Listed in both `script-src` and `script-src-elem` for browsers that consult the latter first
+- Pruned `https://techcoderx.com` and `https://api.deathwing.me` from `FALLBACK_HIVE_RPC_NODES` — both unreachable from the browser (0% uptime / 503 / no CORS) so they only generated console noise on every health probe. Users can still add them back via `PUBLIC_HIVE_RPC_NODES` env var
+
 ## [0.3.5] — 2026-05-20
 
 ### Swap (QuickSwap dashboard card)

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -33,11 +33,16 @@ export const handle: Handle = async ({ event, resolve }) => {
 		'Permissions-Policy',
 		'geolocation=(), microphone=(), camera=()'
 	);
+	// va.vercel-scripts.com hosts Vercel Web Analytics; without it `script-src`
+	// blocks the analytics bundle. Listed in both `script-src` and
+	// `script-src-elem` because some browsers consult the latter for <script>
+	// tag loads and fall back to `script-src` only when it's absent.
 	response.headers.set(
 		'Content-Security-Policy',
 		[
 			"default-src 'self'",
-			"script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+			"script-src 'self' 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com",
+			"script-src-elem 'self' 'unsafe-inline' https://va.vercel-scripts.com",
 			"style-src 'self' 'unsafe-inline'",
 			"img-src 'self' data: blob: https:",
 			"font-src 'self' data:",

--- a/src/lib/nodeSelection/env.ts
+++ b/src/lib/nodeSelection/env.ts
@@ -8,11 +8,20 @@ export const FALLBACK_INDEXER_NODES = [
 	'https://indexer.magi.milohpr.com'
 ];
 export const FALLBACK_VSC_API_NODES = ['https://api.vsc.eco', 'https://vsc.techcoderx.com'];
+// Dropped previously-listed nodes that are unreachable from the browser:
+//   - techcoderx.com:    Hive node registry shows 0% uptime, no CORS
+//   - api.deathwing.me:  recently returning 503, no CORS for our origin
+// Both polluted the browser console with CORS errors on every probe. Kept
+// only nodes with a recent track record of liveness (>= 97% per the public
+// Hive node registry). First node is what the resolver falls back to when
+// browser probes fail (which is currently always — Hive RPCs don't expose
+// CORS for our origin). Users can still override via PUBLIC_HIVE_RPC_NODES.
 export const FALLBACK_HIVE_RPC_NODES = [
 	'https://api.hive.blog',
 	'https://api.openhive.network',
-	'https://techcoderx.com',
-	'https://api.deathwing.me'
+	'https://api.c0ff33a.uk',
+	'https://hapi.ecency.com',
+	'https://api.syncad.com'
 ];
 
 /** Parse a comma-separated node list; bare hosts get https://; trailing


### PR DESCRIPTION
Two follow-ups to the audit / multi-node PRs that landed in the last day:

- **CSP**: `script-src` now allows `https://va.vercel-scripts.com` (and `script-src-elem` for browsers that consult that one first). Without this, Vercel Web Analytics was silently blocked in prod.
- **Hive RPC fallbacks**: dropped `techcoderx.com` (0% uptime, no CORS) and `api.deathwing.me` (503, no CORS). Replaced with three healthy nodes from the public Hive registry (97-100% uptime): `api.c0ff33a.uk`, `hapi.ecency.com`, `api.syncad.com`.