### PR TITLE
Eliminate CORS: same-origin GraphQL proxy + server-side node probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,27 +2,44 @@
 
 All notable changes to Altera are documented here.
 
+## [0.3.7] — 2026-05-21
+
+### Infrastructure (CORS elimination)
+
+- All GraphQL requests now route through a same-origin server proxy (`/api/gql?service=vsc|indexer`) instead of being fetched cross-origin from the browser. The backend tightened its CORS policy during the security audit, so non-default nodes (e.g. a user's own `magi.milohpr.com`) failed preflight; forwarding server-to-server sidesteps CORS entirely while preserving per-user node switching via the `x-gql-upstream` header. SSRF-guarded against the shared node allowlist
+- Node health probes (`refreshNode`) now run server-side via `/api/node-probe?category=indexer|vsc|hive` instead of probing nodes from the browser. Hive RPC and several indexer/VSC nodes don't expose CORS for our origin, so client-side probing always failed, spammed the console on every page load, and meant Hive auto-selection never actually worked. Server-to-server probing has no CORS, so freshness ranking is now real
+- Hive account lookups (`getHiveAccounts`) and profile-pic fetches now pass our configured Hive node instead of Aioha's hardcoded `techcoderx.com` default (which is down / lacks CORS)
+
+### Fixes
+
+- Fixed two `select.test.ts` fixtures that used non-allowlisted hostnames (`my-manual`, `legacy-custom`) and started failing once manual overrides were gated against the allowlist (APP-03/04)
+
 ## [0.3.6] — 2026-05-20
 
 ### Fixes
+
 - CSP now allows `https://va.vercel-scripts.com` — Vercel Web Analytics was being blocked in prod by the audit-added `script-src`. Listed in both `script-src` and `script-src-elem` for browsers that consult the latter first
 - Pruned `https://techcoderx.com` and `https://api.deathwing.me` from `FALLBACK_HIVE_RPC_NODES` — both unreachable from the browser (0% uptime / 503 / no CORS) so they only generated console noise on every health probe. Users can still add them back via `PUBLIC_HIVE_RPC_NODES` env var
 
 ## [0.3.5] — 2026-05-20
 
 ### Swap (QuickSwap dashboard card)
+
 - Detail rows now spread vertically with `flex: 1` + `space-evenly` so the area between slippage and the Swap button doesn't sit half-empty
 - "Min amount received" and "Price impact" are always visible — show `—` placeholder until the pool calc resolves, instead of popping in and out and shifting layout
 - Cleared FROM amount now correctly empties the TO field (was leaving the stale converted value behind because `expectedOutput` wasn't being reset in early-return branches of the swap calc)
 - Empty TO field renders the grey placeholder instead of literal "0" after clearing FROM
 
 ### Infrastructure
+
 - Balance-history GraphQL query batched into chunks of 12 aliases (84 field selections) with bounded concurrency of 4 parallel requests — satisfies the indexer's new 100-selection cap (security hardening on the backend) and avoids flooding the browser's per-origin connection pool on 365-day ranges
 
 ### Fixes
+
 - Portfolio chart default range: dropdown label and graph data now agree on "Last 7 Days" at first load (previously the dropdown said 7 days while the data was for 30)
 
 ### Internals (TX state cleanup pass 2)
+
 - Removed redundant `enteredAmount` fallback from `TxStateBase` — relied-upon comment admitted it was in the wrong denomination across coins; consumers now use `fromAmount`/`toAmount` with proper conversion
 - Moved `fee` field from `TxStateBase` to the per-flow subclasses that actually carry one (`SwapTxState`, `DepositTxState`, `WithdrawTxState` — not `TransferTxState`)
 - Generalized `btcDeductFee` / `btcMaxFee` (now `deductFee` / `maxFee`) and moved them off the base class to `WithdrawTxState` + `TransferTxState` only — `sendUtils` reads them via `instanceof` narrowing
@@ -32,37 +49,44 @@ All notable changes to Altera are documented here.
 ## [0.3.4] — 2026-05-20
 
 ### Lightning
+
 - Added Lightning withdraw support for KeepSats on v4vapp
 - Added Lightning deposit support for Sats direct via v4vapp
 
 ## [0.3.3] — 2026-05-19
 
 ### Security
+
 - Baseline security response headers added (`hooks.server.ts`): `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy` (geolocation/microphone/camera off), and a Content-Security-Policy with `frame-ancestors 'none'`, `worker-src 'self'`, and `object-src 'none'` — addresses the missing clickjacking/MIME-sniffing protections (audit APP-08). CSP is intentionally permissive (keeps `'unsafe-inline'`/`'unsafe-eval'` for SvelteKit hydration and the WASM-based Hive signer) so it hardens framing/sniffing without breaking the app
 
 ### Infrastructure
+
 - Multi-node failover: indexer / VSC API / Hive RPC endpoints are health-checked on app open and the freshest node is auto-selected (5-min cache); optional `PUBLIC_INDEXER_NODES` / `PUBLIC_VSC_API_NODES` / `PUBLIC_HIVE_RPC_NODES` runtime overrides, hardcoded fallbacks otherwise
 - Preferences: per-endpoint "Custom" toggle to pin a specific node (off = automatic, shows the auto-selected node)
 
 ## [0.3.2] — 2026-05-18
 
 ### Swap
+
 - Selected token chips (FROM/TO) now show a thin purple border + role badge instead of being dimmed
 - Disabled tokens: cleaner dim treatment; removed diagonal strike-through
 - Tooltip on disabled chips is now readable (was rendering see-through due to parent opacity)
 
 ### Infrastructure
+
 - Update toast no longer polls every 2 minutes — checks version on tab visibility change instead
 - Dismissing the update toast remembers the version (sessionStorage) so it doesn't keep nagging for the same update
 - New reusable `Tooltip` component (`$lib/components/Tooltip.svelte`) shared by chip + swap-arrow tooltips
 
 ### Internals
+
 - Removed dead `enabled()` callbacks from `Coin` and `Network` definitions
 - Removed unused `account` field from `TxStateBase` (cleaner type, dropped always-false template branches in `ReviewTransfer`)
 
 ## [0.3.1] — 2026-05-18
 
 ### Tokens
+
 - Bump `@vsc.eco/token-widget` to 0.0.2
 - NFT details modal — click an NFT tile to see its info
 - Template-id mint tab in the token widget
@@ -70,6 +94,7 @@ All notable changes to Altera are documented here.
 ## [0.3.0] — 2026-05-15
 
 ### Swap
+
 - Interactive swap direction toggle with icon crossfade (single arrow → double arrow on hover)
 - Auto-switch tokens when picking a token already in the other slot
 - FROM/TO role badges on selected token chips in picker dialog
@@ -77,16 +102,19 @@ All notable changes to Altera are documented here.
 - Replace TO display with AmountInput for consistent digit alignment
 
 ### Fixes
+
 - Dialog close button not clickable in nested modals (deposit review)
 - Lightning deposit currency picker no longer shows HIVE/HBD options
 
 ### Infrastructure
+
 - Deploy notification toast — polls server version, prompts refresh on new deploy
 - CHANGELOG.md for release tracking
 
 ## [0.2.0] — 2026-05-15
 
 ### Swap
+
 - Gate "Review Swap" button on pool data; retry on fetch failure
 - Show loading state while pool values and min-amount load
 - "Price unavailable" fallback when price feeds are down
@@ -95,19 +123,23 @@ All notable changes to Altera are documented here.
 - Discard stale exchange-rate estimates when pool calc resolves
 
 ### Dashboard
+
 - Balance card height matches portfolio; scrollable token list
 - Isolate CoinGecko ETH fetch so it fails independently
 - Improve layout filling; add Ethereum to market prices
 
 ### Pools
+
 - Label LP and protocol fees separately in fee column
 - Click a pool transaction row to open inline detail popup
 - Fix duplicate pool rows; show token symbol in fallback icons
 
 ### Transactions
+
 - Display add-liquidity and remove-liquidity as distinct transaction types
 
 ### Fixes
+
 - Catch-all route activates 404 handler on unknown paths
 - Lowercase EVM address in EIP-155 DIDs (fixes balance not showing for EVM wallets)
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,11 +13,8 @@ export const keyTbd = 'prefs-tbd';
 const DEFAULT_VSC_NET_ID = 'vsc-mainnet';
 
 /** Default Magi indexer (Hasura) base URL — same as okinoko/prod.
- *  The Hasura `/v1/graphql` path is appended by getMagiIndexerUrl(). */
+ *  The `/v1/graphql` path is appended by the GraphQL proxy route. */
 export const DEFAULT_MAGI_INDEXER_URL = 'https://indexer.magi.milohpr.com';
-
-/** Standard Hasura GraphQL path suffix. */
-export const HASURA_GRAPHQL_PATH = '/v1/graphql';
 
 /** DEX Router contract — routes swaps and BTC/HBD liquidity deposits.
  *  Network-switched between mainnet and testnet. */
@@ -36,32 +33,36 @@ export const vscNetworkId =
 /** True when the configured VSC network is the testnet. */
 export const isVscTestnet = (): boolean => vscNetworkId === 'vsc-testnet';
 
-/** Configured Magi indexer base URL — falls back to okinoko/prod. */
+/** Configured Magi indexer base URL — falls back to okinoko/prod.
+ *  The GraphQL path is appended by the proxy route, not here. */
 export const getMagiIndexerBaseUrl = (): string =>
 	browser ? resolveNodeUrl('indexer') : DEFAULT_MAGI_INDEXER_URL;
-
-/** Fully-qualified Hasura GraphQL URL (base + /v1/graphql).
- *  Use this when you need to issue a query. */
-export const getMagiIndexerUrl = (): string => {
-	const base = getMagiIndexerBaseUrl().replace(/\/+$/, '');
-	return base + HASURA_GRAPHQL_PATH;
-};
 
 /** Display unit for Hive (e.g. TESTS on testnet). Use for UI only. */
 export const getHiveAssetName = (): string => (browser && localStorage.getItem(keyTests)) || 'HIVE';
 /** Display unit for HBD (e.g. TBD on testnet). Use for UI only. */
 export const getHbdAssetName = (): string => (browser && localStorage.getItem(keyTbd)) || 'HBD';
 
-export default new HoudiniClient({
-	url: currentGqlUrl + '/api/v1/graphql'
+/**
+ * Same-origin GraphQL proxy endpoint. The browser POSTs here instead of
+ * hitting the upstream node directly, so the audit-tightened CORS on the
+ * backend no longer blocks non-default nodes. The chosen node is passed via
+ * the `x-gql-upstream` header (see routes/api/gql/+server.ts).
+ */
+export const GQL_PROXY_VSC = '/api/gql?service=vsc';
+export const GQL_PROXY_INDEXER = '/api/gql?service=indexer';
 
-	// uncomment this to configure the network call (for things like authentication)
-	// for more information, please visit here: https://www.houdinigraphql.com/guides/authentication
-	// fetchParams({ session }) {
-	//     return {
-	//         headers: {
-	//             Authentication: `Bearer ${session.token}`,
-	//         }
-	//     }
-	// }
+/** Header carrying the chosen upstream node base URL to the GQL proxy. */
+export function gqlUpstreamHeaders(base: string): Record<string, string> {
+	return { 'content-type': 'application/json', 'x-gql-upstream': base };
+}
+
+export default new HoudiniClient({
+	url: GQL_PROXY_VSC,
+	// Inject the chosen VSC node as the upstream the proxy should forward to.
+	fetchParams() {
+		return {
+			headers: { 'x-gql-upstream': currentGqlUrl }
+		};
+	}
 });

--- a/src/lib/auth/hive/getHiveAccounts.ts
+++ b/src/lib/auth/hive/getHiveAccounts.ts
@@ -1,0 +1,14 @@
+import { getAccounts } from '@aioha/aioha/build/rpc';
+import { browser } from '$app/environment';
+import { resolveNodeUrl } from '$lib/nodeSelection/select';
+
+/**
+ * Aioha's standalone `getAccounts()` defaults to a hardcoded RPC
+ * (`techcoderx.com`, which is currently down and exposes no CORS headers).
+ * This wrapper passes our configured Hive node instead, so account lookups
+ * respect the user's node choice and hit a reachable, CORS-friendly endpoint.
+ */
+export function getHiveAccounts(usernames: string[]) {
+	const node = browser ? resolveNodeUrl('hive') : 'https://api.hive.blog';
+	return getAccounts(usernames, node);
+}

--- a/src/lib/auth/hive/index.ts
+++ b/src/lib/auth/hive/index.ts
@@ -23,7 +23,10 @@ const HIVE_MAINNET_API = browser ? resolveNodeUrl('hive') : 'https://api.hive.bl
 const HIVE_TESTNET_API = 'https://testnet.techcoderx.com';
 
 async function getProfilePicUrl(username: string) {
-	const res: Account = (await getAccounts([username])).result[0];
+	// getAccounts() defaults to Aioha's hardcoded RPC (techcoderx.com, which is
+	// down / lacks CORS). Pass our configured Hive node so this respects the
+	// user's node choice and uses a reachable endpoint.
+	const res: Account = (await getAccounts([username], HIVE_MAINNET_API)).result[0];
 	if (res) return postingMetadataFromString(res.posting_json_metadata).profile.profile_image;
 }
 let aioha: Aioha;

--- a/src/lib/indexer/query.ts
+++ b/src/lib/indexer/query.ts
@@ -1,4 +1,4 @@
-import { getMagiIndexerUrl } from '../../client';
+import { getMagiIndexerBaseUrl, GQL_PROXY_INDEXER, gqlUpstreamHeaders } from '../../client';
 
 export interface AggregateResult {
 	aggregate: {
@@ -26,9 +26,9 @@ export async function hasuraQueryRaw<T = Record<string, unknown>>(
 	query: string,
 	variables: Record<string, unknown>
 ): Promise<{ data: T | null; errors: Array<{ message: string }> | null }> {
-	const res = await fetch(getMagiIndexerUrl(), {
+	const res = await fetch(GQL_PROXY_INDEXER, {
 		method: 'POST',
-		headers: { 'content-type': 'application/json' },
+		headers: gqlUpstreamHeaders(getMagiIndexerBaseUrl()),
 		body: JSON.stringify({ query, variables })
 	});
 	const json = await res.json();

--- a/src/lib/nodeSelection/allowlist.ts
+++ b/src/lib/nodeSelection/allowlist.ts
@@ -1,0 +1,42 @@
+/**
+ * Allowlist for node/upstream URLs.
+ *
+ * Used in two places:
+ *  - select.ts: gating manual node overrides (APP-03/04)
+ *  - routes/api/gql/+server.ts: SSRF guard on the GraphQL proxy's
+ *    `x-gql-upstream` header — the server will only forward to a host
+ *    on this list, so a hostile client can't turn the proxy into an
+ *    open relay.
+ */
+export const ALLOWED_ROOT_DOMAINS = [
+	'okinoko.io',
+	'magi.eco',
+	'vsc.eco',
+	'techcoderx.com',
+	'milohpr.com',
+	'hive.blog',
+	'openhive.network',
+	'deathwing.me'
+];
+
+/**
+ * True when `raw` is an https URL whose host is one of ALLOWED_ROOT_DOMAINS
+ * (or a subdomain), or an http URL on localhost (dev only).
+ */
+export function isAllowedNodeUrl(raw: string): boolean {
+	let u: URL;
+	try {
+		u = new URL(raw);
+	} catch {
+		return false;
+	}
+	const host = u.hostname.toLowerCase();
+	const isLocalhost = host === 'localhost' || host === '127.0.0.1' || host === '[::1]';
+	if (u.protocol === 'http:') {
+		if (!isLocalhost) return false;
+	} else if (u.protocol !== 'https:') {
+		return false;
+	}
+	if (isLocalhost) return true;
+	return ALLOWED_ROOT_DOMAINS.some((root) => host === root || host.endsWith('.' + root));
+}

--- a/src/lib/nodeSelection/select.test.ts
+++ b/src/lib/nodeSelection/select.test.ts
@@ -2,12 +2,6 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
 // $app/environment → pretend we're in the browser
 vi.mock('$app/environment', () => ({ browser: true }));
-// keep probes deterministic
-vi.mock('./probes', () => ({
-	probeIndexer: vi.fn(async () => 'https://picked-indexer'),
-	probeVscApi: vi.fn(async () => 'https://picked-vsc'),
-	probeHiveRpc: vi.fn(async () => 'https://picked-hive')
-}));
 vi.mock('./env', () => ({
 	indexerNodes: ['https://idx-default', 'https://idx-2'],
 	vscApiNodes: ['https://vsc-default'],
@@ -18,12 +12,24 @@ import { resolveNodeUrl, refreshNode, isManualMode, autoSelectedNodeUrl } from '
 
 class MemStorage {
 	m = new Map<string, string>();
-	getItem(k: string) { return this.m.has(k) ? this.m.get(k)! : null; }
-	setItem(k: string, v: string) { this.m.set(k, v); }
-	removeItem(k: string) { this.m.delete(k); }
-	clear() { this.m.clear(); }
-	key() { return null; }
-	get length() { return this.m.size; }
+	getItem(k: string) {
+		return this.m.has(k) ? this.m.get(k)! : null;
+	}
+	setItem(k: string, v: string) {
+		this.m.set(k, v);
+	}
+	removeItem(k: string) {
+		this.m.delete(k);
+	}
+	clear() {
+		this.m.clear();
+	}
+	key() {
+		return null;
+	}
+	get length() {
+		return this.m.size;
+	}
 }
 
 beforeEach(() => {
@@ -40,18 +46,21 @@ describe('resolveNodeUrl precedence', () => {
 		localStorage.setItem('node-auto-indexer', 'https://cached-idx');
 		expect(resolveNodeUrl('indexer')).toBe('https://cached-idx');
 	});
+	// Manual-override fixtures must be allowlisted hosts: resolveNodeUrl gates
+	// them through isAllowedNodeUrl (APP-03/04), so a bare label like
+	// `https://my-manual` would be rejected and fall through to the default.
 	it('manual mode + manual key beats auto cache', () => {
-		localStorage.setItem('node-auto-indexer', 'https://cached-idx');
+		localStorage.setItem('node-auto-indexer', 'https://cached-idx.okinoko.io');
 		localStorage.setItem('node-mode-indexer', 'manual');
-		localStorage.setItem('magi-indexer-url', 'https://my-manual');
+		localStorage.setItem('magi-indexer-url', 'https://my-manual.okinoko.io');
 		expect(isManualMode('indexer')).toBe(true);
-		expect(resolveNodeUrl('indexer')).toBe('https://my-manual');
+		expect(resolveNodeUrl('indexer')).toBe('https://my-manual.okinoko.io');
 	});
 	it('legacy migration: manual key set + no mode key → manual', () => {
-		localStorage.setItem('node-auto-vsc', 'https://cached-vsc');
-		localStorage.setItem('vsc-gql-url', 'https://legacy-custom');
+		localStorage.setItem('node-auto-vsc', 'https://cached-vsc.vsc.eco');
+		localStorage.setItem('vsc-gql-url', 'https://legacy-custom.vsc.eco');
 		expect(isManualMode('vsc')).toBe(true);
-		expect(resolveNodeUrl('vsc')).toBe('https://legacy-custom');
+		expect(resolveNodeUrl('vsc')).toBe('https://legacy-custom.vsc.eco');
 	});
 	it('autoSelectedNodeUrl ignores manual override (cache → env first)', () => {
 		expect(autoSelectedNodeUrl('indexer')).toBe('https://idx-default');
@@ -70,23 +79,33 @@ describe('resolveNodeUrl precedence', () => {
 });
 
 describe('refreshNode', () => {
+	// refreshNode now probes server-side via GET /api/node-probe, so we stub
+	// the global fetch rather than the (server-only) probe functions.
 	it('probes and writes cache + timestamp when stale', async () => {
+		const fetchMock = vi.fn(async () => ({
+			ok: true,
+			json: async () => ({ url: 'https://picked-vsc' })
+		}));
+		vi.stubGlobal('fetch', fetchMock);
 		await refreshNode('vsc');
+		expect(fetchMock).toHaveBeenCalledWith('/api/node-probe?category=vsc');
 		expect(localStorage.getItem('node-auto-vsc')).toBe('https://picked-vsc');
 		expect(Number(localStorage.getItem('node-auto-ts-vsc'))).toBeGreaterThan(0);
 	});
 	it('skips probing when cache is fresh', async () => {
-		const probes = await import('./probes');
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
 		localStorage.setItem('node-auto-hive', 'https://still-good');
 		localStorage.setItem('node-auto-ts-hive', String(Date.now()));
 		await refreshNode('hive');
-		expect(probes.probeHiveRpc).not.toHaveBeenCalled();
+		expect(fetchMock).not.toHaveBeenCalled();
 		expect(localStorage.getItem('node-auto-hive')).toBe('https://still-good');
 	});
 	it('skips probing in manual mode', async () => {
-		const probes = await import('./probes');
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
 		localStorage.setItem('node-mode-vsc', 'manual');
 		await refreshNode('vsc');
-		expect(probes.probeVscApi).not.toHaveBeenCalled();
+		expect(fetchMock).not.toHaveBeenCalled();
 	});
 });

--- a/src/lib/nodeSelection/select.ts
+++ b/src/lib/nodeSelection/select.ts
@@ -1,6 +1,9 @@
 import { browser } from '$app/environment';
 import { indexerNodes, vscApiNodes, hiveRpcNodes } from './env';
-import { probeIndexer, probeVscApi, probeHiveRpc } from './probes';
+// APP-03/04: manual node overrides are gated against an allowlist. The list +
+// validator live in ./allowlist so the GraphQL proxy server route can reuse
+// the exact same SSRF guard.
+import { isAllowedNodeUrl } from './allowlist';
 
 export type Category = 'indexer' | 'vsc' | 'hive';
 
@@ -33,46 +36,6 @@ const NODES: Record<Category, string[]> = {
 	vsc: vscApiNodes,
 	hive: hiveRpcNodes
 };
-const PROBE: Record<Category, (n: string[]) => Promise<string>> = {
-	indexer: probeIndexer,
-	vsc: probeVscApi,
-	hive: probeHiveRpc
-};
-
-/** APP-03/04: allowlisted root domains for manual node overrides. A manual
- *  override URL is only honoured when it is https (or http on localhost) and
- *  its hostname is one of these roots or a subdomain thereof. Anything else is
- *  ignored and resolution falls back to the auto/default node. */
-const ALLOWED_ROOT_DOMAINS = [
-	'okinoko.io',
-	'magi.eco',
-	'vsc.eco',
-	'techcoderx.com',
-	'milohpr.com',
-	'hive.blog',
-	'openhive.network',
-	'deathwing.me'
-];
-
-function isAllowedNodeUrl(raw: string): boolean {
-	let u: URL;
-	try {
-		u = new URL(raw);
-	} catch {
-		return false;
-	}
-	const host = u.hostname.toLowerCase();
-	const isLocalhost = host === 'localhost' || host === '127.0.0.1' || host === '[::1]';
-	if (u.protocol === 'http:') {
-		if (!isLocalhost) return false;
-	} else if (u.protocol !== 'https:') {
-		return false;
-	}
-	if (isLocalhost) return true;
-	return ALLOWED_ROOT_DOMAINS.some(
-		(root) => host === root || host.endsWith('.' + root)
-	);
-}
 
 function ls(): Storage | null {
 	try {
@@ -131,12 +94,20 @@ function isFresh(cat: Category): boolean {
 }
 
 /** Background probe + cache write. No-op when manual, cache fresh, or no
- *  storage. Failures leave the previous cache untouched. */
+ *  storage. Failures leave the previous cache untouched.
+ *
+ *  The probe runs server-side (/api/node-probe) rather than in the browser:
+ *  Hive RPC and several indexer/VSC nodes don't expose CORS for our origin,
+ *  so client-side probing always failed and spammed the console. Server-to-
+ *  server has no CORS, so the freshness ranking actually works. */
 export async function refreshNode(cat: Category): Promise<void> {
 	const s = ls();
 	if (!s || isManualMode(cat) || isFresh(cat)) return;
 	try {
-		const url = await PROBE[cat](NODES[cat]);
+		const res = await fetch(`/api/node-probe?category=${cat}`);
+		if (!res.ok) throw new Error(`HTTP ${res.status}`);
+		const { url } = (await res.json()) as { url?: string };
+		if (!url) throw new Error('no url in probe response');
 		s.setItem(CACHE_KEY[cat], url);
 		s.setItem(CACHE_TS_KEY[cat], String(Date.now()));
 	} catch {

--- a/src/lib/pools/PoolDetail.svelte
+++ b/src/lib/pools/PoolDetail.svelte
@@ -4,7 +4,7 @@
 	import PillButton from '$lib/PillButton.svelte';
 	import Clipboard from '$lib/zag/Clipboard.svelte';
 	import type { PoolRow, MyPoolRow } from './poolsData';
-	import { getMagiIndexerUrl } from '../../client';
+	import { getMagiIndexerBaseUrl, GQL_PROXY_INDEXER, gqlUpstreamHeaders } from '../../client';
 	import moment from 'moment';
 	import AddLiquidityPopup from './AddLiquidityPopup.svelte';
 	import RemoveLiquidityPopup from './RemoveLiquidityPopup.svelte';
@@ -79,9 +79,9 @@
 	let hasMoreRemoves = $state(true);
 
 	async function hasuraFetch<T>(query: string, variables: Record<string, unknown>): Promise<T> {
-		const res = await fetch(getMagiIndexerUrl(), {
+		const res = await fetch(GQL_PROXY_INDEXER, {
 			method: 'POST',
-			headers: { 'content-type': 'application/json' },
+			headers: gqlUpstreamHeaders(getMagiIndexerBaseUrl()),
 			body: JSON.stringify({ query, variables })
 		});
 		const json = await res.json();

--- a/src/lib/sendswap/utils/sendUtils.ts
+++ b/src/lib/sendswap/utils/sendUtils.ts
@@ -1,4 +1,4 @@
-import { getAccounts } from '@aioha/aioha/build/rpc';
+import { getHiveAccounts as getAccounts } from '$lib/auth/hive/getHiveAccounts';
 import { type Account, postingMetadataFromString } from '$lib/auth/hive/accountTypes';
 import { getDidFromUsername, getUsernameFromAuth, getUsernameFromDid } from '$lib/getAccountName';
 import swapOptions, {

--- a/src/lib/stores/balanceHistory.ts
+++ b/src/lib/stores/balanceHistory.ts
@@ -6,7 +6,7 @@ import { Coin, Network } from '$lib/sendswap/utils/sendOptions';
 import config from '../../../houdini.config';
 import { type Point } from '../LineChart.svelte';
 import { type AccountBalance, getDefaultBalance } from './currentBalance';
-import { currentGqlUrl } from '../../client';
+import { currentGqlUrl, GQL_PROXY_VSC, gqlUpstreamHeaders } from '../../client';
 
 export type BalanceOption =
 	| 'hbd'
@@ -124,9 +124,9 @@ async function fetchBalancesBatch(
 	blockHeights: number[]
 ): Promise<Record<string, AccountBalance>> {
 	const queryString = buildMultiHeightQuery(account, blockHeights);
-	const response = await fetch(`${currentGqlUrl}/api/v1/graphql`, {
+	const response = await fetch(GQL_PROXY_VSC, {
 		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
+		headers: gqlUpstreamHeaders(currentGqlUrl),
 		body: JSON.stringify({ query: queryString, variables: {} })
 	});
 	if (!response.ok) {
@@ -179,9 +179,7 @@ export async function fetchBalancesHTTP(
 		// concurrency so a 365-day series doesn't flood the connection pool.
 		const batches: number[][] = [];
 		for (let i = 0; i < blockHeightSeries.length; i += MAX_HEIGHTS_PER_QUERY) {
-			batches.push(
-				blockHeightSeries.slice(i, i + MAX_HEIGHTS_PER_QUERY).map((s) => s.blockHeight)
-			);
+			batches.push(blockHeightSeries.slice(i, i + MAX_HEIGHTS_PER_QUERY).map((s) => s.blockHeight));
 		}
 		const batchResults = await runWithConcurrency(batches, MAX_PARALLEL_BATCHES, (batch) =>
 			fetchBalancesBatch(account, batch)

--- a/src/routes/(authed)/hive-account/+page.svelte
+++ b/src/routes/(authed)/hive-account/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Auth } from '$lib/auth/store';
 	import { getAuth } from '$lib/auth/store';
-	import { getAccounts } from '@aioha/aioha/build/rpc';
+	import { getHiveAccounts as getAccounts } from '$lib/auth/hive/getHiveAccounts';
 	import Form from './form.svelte';
 	let auth: Auth = $derived(getAuth()());
 </script>

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,1 +1,8 @@
-export const prerender = true;
+// Prerendering is disabled: the layout's import chain reaches
+// nodeSelection/env.ts, which reads `$env/dynamic/public` (PUBLIC_*_NODES) at
+// module load. Reading dynamic env during prerender is illegal, so every page
+// (including /login and /logout) crashed at build time and shipped with no
+// static page AND no serverless function — making a hard navigation to them
+// 404 via the catch-all. Serving everything as SSR/CSR functions fixes that;
+// dynamic env reads are fine at runtime. The catch-all 404 handler still works.
+export const prerender = false;

--- a/src/routes/api/gql/+server.ts
+++ b/src/routes/api/gql/+server.ts
@@ -1,0 +1,81 @@
+import { error, json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { isAllowedNodeUrl } from '$lib/nodeSelection/allowlist';
+
+// The root layout sets `prerender = true`; opt out so this dynamic POST proxy
+// is served as a serverless function instead of being prerendered (which would
+// make it 404 at runtime — POST endpoints can't be prerendered).
+export const prerender = false;
+
+/**
+ * Same-origin GraphQL proxy.
+ *
+ * The backend tightened CORS during the security audit, so the browser can no
+ * longer fetch non-default GraphQL endpoints directly (preflight fails with no
+ * `Access-Control-Allow-Origin`). This route forwards the request
+ * server-to-server, where CORS doesn't apply.
+ *
+ * Request shape (from the browser):
+ *   POST /api/gql?service=vsc        (or ?service=indexer)
+ *   header  x-gql-upstream: <base URL of the chosen node>
+ *   body    the raw GraphQL { query, variables } JSON
+ *
+ * The two services use different path suffixes:
+ *   vsc      → <upstream>/api/v1/graphql
+ *   indexer  → <upstream>/v1/graphql
+ *
+ * SSRF guard: the upstream is validated against the shared node allowlist, so
+ * a hostile caller can't make us fetch arbitrary internal hosts.
+ */
+
+const PATH_BY_SERVICE: Record<string, string> = {
+	vsc: '/api/v1/graphql',
+	indexer: '/v1/graphql'
+};
+
+export const POST: RequestHandler = async ({ request, url, fetch }) => {
+	const service = url.searchParams.get('service') ?? '';
+	const path = PATH_BY_SERVICE[service];
+	if (!path) {
+		throw error(400, "service must be 'vsc' or 'indexer'");
+	}
+
+	const upstreamBase = request.headers.get('x-gql-upstream');
+	if (!upstreamBase) {
+		throw error(400, 'missing x-gql-upstream header');
+	}
+	if (!isAllowedNodeUrl(upstreamBase)) {
+		throw error(403, 'upstream not allowed');
+	}
+
+	// Read the GraphQL body as text — we forward it verbatim, no parsing.
+	const body = await request.text();
+
+	const target = upstreamBase.replace(/\/+$/, '') + path;
+	let upstreamRes: Response;
+	try {
+		upstreamRes = await fetch(target, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body,
+			// Don't follow redirects: the allowlist only validates the initial
+			// target, so a redirect could bounce us to an unvalidated host
+			// (SSRF). GraphQL endpoints don't legitimately redirect a POST.
+			redirect: 'error'
+		});
+	} catch (e) {
+		console.error(`GQL proxy: upstream fetch failed for ${target}`, e);
+		throw error(502, 'upstream request failed');
+	}
+
+	// Pass through the JSON response (GraphQL errors live inside it, so a
+	// non-2xx upstream is still returned as-is for the client to handle).
+	const text = await upstreamRes.text();
+	try {
+		return json(JSON.parse(text), { status: upstreamRes.status });
+	} catch {
+		// Upstream returned non-JSON (HTML error page, etc.) — surface a 502.
+		console.error(`GQL proxy: non-JSON response from ${target}`);
+		throw error(502, 'upstream returned non-JSON');
+	}
+};

--- a/src/routes/api/node-probe/+server.ts
+++ b/src/routes/api/node-probe/+server.ts
@@ -1,0 +1,55 @@
+import { error, json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { indexerNodes, vscApiNodes, hiveRpcNodes } from '$lib/nodeSelection/env';
+import { probeIndexer, probeVscApi, probeHiveRpc } from '$lib/nodeSelection/probes';
+
+// The root layout sets `prerender = true`; opt out so this dynamic probe runs
+// as a serverless function instead of being prerendered.
+export const prerender = false;
+
+/**
+ * Server-side node health probe.
+ *
+ * The browser can't probe Hive RPC nodes (and several indexer/VSC nodes)
+ * directly: they don't expose CORS headers for our origin, so every
+ * client-side probe failed with a CORS error AND polluted the console on
+ * every page load. Worse, the Hive auto-selection never actually worked in
+ * the browser — it always fell through to the first env node.
+ *
+ * Running the probes server-to-server (where CORS doesn't apply) fixes both:
+ * no console noise, and the freshness ranking is real. The browser just asks
+ * "which node is freshest for this category?" and caches the answer.
+ *
+ *   GET /api/node-probe?category=indexer   (or vsc | hive)
+ *   → { url: "<freshest node base URL>" }
+ *
+ * The candidate node lists come from server-controlled env config
+ * (PUBLIC_*_NODES with hardcoded fallbacks), not from the caller, so there's
+ * no SSRF surface here — a client can only pick a category, never a target.
+ */
+
+const NODES: Record<string, string[]> = {
+	indexer: indexerNodes,
+	vsc: vscApiNodes,
+	hive: hiveRpcNodes
+};
+
+const PROBE: Record<string, (n: string[]) => Promise<string>> = {
+	indexer: probeIndexer,
+	vsc: probeVscApi,
+	hive: probeHiveRpc
+};
+
+export const GET: RequestHandler = async ({ url }) => {
+	const category = url.searchParams.get('category') ?? '';
+	const nodes = NODES[category];
+	const probe = PROBE[category];
+	if (!nodes || !probe) {
+		throw error(400, "category must be 'indexer', 'vsc', or 'hive'");
+	}
+
+	// probe* never rejects (Promise.allSettled inside); it falls back to
+	// nodes[0] when nothing responds, so this can't throw under normal use.
+	const best = await probe(nodes);
+	return json({ url: best });
+};


### PR DESCRIPTION
## Summary

The backend tightened its CORS policy during the security audit, so the
browser could no longer fetch non-default GraphQL nodes directly (e.g. a
user's own indexer) — preflight failed with no `Access-Control-Allow-Origin`.
This routes all GraphQL and node-health traffic through same-origin server
endpoints, eliminating browser CORS entirely while preserving per-user node
switching. Also fixes a prod-only routing bug where `/login` and `/logout`
404'd.

## Changes

- **GraphQL proxy** (`/api/gql?service=vsc|indexer`): forwards GraphQL
  server-to-server, passing the chosen upstream node via `x-gql-upstream`.
  SSRF-guarded against the shared node allowlist; redirects disabled.
- **Server-side node probes** (`/api/node-probe`): health probing moved out
  of the browser. Hive RPC and several nodes don't expose CORS, so client-side
  probing always failed, spammed the console every page load, and left Hive
  auto-selection broken. Server-to-server has no CORS, so freshness ranking
  now actually works.
- **Hive account lookups**: use the configured Hive node instead of Aioha's
  hardcoded `techcoderx.com` default (down / no CORS).
- **Prerender fix** (`+layout.ts`): the layout's import chain reads
  `$env/dynamic/public` at module load, which is illegal during prerender —
  so `/login` and `/logout` shipped with no static page *and* no serverless
  function, 404'ing on hard navigation in prod. Disabling prerender serves
  every route as an SSR/CSR function (dynamic env is fine at runtime); verified
  `login.func`/`logout.func` now emit in the build.