### PR TITLE
Pool fee fix + sHBD payout estimate + consensus-staking explainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Altera are documented here.
 
+## [0.3.8] — 2026-05-25
+
+### Pools
+
+- Pool "Fee Earned" is now valued **per asset**. The fee column summed a pool's fees across both assets into one number and priced it all as the first asset — so HIVE-denominated fees were counted as HBD, inflating the figure several-fold (e.g. ~$382 shown vs ~$32 actual). Each asset's fees are now valued at its own price via `dex_pool_fees_by_asset`. (All-time for now — range-aware fees need a per-asset `fees_by_asset_since($pool, $ts)` view on the indexer)
+- "My liquidity" no longer flashes in and out when changing the timeframe. The section re-fetched positions on every range change and rendered during the loading window, then hid when empty; it now only renders once positions are loaded
+
+### Staking (sHBD)
+
+- The staking card's "Next payout" shows an estimate (`≈ N days`) instead of a hardcoded `—`. sHBD interest is the VSC gateway's L1 HBD-savings interest, distributed to holders automatically (~monthly); the estimate is `hbd_claim` (last distribution block) + ~30 days, shown only when the user holds sHBD
+
+### Witness Assistant
+
+- Added an `ⓘ` tooltip beside the Stake and Unstake headings explaining what staking does — deposits HIVE into VSC, locked while staked, ~1-day unstake cooldown, Hive accounts only — with a link to the docs
+- Loosened the cramped field spacing in the stake / unstake forms
+
 ## [0.3.7] — 2026-05-21
 
 ### Infrastructure (CORS elimination)

--- a/src/lib/AccBalance.gql
+++ b/src/lib/AccBalance.gql
@@ -4,6 +4,7 @@ query GetAccountBalance($account: String!) {
     consensus_unstaking
     hbd
     hbd_savings
+    hbd_claim
     hive_consensus
     hive
   }

--- a/src/lib/cards/StakingEarnings.svelte
+++ b/src/lib/cards/StakingEarnings.svelte
@@ -4,6 +4,8 @@
 	import { sHbdAprStore } from '$lib/stores/aprStore';
 	import { accountBalance } from '$lib/stores/currentBalance';
 	import { Coin } from '$lib/sendswap/utils/sendOptions';
+	import { getDateFromBlockHeight } from '../../routes/(authed)/transactions/getDateFromBlockHeight';
+	import moment from 'moment';
 
 	type Props = {
 		onStake: () => void;
@@ -31,6 +33,19 @@
 		if ($sHbdAprStore === null || hbdSavings === 0) return '—';
 		const monthly = (hbdSavings * ($sHbdAprStore / 100)) / 12;
 		return `$${monthly.toFixed(2)}`;
+	});
+
+	// sHBD interest is the VSC gateway's L1 HBD-savings interest: the gateway
+	// holds the backing HBD in Hive savings, and when it RECEIVES that interest
+	// (~every 30 days) it's distributed to sHBD holders automatically — no
+	// per-user claim (per techcoderx). `hbd_claim` is the block of the last
+	// distribution, so the next is ≈ 30 days later. Approximate — gateway-driven.
+	const PAYOUT_PERIOD_DAYS = 30;
+	const nextPayoutLabel = $derived.by(() => {
+		const lastPayoutBlock = $accountBalance.bal.hbd_claim;
+		if (hbdSavings === 0 || !lastPayoutBlock) return '—';
+		const next = getDateFromBlockHeight(lastPayoutBlock).add(PAYOUT_PERIOD_DAYS, 'days');
+		return next.isAfter(moment()) ? `≈ ${next.fromNow(true)}` : 'soon';
 	});
 </script>
 
@@ -69,8 +84,8 @@
 			<span class="value">{new CoinAmount($accountBalance.bal.hbd_savings, Coin.hbd, true)}</span>
 		</div>
 		<div class="staking-stat">
-			<span class="label">Next payout in:</span>
-			<span class="value">—</span>
+			<span class="label">Next payout:</span>
+			<span class="value">{nextPayoutLabel}</span>
 		</div>
 	</div>
 </div>
@@ -117,6 +132,10 @@
 		gap: 0.2rem;
 		flex: 1 1 auto;
 		min-width: max-content;
+		/* Right-align each label + its value so the number lines up under its
+		   label instead of floating at the left of the (flex-grown) cell. */
+		align-items: flex-end;
+		text-align: right;
 	}
 	.staking-stat .label {
 		color: var(--dash-text-muted);

--- a/src/lib/indexer/poolQueries.ts
+++ b/src/lib/indexer/poolQueries.ts
@@ -35,29 +35,37 @@ export async function fetchPoolVolume(
 	};
 }
 
-export async function fetchPoolFees(
-	poolId: string,
-	range: TimeRange
-): Promise<{ totalFee: number; magiFee: number; lpFee: number }> {
-	const gte = getTimeGte(range);
-	const whereClause = gte
-		? `{indexer_contract_id: {_eq: $pool}, indexer_ts: {_gte: "${gte}"}}`
-		: `{indexer_contract_id: {_eq: $pool}}`;
+export type PoolAssetFee = { asset: string; magiFee: number; lpFee: number };
 
+/**
+ * Per-asset fee breakdown for a pool.
+ *
+ * A pool collects fees in BOTH of its assets — one per swap direction — so the
+ * old approach (summing `dex_pool_fee_events` into a single number, then
+ * pricing it as one asset in poolsData) inflated the figure several-fold:
+ * HIVE-denominated fees were counted as HBD. `dex_pool_fees_by_asset` keeps the
+ * per-asset split, which the caller values at each asset's own price.
+ *
+ * NOTE: this view is all-time (no timestamp), so unlike the old query this is
+ * NOT range-aware. Restoring range filtering needs a time-bucketed per-asset
+ * rollup (or group-by) on the indexer.
+ */
+export async function fetchPoolFees(poolId: string): Promise<PoolAssetFee[]> {
 	const query = `
-		query PoolFees($pool: String!) {
-			result: dex_pool_fee_events_aggregate(where: ${whereClause}) {
-				aggregate { sum { total_fee magi_fee lp_fee } }
+		query PoolFeesByAsset($pool: String!) {
+			dex_pool_fees_by_asset(where: {pool_contract: {_eq: $pool}}) {
+				asset lp_fees protocol_fees
 			}
 		}
 	`;
 	const data = await hasuraQuery(query, { pool: poolId });
-	const sum = (data?.result as AggregateResult)?.aggregate?.sum;
-	return {
-		totalFee: sum?.total_fee ?? 0,
-		magiFee: sum?.magi_fee ?? 0,
-		lpFee: sum?.lp_fee ?? 0
-	};
+	const rows =
+		(data?.dex_pool_fees_by_asset as Array<Record<string, number | string>> | undefined) ?? [];
+	return rows.map((r) => ({
+		asset: String(r.asset),
+		magiFee: Number(r.protocol_fees) || 0,
+		lpFee: Number(r.lp_fees) || 0
+	}));
 }
 
 /**

--- a/src/lib/pools/PoolsContent.svelte
+++ b/src/lib/pools/PoolsContent.svelte
@@ -49,7 +49,6 @@
 	const auth = $derived(getAuth()());
 	const did = $derived(auth.value?.did);
 	let myPools = $state<MyPoolRow[]>([]);
-	let myPoolsLoading = $state(false);
 	// PoolRow subset for pools the user has LP in — passed to the
 	// Remove Liquidity dialog so it only lists pools the user can
 	// actually withdraw from.
@@ -74,7 +73,6 @@
 			return;
 		}
 		let cancelled = false;
-		myPoolsLoading = true;
 		fetchMyPoolPositions(currentDid, currentPools)
 			.then((rows) => {
 				if (cancelled) return;
@@ -83,9 +81,6 @@
 			.catch((err) => {
 				console.error('Failed to fetch user pool positions', err);
 				if (!cancelled) myPools = [];
-			})
-			.finally(() => {
-				if (!cancelled) myPoolsLoading = false;
 			});
 		return () => {
 			cancelled = true;
@@ -178,17 +173,13 @@
 
 	{@render poolsTable(sortedPools)}
 
-	{#if did && (myPools.length > 0 || myPoolsLoading)}
+	<!-- Only render once we actually have positions. Gating on `myPoolsLoading`
+	     too caused the section to flash in and out on every filter change (the
+	     position fetch re-runs when `pools` is reassigned, finds none, hides). -->
+	{#if did && myPools.length > 0}
 		<div class="my-pools-section">
-			<h3 class="section-title">
-				My liquidity
-				{#if myPoolsLoading}<span class="muted">loading…</span>{/if}
-			</h3>
-			{#if myPools.length > 0}
-				{@render myPoolsTable(myPools)}
-			{:else if !myPoolsLoading}
-				<p class="placeholder-text">No active LP positions.</p>
-			{/if}
+			<h3 class="section-title">My liquidity</h3>
+			{@render myPoolsTable(myPools)}
 		</div>
 	{/if}
 </div>
@@ -617,11 +608,6 @@
 		opacity: 0.6;
 	}
 
-	.placeholder-text {
-		color: var(--dash-text-muted);
-		padding: 0.5rem 0;
-	}
-
 	.my-pools-section {
 		margin-top: 1.25rem;
 		display: flex;
@@ -637,11 +623,6 @@
 		display: flex;
 		align-items: baseline;
 		gap: 0.5rem;
-	}
-	.muted {
-		font-weight: 500;
-		font-size: 0.7rem;
-		color: var(--dash-text-muted);
 	}
 	.share-pct,
 	.lp-amount {

--- a/src/lib/pools/poolsData.ts
+++ b/src/lib/pools/poolsData.ts
@@ -9,7 +9,8 @@ import {
 	fetchPoolRegistry,
 	fetchUserLpPositions,
 	type UserLpPosition,
-	type PoolRegistryEntry
+	type PoolRegistryEntry,
+	type PoolAssetFee
 } from '$lib/indexer/poolQueries';
 
 export type { TimeRange, UserLpPosition, PoolRegistryEntry } from '$lib/indexer/poolQueries';
@@ -99,7 +100,7 @@ function mapStateToPoolRow(
 	state: PoolState,
 	indexerData: {
 		volume: { count: number; amountIn: number; amountOut: number };
-		fees: { totalFee: number; magiFee: number; lpFee: number };
+		fees: PoolAssetFee[];
 		liquidity: {
 			netAmount0: number;
 			netAmount1: number;
@@ -187,13 +188,35 @@ function mapStateToPoolRow(
 		? totalLpRawParsed
 		: snapshot?.totalLp ?? 0;
 
-	// Fees from indexer — all fee values are denominated in sym0 (dec0)
-	const feeTotal = fees.totalFee / 10 ** dec0;
-	const feeLp = fees.lpFee / 10 ** dec0;
-	const feeMagi = fees.magiFee / 10 ** dec0;
+	// Fees are collected PER ASSET (a pool takes a fee in both assets, one per
+	// swap direction). Value each asset's fees at ITS OWN price/decimals — the
+	// old code summed everything and priced it as sym0, which inflated the
+	// figure several-fold (HIVE fees counted as HBD).
+	let feeLpUsd = 0;
+	let feeMagiUsd = 0;
+	const lpParts: string[] = [];
+	const magiParts: string[] = [];
+	// Order the per-asset rows to match the pair (sym0 first, then sym1) so the
+	// breakdown reads consistently with the pair label; unknown assets last.
+	const feeRank = (s: string) => {
+		const i = [sym0, sym1].indexOf(s.toUpperCase());
+		return i === -1 ? 99 : i;
+	};
+	const orderedFees = [...fees].sort((a, b) => feeRank(a.asset) - feeRank(b.asset));
+	for (const f of orderedFees) {
+		const fSym = f.asset.toUpperCase();
+		const fDec = decimalPlaces(fSym);
+		const fUsd = getUsdPrice(fSym);
+		const lpAmt = f.lpFee / 10 ** fDec;
+		const magiAmt = f.magiFee / 10 ** fDec;
+		feeLpUsd += lpAmt * fUsd;
+		feeMagiUsd += magiAmt * fUsd;
+		if (lpAmt > 0) lpParts.push(formatNum(lpAmt, fSym, fDec));
+		if (magiAmt > 0) magiParts.push(formatNum(magiAmt, fSym, fDec));
+	}
 	const feeEarnedAssets: [string, string] = [
-		formatNum(feeLp, sym0, dec0),
-		formatNum(feeMagi, sym0, dec0)
+		lpParts.join(' + ') || formatNum(0, sym0, dec0),
+		magiParts.join(' + ') || formatNum(0, sym0, dec0)
 	];
 
 	// Volume from indexer
@@ -206,10 +229,10 @@ function mapStateToPoolRow(
 
 	// Compute USD totals
 	const totalLiquidityUsd = liqAmt0 * usd0 + liqAmt1 * usd1;
-	const feeEarnedUsdTotal = feeTotal * usd0;
+	const feeEarnedUsdTotal = feeLpUsd + feeMagiUsd;
 	const feeEarnedUsdBreakdown: [string, string] = [
-		formatNum(feeLp * usd0, '$', 2),
-		formatNum(feeMagi * usd0, '$', 2)
+		formatNum(feeLpUsd, '$', 2),
+		formatNum(feeMagiUsd, '$', 2)
 	];
 	const volumeUsdTotal = volIn * usd0 + volOut * usd1;
 
@@ -312,7 +335,7 @@ async function fetchSinglePool(
 			policy: 'NetworkOnly'
 		}),
 		fetchPoolVolume(contractId, range),
-		fetchPoolFees(contractId, range),
+		fetchPoolFees(contractId),
 		fetchPoolLiquidity(contractId)
 	]);
 

--- a/src/lib/stores/currentBalance.ts
+++ b/src/lib/stores/currentBalance.ts
@@ -120,6 +120,9 @@ async function fetchOnChainBtcBalance(address: string): Promise<number> {
 export type AccountBalance = {
 	hbd: number;
 	hbd_savings: number;
+	/** Block height of the last sHBD interest payout (mirrors Hive's
+	 *  savings_hbd_last_interest_payment). Used to estimate the next payout. */
+	hbd_claim: number;
 	pending_hbd_unstaking: number;
 	hive: number;
 	hive_consensus: number;
@@ -156,6 +159,7 @@ export function getDefaultBalance(): AccountBalance {
 	return {
 		hbd: 0,
 		hbd_savings: 0,
+		hbd_claim: 0,
 		pending_hbd_unstaking: 0,
 		hive: 0,
 		hive_consensus: 0,
@@ -220,6 +224,7 @@ async function fetchAccountData(auth: Auth) {
 				const balances: AccountBalance = {
 					hbd: resultBal?.hbd ?? 0,
 					hbd_savings: resultBal?.hbd_savings ?? 0,
+					hbd_claim: resultBal?.hbd_claim ?? 0,
 					pending_hbd_unstaking: resultBal?.pending_hbd_unstaking ?? 0,
 					hive: resultBal?.hive ?? 0,
 					hive_consensus: resultBal?.hive_consensus ?? 0,

--- a/src/routes/(authed)/witness-assistant/ConsensusStakeModal.svelte
+++ b/src/routes/(authed)/witness-assistant/ConsensusStakeModal.svelte
@@ -9,6 +9,7 @@
 	import { addLocalTransaction, type PendingTx } from '$lib/stores/localStorageTxs';
 	import { CoinAmount } from '$lib/currency/CoinAmount';
 	import { type OperationError, type OperationResult } from '@aioha/aioha/build/types';
+	import InfoTooltip from '$lib/components/InfoTooltip.svelte';
 	let auth = $derived(getAuth()());
 	let username = $derived(auth.value?.username);
 	let nodeRunnerAccount: string | undefined = $state();
@@ -98,9 +99,16 @@
 		});
 	}}
 >
-	<h2>Consensus Staking</h2>
+	<div class="modal-title">
+		<h2>Consensus Staking</h2>
+		<InfoTooltip>
+			Staking deposits your HIVE into VSC and locks it while staked. Unstaking has a short
+			cooldown (about a day) before the HIVE returns to your liquid balance. Only Hive accounts
+			can stake. <a href="https://docs.vsc.eco" target="_blank" rel="noopener">Learn more →</a>
+		</InfoTooltip>
+	</div>
 	<p>Be sure to be signed in with the account you'd like to deposit and stake hive from.</p>
-	<p class="error">{error}</p>
+	{#if error}<p class="error">{error}</p>{/if}
 	<Username label="Witness Account" id="node-runner" bind:value={nodeRunnerAccount} required />
 	<div class="amount-flex">
 		<Amount
@@ -134,6 +142,14 @@
 	form {
 		box-sizing: border-box;
 		padding-top: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.85rem;
+	}
+	.modal-title {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
 	}
 	.amount-flex {
 		display: flex;
@@ -142,6 +158,6 @@
 		color: var(--dash-accent-purple);
 	}
 	p {
-		margin-bottom: 0.5rem;
+		margin: 0;
 	}
 </style>

--- a/src/routes/(authed)/witness-assistant/ConsensusUnstakeModal.svelte
+++ b/src/routes/(authed)/witness-assistant/ConsensusUnstakeModal.svelte
@@ -8,6 +8,7 @@
 	import { consensusUnstakeTx } from '$lib/magiTransactions/hive';
 	import { addLocalTransaction, type PendingTx } from '$lib/stores/localStorageTxs';
 	import { CoinAmount } from '$lib/currency/CoinAmount';
+	import InfoTooltip from '$lib/components/InfoTooltip.svelte';
 	let auth = $derived(getAuth()());
 	let username = $derived(auth.value?.username);
 	let nodeRunnerAccount: string | undefined = $state();
@@ -73,13 +74,20 @@
 			});
 		}}
 	>
-		<h2>Consensus Unstaking</h2>
+		<div class="modal-title">
+			<h2>Consensus Unstaking</h2>
+			<InfoTooltip>
+				Staking deposits your HIVE into VSC and locks it while staked. Unstaking has a short
+				cooldown (about a day) before the HIVE returns to your liquid balance. Only Hive accounts
+				can stake. <a href="https://docs.vsc.eco" target="_blank" rel="noopener">Learn more →</a>
+			</InfoTooltip>
+		</div>
 		<p>Be sure to be signed in with the account you'd like to unstake hive from.</p>
 		<p>
 			<b>Note:</b> Unstaked coins will be made available after an unbonding period of five elections
 			(about a day).
 		</p>
-		<p class="error">{error}</p>
+		{#if error}<p class="error">{error}</p>{/if}
 		<Username label="Witness Account" id="node-runner" bind:value={nodeRunnerAccount} required />
 		<div class="amount-flex">
 			<Amount
@@ -110,6 +118,14 @@
 	form {
 		box-sizing: border-box;
 		padding-top: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.85rem;
+	}
+	.modal-title {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
 	}
 	.amount-flex {
 		display: flex;
@@ -118,7 +134,7 @@
 		color: var(--dash-accent-purple);
 	}
 	p {
-		margin-bottom: 0.5rem;
+		margin: 0;
 	}
 	b {
 		color: var(--dash-accent-red);


### PR DESCRIPTION
## Summary

A batch of pool/staking improvements on top of `main`:

- **Fix:** pool "Fee Earned" was wildly inflated (per-asset valuation bug)
- **Fix:** "My liquidity" section flashed in/out when changing the timeframe
- **Feature:** sHBD card now shows an estimated next payout (was hardcoded `—`)
- **Feature:** consensus-staking explainer tooltip + tidier forms on `/witness-assistant`

## Changes

### Pools
- **Per-asset fee valuation** (`9348a72`). The fee column summed a pool's fees across *both* assets into one number and priced it all as the first asset — so HIVE-denominated fees were counted as HBD, inflating the figure ~12× (e.g. **$382 shown vs ~$32 actual**). Now each asset's fees are valued at its own price via `dex_pool_fees_by_asset`, summed in USD. *Note: this view is all-time, so the fee figure isn't range-aware for now — restoring that needs a backend per-asset `fees_by_asset_since($pool, $ts)` view (follow-up).*
- **My-liquidity flash** (`05b0f82`). The section re-fetched positions on every timeframe change and rendered during the loading window, then hid when empty — a visible blink. Now it only renders when the user actually has positions; removed the dead loading/empty branches, unused state, and orphan CSS.

### Staking (sHBD)
- **Next-payout estimate** (`2415108`). "Next payout" was a hardcoded `—`. sHBD interest is the VSC gateway's L1 HBD-savings interest, distributed to holders automatically (~monthly). Added `hbd_claim` (last-distribution block) to the balance query and show `≈ X days` from there, `—` when no sHBD held. Estimate is gateway-driven, hence the `≈`.

### Witness Assistant (consensus staking)
- **Explainer + spacing** (`ceaa065`). Added an `ⓘ` tooltip on both the Stake and Unstake headings describing the mechanics only (deposit into VSC, locked while staked, ~1-day unstake cooldown, Hive-only) with a docs link. Copy was confirmed with the VSC team — it deliberately avoids consensus/witness/reward claims (that role is an unbuilt placeholder). Also loosened the cramped form spacing.