### PR TITLE
fix(pools): restore range-aware Fee Earned + guard overlapping range fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to Altera are documented here.
 
 ### Pools
 
-- Pool "Fee Earned" is now valued **per asset**. The fee column summed a pool's fees across both assets into one number and priced it all as the first asset — so HIVE-denominated fees were counted as HBD, inflating the figure several-fold (e.g. ~$382 shown vs ~$32 actual). Each asset's fees are now valued at its own price via `dex_pool_fees_by_asset`. (All-time for now — range-aware fees need a per-asset `fees_by_asset_since($pool, $ts)` view on the indexer)
+- Pool "Fee Earned" is now valued **per asset**. The fee column summed a pool's fees across both assets into one number and priced it all as the first asset — so HIVE-denominated fees were counted as HBD, inflating the figure several-fold (e.g. ~$382 shown vs ~$32 actual). Each asset's fees are now valued at its own price.
+- Fee Earned is **range-aware** again — it tracks the selected 1d/7d/30d/Max window like Volume, instead of always showing all-time. We aggregate the raw per-asset `dex_pool_fee_events` (which carry a timestamp) for the chosen window rather than the all-time `dex_pool_fees_by_asset` rollup
+- Time-range buttons are disabled while a fetch is in flight, and stale responses are dropped if the range changes mid-request — prevents overlapping queries from showing the wrong window's numbers
 - "My liquidity" no longer flashes in and out when changing the timeframe. The section re-fetched positions on every range change and rendered during the loading window, then hid when empty; it now only renders once positions are loaded
 
 ### Staking (sHBD)

--- a/src/lib/indexer/poolQueries.ts
+++ b/src/lib/indexer/poolQueries.ts
@@ -38,34 +38,46 @@ export async function fetchPoolVolume(
 export type PoolAssetFee = { asset: string; magiFee: number; lpFee: number };
 
 /**
- * Per-asset fee breakdown for a pool.
+ * Per-asset fee breakdown for a pool, over the selected time window.
  *
  * A pool collects fees in BOTH of its assets — one per swap direction — so the
- * old approach (summing `dex_pool_fee_events` into a single number, then
- * pricing it as one asset in poolsData) inflated the figure several-fold:
- * HIVE-denominated fees were counted as HBD. `dex_pool_fees_by_asset` keeps the
- * per-asset split, which the caller values at each asset's own price.
+ * old approach (summing into a single number and pricing it as one asset)
+ * inflated the figure several-fold (HIVE fees counted as HBD). We aggregate the
+ * raw `dex_pool_fee_events` (which carry `asset` + `indexer_ts`) per asset for
+ * the chosen range, so fees stay correct AND track the timeframe like volume;
+ * the caller values each asset at its own price.
  *
- * NOTE: this view is all-time (no timestamp), so unlike the old query this is
- * NOT range-aware. Restoring range filtering needs a time-bucketed per-asset
- * rollup (or group-by) on the indexer.
+ * PERF: for wide windows (30d/max) across the whole pool list this pulls a few
+ * hundred rows per pool. When the indexer exposes a per-asset rollup that takes
+ * a `$since` timestamp (e.g. `fees_by_asset_since(pool, since)`), swap the query
+ * below for a single aggregated call — the return shape stays the same.
  */
-export async function fetchPoolFees(poolId: string): Promise<PoolAssetFee[]> {
+export async function fetchPoolFees(poolId: string, range: TimeRange): Promise<PoolAssetFee[]> {
+	const gte = getTimeGte(range);
+	const whereClause = gte
+		? `{indexer_contract_id: {_eq: $pool}, indexer_ts: {_gte: "${gte}"}}`
+		: `{indexer_contract_id: {_eq: $pool}}`;
+
 	const query = `
-		query PoolFeesByAsset($pool: String!) {
-			dex_pool_fees_by_asset(where: {pool_contract: {_eq: $pool}}) {
-				asset lp_fees protocol_fees
+		query PoolFeeEvents($pool: String!) {
+			dex_pool_fee_events(where: ${whereClause}) {
+				asset lp_fee magi_fee
 			}
 		}
 	`;
 	const data = await hasuraQuery(query, { pool: poolId });
 	const rows =
-		(data?.dex_pool_fees_by_asset as Array<Record<string, number | string>> | undefined) ?? [];
-	return rows.map((r) => ({
-		asset: String(r.asset),
-		magiFee: Number(r.protocol_fees) || 0,
-		lpFee: Number(r.lp_fees) || 0
-	}));
+		(data?.dex_pool_fee_events as Array<Record<string, number | string>> | undefined) ?? [];
+
+	const byAsset = new Map<string, PoolAssetFee>();
+	for (const r of rows) {
+		const asset = String(r.asset);
+		const entry = byAsset.get(asset) ?? { asset, lpFee: 0, magiFee: 0 };
+		entry.lpFee += Number(r.lp_fee) || 0;
+		entry.magiFee += Number(r.magi_fee) || 0;
+		byAsset.set(asset, entry);
+	}
+	return [...byAsset.values()];
 }
 
 /**

--- a/src/lib/pools/PoolsContent.svelte
+++ b/src/lib/pools/PoolsContent.svelte
@@ -58,11 +58,19 @@
 
 	$effect(() => {
 		const range = timeRange;
+		let cancelled = false;
 		loading = true;
 		fetchPools(range).then((result) => {
+			// Guard against out-of-order resolves: if the range changed while
+			// this fetch was in flight, drop the stale result so it can't
+			// overwrite the newer range's numbers.
+			if (cancelled) return;
 			pools = result;
 			loading = false;
 		});
+		return () => {
+			cancelled = true;
+		};
 	});
 
 	$effect(() => {
@@ -163,6 +171,7 @@
 					type="button"
 					class="time-btn"
 					class:active={timeRange === tr.value}
+					disabled={loading}
 					onclick={() => (timeRange = tr.value)}
 				>
 					{tr.label}
@@ -444,13 +453,17 @@
 		padding: 0.5rem 0.75rem;
 		cursor: pointer;
 		transition: background-color 0.1s, color 0.1s;
-		&:hover {
+		&:not(:disabled):hover {
 			background-color: var(--dash-surface-alt);
 			color: var(--dash-text-primary);
 		}
 		&.active {
 			background-color: #6F6AF8;
 			color: #FFFFFF;
+		}
+		&:disabled {
+			cursor: progress;
+			opacity: 0.6;
 		}
 	}
 

--- a/src/lib/pools/poolsData.ts
+++ b/src/lib/pools/poolsData.ts
@@ -335,7 +335,7 @@ async function fetchSinglePool(
 			policy: 'NetworkOnly'
 		}),
 		fetchPoolVolume(contractId, range),
-		fetchPoolFees(contractId),
+		fetchPoolFees(contractId, range),
 		fetchPoolLiquidity(contractId)
 	]);
 


### PR DESCRIPTION
## Summary

- **Restore range-aware Fee Earned.** After the per-asset fix (#prev) the fee column switched to the all-time `dex_pool_fees_by_asset` rollup, so "Fee Earned" stopped changing with the 1d/7d/30d/Max selector. This re-aggregates the raw, timestamped `dex_pool_fee_events` per asset for the selected window — so fees track the timeframe like Volume again, while keeping the correct per-asset valuation (each asset priced in its own USD) and the existing UI untouched.
- **Guard against overlapping range fetches.** Rapid timeframe switching could fire multiple pool fetches that resolve out of order and leave the wrong window's numbers on screen. The time-range buttons are now disabled while a fetch is in flight, and a cancellation flag drops any stale response if the range changes mid-request.

## Details

- `fetchPoolFees(poolId, range)` now takes the range and filters `dex_pool_fee_events` by `indexer_ts >= getTimeGte(range)`, aggregating `lp_fee` + `magi_fee` per asset. Return shape (`PoolAssetFee[]`) is unchanged, so the valuation/display in `poolsData.ts` is identical.
- `poolsData.ts`: single call-site change to pass `range`.
- `PoolsContent.svelte`: `disabled={loading}` on the range buttons + `cancelled` guard in the fetch `$effect` (same pattern the My-liquidity effect already uses); disabled styling (`cursor: progress`, dimmed, no hover).
- Verified against the indexer that fees now differ by window and use **actual collected fees** (summed recorded `lp_fee`/`magi_fee`), not a rate-of-volume estimate.