### PR TITLE
fix(pools+routing): /login prod 500 + stray NULL currency in Max fees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Altera are documented here.
 
+## [0.3.9] — 2026-05-26
+
+### Fixes
+
+- **`/login` and `/logout` no longer 500 on a direct/hard navigation in production.** Both routes defaulted to server-side rendering, so the Vercel function tried to server-render them and import the browser-only wallet SDK graph (Reown AppKit / wagmi / `@metamask/sdk` via the auth store) — whose optional deps aren't bundled into the function, throwing "Cannot find module" at request time. Reaching `/login` via the client-side redirect from `/` never crashed because `/` is an `(authed)` route with `ssr=false`. Both routes are now `ssr=false` to match, so they render client-side; `prerender` stays false so they're still served as functions with a CSR shell
+- **Pool "Fee Earned" no longer shows a stray `NULL` currency in the Max range.** 84 `dex_pool_fee_events` (two pools, 2026-04-16→18) have a null `asset` and only the Max window reaches them; they bucketed under `"null"` and rendered as `… NULL`. They're now excluded at the query and guarded in aggregation (the underlying indexer rows still need their `asset` backfilled)
+
+### Security
+
+- Added a styled self-XSS warning in the browser console on load — deters the common scam of telling users to paste code into devtools, which in a non-custodial wallet can leak keys and drain funds
+
 ## [0.3.8] — 2026-05-25
 
 ### Pools

--- a/src/lib/consoleWarning.ts
+++ b/src/lib/consoleWarning.ts
@@ -1,0 +1,41 @@
+// A styled "self-XSS" warning printed to the browser console on app load.
+//
+// The classic scam: someone tells a user to open devtools and paste a snippet
+// to "verify", "unlock", or "boost" their wallet. In a non-custodial wallet
+// that snippet can read keys / sign transactions and drain funds. Big sites
+// (Facebook, Google, Discord…) print a warning like this for exactly this
+// reason. Console-only, so it costs nothing for normal users but is right
+// there for anyone who's been talked into opening the console.
+
+let shown = false;
+
+export function showConsoleSecurityWarning(): void {
+	// Browser-only, and only once per page load (guards against re-mounts/HMR).
+	if (typeof window === 'undefined' || shown) return;
+	shown = true;
+
+	const title = [
+		'color:#ff3b30',
+		'font-size:40px',
+		'font-weight:800',
+		'text-shadow:1px 1px 0 rgba(0,0,0,0.25)',
+		'padding:4px 0'
+	].join(';');
+	const body = 'font-size:15px;line-height:1.5;';
+	const brand = 'font-size:14px;color:#6F6AF8;font-weight:600;';
+
+	// eslint-disable-next-line no-console
+	console.log('%c⛔ Stop!', title);
+	// eslint-disable-next-line no-console
+	console.log(
+		'%cThis console is for developers. If someone told you to paste something here to ' +
+			'"verify", "unlock", or "boost" your wallet, it is a scam, and it can hand them your ' +
+			'keys and drain your funds. Never paste code you do not understand.',
+		body
+	);
+	// eslint-disable-next-line no-console
+	console.log(
+		'%cAltera is non-custodial: your keys, your coins. Let us keep it that way. 🔐',
+		brand
+	);
+}

--- a/src/lib/indexer/poolQueries.ts
+++ b/src/lib/indexer/poolQueries.ts
@@ -54,9 +54,13 @@ export type PoolAssetFee = { asset: string; magiFee: number; lpFee: number };
  */
 export async function fetchPoolFees(poolId: string, range: TimeRange): Promise<PoolAssetFee[]> {
 	const gte = getTimeGte(range);
+	// Exclude rows with no `asset` tag. A 3-day indexer window (2026-04-16..18)
+	// emitted fee events with a null asset; they only surface in the `max`
+	// range (older than 30d), where they were aggregating under the key
+	// "null" and rendering as a bogus "… NULL" currency in the breakdown.
 	const whereClause = gte
-		? `{indexer_contract_id: {_eq: $pool}, indexer_ts: {_gte: "${gte}"}}`
-		: `{indexer_contract_id: {_eq: $pool}}`;
+		? `{indexer_contract_id: {_eq: $pool}, indexer_ts: {_gte: "${gte}"}, asset: {_is_null: false}}`
+		: `{indexer_contract_id: {_eq: $pool}, asset: {_is_null: false}}`;
 
 	const query = `
 		query PoolFeeEvents($pool: String!) {
@@ -71,6 +75,9 @@ export async function fetchPoolFees(poolId: string, range: TimeRange): Promise<P
 
 	const byAsset = new Map<string, PoolAssetFee>();
 	for (const r of rows) {
+		// Defensive: skip any untagged row that slips past the query filter so
+		// it can't create a "null"/"NULL" asset bucket.
+		if (r.asset == null) continue;
 		const asset = String(r.asset);
 		const entry = byAsset.get(asset) ?? { asset, lpFee: 0, magiFee: 0 };
 		entry.lpFee += Number(r.lp_fee) || 0;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,12 +10,14 @@
 	import { themeStore, getInitialTheme, THEMES } from '$lib/theme';
 	import { cleanOldLocalStorage } from '$lib/cleanup';
 	import { refreshAllNodes } from '$lib/nodeSelection/select';
+	import { showConsoleSecurityWarning } from '$lib/consoleWarning';
 
 	let { children } = $props();
 	injectAnalytics();
 	let allowFocusVisible = false;
 	// set the theme on load
 	onMount(() => {
+		showConsoleSecurityWarning();
 		const initialTheme = getInitialTheme();
 		themeStore.set(THEMES[initialTheme]);
 		cleanOldLocalStorage();

--- a/src/routes/login/+page.ts
+++ b/src/routes/login/+page.ts
@@ -1,0 +1,10 @@
+// Render client-side only. The login page mounts browser-only wallet SDKs
+// (Reown AppKit / wagmi via AppKitLogin) and reads localStorage. Server-
+// rendering it crashed the Vercel function on a HARD navigation to /login
+// (a direct hit SSRs the page), returning a 500. Reaching /login via the
+// client-side redirect from `/` never crashed because `/` is an (authed)
+// route with ssr=false, so the login page only ever rendered in the browser.
+// Mirrors the (authed) group's `ssr = false`. prerender stays false
+// (inherited from the root layout) so the route is still served as a
+// function with a CSR fallback shell — no catch-all 404.
+export const ssr = false;

--- a/src/routes/logout/+page.ts
+++ b/src/routes/logout/+page.ts
@@ -1,0 +1,6 @@
+// Client-side only, for the same reason as /login: this route imports the
+// auth store (whose graph reaches the browser-only Reown AppKit / wagmi
+// setup) and calls `logout()` in an effect. A hard navigation to /logout
+// would SSR it in prod and risk the same 500. Mirrors the (authed) group's
+// `ssr = false`; prerender stays false so it's still served as a function.
+export const ssr = false;


### PR DESCRIPTION
## Summary
- **Fix /login (and /logout) 500 on prod.** These routes defaulted to `ssr=true`, so the Vercel function server-rendered them and imported the browser-only wallet SDK graph (Reown AppKit / wagmi / @metamask-sdk via the auth store), whose optional deps aren't bundled into the function → "Cannot find module" → 500. Set `ssr=false` so they render client-side, matching the `(authed)` group (which imports the same graph and already works). Reaching `/login` via the client-side redirect from `/` never crashed, which is why only the direct URL 500'd.
- **Fix stray `NULL` in the pool Fee Earned breakdown (Max range).** 84 `dex_pool_fee_events` (2026-04-16→18, two pools) have `asset: null`; only the Max window reaches them. They bucketed under `"null"` and rendered as `… NULL`. Now excluded at the query (`asset: {_is_null: false}`) + a defensive skip in the aggregation. (Underlying indexer data gap — those events should be backfilled with their asset.)