### PR TITLE
Allow non-Hive accounts to deposit SATS and increase transaction limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,16 @@ npm run build
 You can preview the production build with `npm run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+
+
+## V4VAPP API
+
+The V4VAPP API is a RESTful API that provides access to the V4VAPP backend. It is used by the V4VAPP frontend to fetch data and perform actions such as generate deposit invoices.
+
+The API is available at `https://api.v4v.app` in production, and `https://devapi.v4v.app` in development. You can also set the API base URL using the `V4VAPP_API_BASE` environment variable.
+
+To use the development API, set the `PUBLIC_V4VAPP_API_MODE` environment variable to `dev` in your `.env` file:
+
+```env
+PUBLIC_V4VAPP_API_MODE=dev
+```

--- a/src/lib/magiTransactions/eth/client.ts
+++ b/src/lib/magiTransactions/eth/client.ts
@@ -202,7 +202,7 @@ function createVSCTransactionContainer(
 		headers: {
 			nonce: client.nonce!,
 			required_auths: Array.from(requiredAuthsSet),
-			rc_limit: 500,
+			rc_limit: 1000,
 			net_id: client.netId
 		},
 		tx: ops.map((op) => ({

--- a/src/lib/magiTransactions/hive/vscOperations/keepsatsTransfer.ts
+++ b/src/lib/magiTransactions/hive/vscOperations/keepsatsTransfer.ts
@@ -1,8 +1,9 @@
+import { BTC_MAPPING_CONTRACT_ID } from '$lib/constants'
 import { CoinAmount } from '$lib/currency/CoinAmount'
 import { Coin } from '$lib/sendswap/utils/sendOptions'
-import { BTC_MAPPING_CONTRACT_ID } from '$lib/constants'
+import { V4V_KEEPSATS_DESTINATION_ACCOUNT } from '$lib/sendswap/v4v/config'
 import type { CustomJsonOperation } from '@hiveio/dhive'
-import { isVscTestnet, vscNetworkId } from '../../../../client'
+import { vscNetworkId } from '../../../../client'
 
 /**
  * Create a custom_json operation to transfer MagiSats to V4VApp
@@ -24,7 +25,7 @@ type keepsatsTransferOp = {
 };
 
 export const getKeepsatsDestinationDid = (): string =>
-	`hive:${isVscTestnet() ? 'devser.v4vapp' : 'v4vapp'}`
+	`hive:${V4V_KEEPSATS_DESTINATION_ACCOUNT}`
 
 export function getKeepsatsTransferOp(
 	from: string,

--- a/src/lib/magiTransactions/hive/vscOperations/keepsatsTransfer.ts
+++ b/src/lib/magiTransactions/hive/vscOperations/keepsatsTransfer.ts
@@ -24,7 +24,7 @@ type keepsatsTransferOp = {
 };
 
 export const getKeepsatsDestinationDid = (): string =>
-	`hive:${isVscTestnet() ? 'v4vapp-test' : 'v4vapp'}`
+	`hive:${isVscTestnet() ? 'devser.v4vapp' : 'v4vapp'}`
 
 export function getKeepsatsTransferOp(
 	from: string,

--- a/src/lib/sendswap/utils/sendUtils.ts
+++ b/src/lib/sendswap/utils/sendUtils.ts
@@ -1,6 +1,35 @@
-import { getHiveAccounts as getAccounts } from '$lib/auth/hive/getHiveAccounts';
-import { type Account, postingMetadataFromString } from '$lib/auth/hive/accountTypes';
-import { getDidFromUsername, getUsernameFromAuth, getUsernameFromDid } from '$lib/getAccountName';
+import { postingMetadataFromString, type Account } from '$lib/auth/hive/accountTypes'
+import { wagmiConfig } from '$lib/auth/reown'
+import { authStore, getAuth, type Auth } from '$lib/auth/store'
+import { CoinAmount } from '$lib/currency/CoinAmount'
+import { getDidFromUsername, getUsernameFromAuth, getUsernameFromDid } from '$lib/getAccountName'
+import { btcSigner } from '$lib/magiTransactions/bitcoin/signer'
+import { getEVMOpType } from '$lib/magiTransactions/eth'
+import { createClient, signAndBrodcastTransaction } from '$lib/magiTransactions/eth/client'
+import { wagmiSigner } from '$lib/magiTransactions/eth/wagmi'
+import { executeTx, getSendOpGenerator, getSendOpType } from '$lib/magiTransactions/hive'
+import { getHiveDepositOp } from '$lib/magiTransactions/hive/vscOperations/deposit'
+import { getKeepsatsDestinationDid, getKeepsatsTransferOp } from '$lib/magiTransactions/hive/vscOperations/keepsatsTransfer'
+import { getBtcApproveOp, getHiveSwapOp } from '$lib/magiTransactions/hive/vscOperations/swap'
+import {
+	accountBalance,
+	type AccountBalance,
+	type HiveMainnetBalance
+} from '$lib/stores/currentBalance'
+import {
+	fetchTxs,
+	getTimestamp,
+	magiTxsStore,
+	waitForExtend,
+	type TransactionInter
+} from '$lib/stores/txStores'
+import { getAccounts } from '@aioha/aioha/build/rpc'
+import type { Operation, TransferOperation } from '@hiveio/dhive'
+import { Network as BtcNetwork, validate } from 'bitcoin-address-validation'
+import moment, { type Moment } from 'moment'
+import { get } from 'svelte/store'
+import { addLocalTransaction } from '../../stores/localStorageTxs'
+import { getIntermediaryNetwork } from './getNetwork'
 import swapOptions, {
 	Coin,
 	Network,
@@ -9,38 +38,9 @@ import swapOptions, {
 	type CoinOnNetwork,
 	type CoinOptions,
 	type IntermediaryNetwork
-} from './sendOptions';
-import { type TxState, SwapTxState, TransferTxState, WithdrawTxState } from './txState.svelte';
-import { authStore, getAuth, type Auth } from '$lib/auth/store';
-import { executeTx, getSendOpGenerator, getSendOpType } from '$lib/magiTransactions/hive';
-import { getKeepsatsDestinationDid, getKeepsatsTransferOp } from '$lib/magiTransactions/hive/vscOperations/keepsatsTransfer';
-import { getHiveSwapOp, getBtcApproveOp } from '$lib/magiTransactions/hive/vscOperations/swap';
-import { getHiveDepositOp } from '$lib/magiTransactions/hive/vscOperations/deposit';
-import { getEVMOpType } from '$lib/magiTransactions/eth';
-import { CoinAmount } from '$lib/currency/CoinAmount';
-import type { Operation, TransferOperation } from '@hiveio/dhive';
-import { addLocalTransaction } from '../../stores/localStorageTxs';
-import { createClient, signAndBrodcastTransaction } from '$lib/magiTransactions/eth/client';
-import { wagmiSigner } from '$lib/magiTransactions/eth/wagmi';
-import { btcSigner } from '$lib/magiTransactions/bitcoin/signer';
-import { wagmiConfig } from '$lib/auth/reown';
-import { get } from 'svelte/store';
-import {
-	fetchTxs,
-	getTimestamp,
-	magiTxsStore,
-	waitForExtend,
-	type TransactionInter
-} from '$lib/stores/txStores';
-import moment, { type Moment } from 'moment';
-import { getIntermediaryNetwork } from './getNetwork';
-import { validate, Network as BtcNetwork } from 'bitcoin-address-validation';
-import {
-	accountBalance,
-	type AccountBalance,
-	type HiveMainnetBalance
-} from '$lib/stores/currentBalance';
-import type { TxStateBase } from './txState.svelte';
+} from './sendOptions'
+import type { TxStateBase } from './txState.svelte'
+import { SwapTxState, TransferTxState, WithdrawTxState, type TxState } from './txState.svelte'
 
 export function scanForBalance(opts: CoinOnNetwork[]): CoinOnNetwork | undefined {
 	const accBal = get(accountBalance);

--- a/src/lib/sendswap/utils/sendUtils.ts
+++ b/src/lib/sendswap/utils/sendUtils.ts
@@ -1,6 +1,35 @@
-import { getAccounts } from '@aioha/aioha/build/rpc';
-import { type Account, postingMetadataFromString } from '$lib/auth/hive/accountTypes';
-import { getDidFromUsername, getUsernameFromAuth, getUsernameFromDid } from '$lib/getAccountName';
+import { postingMetadataFromString, type Account } from '$lib/auth/hive/accountTypes'
+import { wagmiConfig } from '$lib/auth/reown'
+import { authStore, getAuth, type Auth } from '$lib/auth/store'
+import { CoinAmount } from '$lib/currency/CoinAmount'
+import { getDidFromUsername, getUsernameFromAuth, getUsernameFromDid } from '$lib/getAccountName'
+import { btcSigner } from '$lib/magiTransactions/bitcoin/signer'
+import { getEVMOpType } from '$lib/magiTransactions/eth'
+import { createClient, signAndBrodcastTransaction } from '$lib/magiTransactions/eth/client'
+import { wagmiSigner } from '$lib/magiTransactions/eth/wagmi'
+import { executeTx, getSendOpGenerator, getSendOpType } from '$lib/magiTransactions/hive'
+import { getHiveDepositOp } from '$lib/magiTransactions/hive/vscOperations/deposit'
+import { getKeepsatsDestinationDid, getKeepsatsTransferOp } from '$lib/magiTransactions/hive/vscOperations/keepsatsTransfer'
+import { getBtcApproveOp, getHiveSwapOp } from '$lib/magiTransactions/hive/vscOperations/swap'
+import {
+	accountBalance,
+	type AccountBalance,
+	type HiveMainnetBalance
+} from '$lib/stores/currentBalance'
+import {
+	fetchTxs,
+	getTimestamp,
+	magiTxsStore,
+	waitForExtend,
+	type TransactionInter
+} from '$lib/stores/txStores'
+import { getAccounts } from '@aioha/aioha/build/rpc'
+import type { Operation, TransferOperation } from '@hiveio/dhive'
+import { Network as BtcNetwork, validate } from 'bitcoin-address-validation'
+import moment, { type Moment } from 'moment'
+import { get } from 'svelte/store'
+import { addLocalTransaction } from '../../stores/localStorageTxs'
+import { getIntermediaryNetwork } from './getNetwork'
 import swapOptions, {
 	Coin,
 	Network,
@@ -9,38 +38,9 @@ import swapOptions, {
 	type CoinOnNetwork,
 	type CoinOptions,
 	type IntermediaryNetwork
-} from './sendOptions';
-import { type TxState, SwapTxState, TransferTxState, WithdrawTxState } from './txState.svelte';
-import { authStore, getAuth, type Auth } from '$lib/auth/store';
-import { executeTx, getSendOpGenerator, getSendOpType } from '$lib/magiTransactions/hive';
-import { getKeepsatsDestinationDid, getKeepsatsTransferOp } from '$lib/magiTransactions/hive/vscOperations/keepsatsTransfer';
-import { getHiveSwapOp, getBtcApproveOp } from '$lib/magiTransactions/hive/vscOperations/swap';
-import { getHiveDepositOp } from '$lib/magiTransactions/hive/vscOperations/deposit';
-import { getEVMOpType } from '$lib/magiTransactions/eth';
-import { CoinAmount } from '$lib/currency/CoinAmount';
-import type { Operation, TransferOperation } from '@hiveio/dhive';
-import { addLocalTransaction } from '../../stores/localStorageTxs';
-import { createClient, signAndBrodcastTransaction } from '$lib/magiTransactions/eth/client';
-import { wagmiSigner } from '$lib/magiTransactions/eth/wagmi';
-import { btcSigner } from '$lib/magiTransactions/bitcoin/signer';
-import { wagmiConfig } from '$lib/auth/reown';
-import { get } from 'svelte/store';
-import {
-	fetchTxs,
-	getTimestamp,
-	magiTxsStore,
-	waitForExtend,
-	type TransactionInter
-} from '$lib/stores/txStores';
-import moment, { type Moment } from 'moment';
-import { getIntermediaryNetwork } from './getNetwork';
-import { validate, Network as BtcNetwork } from 'bitcoin-address-validation';
-import {
-	accountBalance,
-	type AccountBalance,
-	type HiveMainnetBalance
-} from '$lib/stores/currentBalance';
-import type { TxStateBase } from './txState.svelte';
+} from './sendOptions'
+import type { TxStateBase } from './txState.svelte'
+import { SwapTxState, TransferTxState, WithdrawTxState, type TxState } from './txState.svelte'
 
 export function scanForBalance(opts: CoinOnNetwork[]): CoinOnNetwork | undefined {
 	const accBal = get(accountBalance);

--- a/src/lib/sendswap/utils/sendUtils.ts
+++ b/src/lib/sendswap/utils/sendUtils.ts
@@ -848,8 +848,67 @@ export async function send(
 
 	if (intermediary == Network.lightning) {
 		// Lightning Transfer withdrawal: Transfer to V4VApp on Magi (Keepsats)
+		if (auth.value?.did?.startsWith('did:pkh:bip122:')) {
+			return new Error('Lightning Transfer Withdraw via a BTC wallet is not supported yet.');
+		}
+
+		if (auth.value?.provider === 'reown') {
+			setStatus('Preparing transaction for signing…');
+			if (!wagmiConfig) {
+				throw new Error('EVM wallet not initialised — click Connect Wallet first');
+			}
+			const client = createClient(auth.value.did);
+			const evmOp = getEVMOpType(
+				fromNetwork,
+				Network.magi,
+				auth.value.did,
+				getKeepsatsDestinationDid(),
+				new CoinAmount(amount, toCoin!.coin)
+			);
+
+			const id = await signAndBrodcastTransaction(
+				[evmOp],
+				wagmiSigner,
+				client,
+				signal,
+				wagmiConfig
+			)
+				.then((result) => {
+					setStatus('Transaction submitted. You will be notified when your transaction is finished.');
+					addLocalTransaction({
+						ops: [
+							{
+								data: {
+									amount: new CoinAmount(amount, toCoin!.coin).toAmountString(),
+									asset: toCoin!.coin.unit.toLowerCase(),
+									from: auth.value!.did,
+									to: getKeepsatsDestinationDid(),
+									memo: 'Deposit #sats',
+									type: 'transfer'
+								},
+								type: 'transfer',
+								index: 0
+							}
+						],
+						timestamp: new Date(),
+						id: result.id,
+						type: 'vsc'
+					});
+					return { id: result.id };
+				})
+				.catch((error) => {
+					if (error instanceof Error) {
+						setStatus(error.message, true);
+						return error;
+					}
+					setStatus('Transaction failed.', true);
+					return new Error('Transaction failed.');
+				});
+			return id;
+		}
+
 		if (!auth.value?.aioha) {
-			return new Error("Lightning Transfer Withdraw via an EVM wallet isn't supported yet.");
+			return new Error('Lightning Transfer Withdraw requires a Hive or EVM wallet.');
 		}
 		setStatus('Waiting for Hive wallet approval…');
 		// Convert BTC amount to SATS: BTC internal units == SATS units

--- a/src/lib/sendswap/v4v/api-types/cryptoprices.ts
+++ b/src/lib/sendswap/v4v/api-types/cryptoprices.ts
@@ -1,4 +1,5 @@
-import { getQuerier } from './query';
+import { V4VAPP_API_BASE } from '../config'
+import { getQuerier } from './query'
 
 export type Cryptoprices = {
 	bitcoin: {
@@ -62,5 +63,5 @@ export type Cryptoprices = {
 	};
 };
 
-const url = 'https://api.v4v.app/v1/cryptoprices/';
+const url = `${V4VAPP_API_BASE}/v1/cryptoprices/`;
 export const getCryptoPrices = getQuerier<Cryptoprices>(url);

--- a/src/lib/sendswap/v4v/api-types/metadata.ts
+++ b/src/lib/sendswap/v4v/api-types/metadata.ts
@@ -1,4 +1,5 @@
-import { getQuerier } from './query';
+import { V4VAPP_API_BASE } from '../config'
+import { getQuerier } from './query'
 
 export type Metadata = {
 	message: string;
@@ -48,6 +49,6 @@ export type Metadata = {
 };
 
 export const getV4VMetadata = getQuerier<Metadata>(
-	'https://api.v4v.app/v1?get_crypto=false',
+	`${V4VAPP_API_BASE}/v1?get_crypto=false`,
 	5 * 60 // refresh every 5 mins at most
 );

--- a/src/lib/sendswap/v4v/config.ts
+++ b/src/lib/sendswap/v4v/config.ts
@@ -1,0 +1,12 @@
+import { env as publicEnv } from '$env/dynamic/public'
+
+const resolvedApiMode = (
+	publicEnv.PUBLIC_V4VAPP_API_MODE ??
+	import.meta.env.VITE_V4VAPP_API_MODE ??
+	(import.meta.env as Record<string, string | undefined>).V4VAPP_API_MODE ??
+	''
+).toLowerCase()
+
+export const isV4VDevMode = resolvedApiMode === 'dev'
+export const V4VAPP_API_BASE = isV4VDevMode ? 'https://devapi.v4v.app' : 'https://api.v4v.app'
+export const V4V_KEEPSATS_DESTINATION_ACCOUNT = isV4VDevMode ? 'devser.v4vapp' : 'v4vapp'

--- a/src/lib/sendswap/v4v/v4v.ts
+++ b/src/lib/sendswap/v4v/v4v.ts
@@ -2,7 +2,10 @@ import type { Auth } from '$lib/auth/store'
 import { vscGateway } from '$lib/constants'
 import { sleep } from 'aninest'
 import { Network } from '../utils/sendOptions'
-const V4VAPP_API = 'https://api.v4v.app';
+import { V4VAPP_API_BASE } from './config'
+
+const V4VAPP_API = V4VAPP_API_BASE
+
 type Token = 'hive' | 'hbd' | 'sats';
 // V4V API only accepts: HIVE, HBD, USD, SATS (uppercase) / hive, hbd, sats (lowercase)
 function toV4VCurrency(token: string): string {

--- a/src/lib/sendswap/v4v/v4v.ts
+++ b/src/lib/sendswap/v4v/v4v.ts
@@ -1,7 +1,7 @@
-import type { Auth } from '$lib/auth/store';
-import { vscGateway } from '$lib/constants';
-import { Network } from '../utils/sendOptions';
-import { sleep } from 'aninest';
+import type { Auth } from '$lib/auth/store'
+import { vscGateway } from '$lib/constants'
+import { sleep } from 'aninest'
+import { Network } from '../utils/sendOptions'
 const V4VAPP_API = 'https://api.v4v.app';
 type Token = 'hive' | 'hbd' | 'sats';
 // V4V API only accepts: HIVE, HBD, USD, SATS (uppercase) / hive, hbd, sats (lowercase)
@@ -35,11 +35,17 @@ export const createLightningInvoice = async (
 	const mainnetAccount =
 		on.value === Network.magi.value ? (isMagiSats ? username : vscGateway) : username;
 	console.log('mainnet account', mainnetAccount);
-	if (mainnetAccount.length > 16) {
-		return 'Invalid hive username.';
-	}
+	console.log('creating invoice with params', {
+		amount,
+		of,
+		into,
+		on,
+		auth: auth.value.address,
+		username,
+		altera_id
+	});
 	const url = new URL(`${V4VAPP_API}/v1/new_invoice_hive`);
-	let message = new URLSearchParams(`to=${auth.value.address}`);
+	const message = new URLSearchParams(`to=${auth.value.address}`);
 	// let message = new URLSearchParams(`to=${vscGateway}`);
 	if (altera_id) {
 		message.append('altera_id', altera_id);
@@ -120,7 +126,7 @@ export const checkLightningSuccess = async (
 			out = 'The invoice expired. Try creating a new one.';
 			break;
 		}
-		await sleep(1);
+		await sleep(2);
 	}
 	return out;
 };


### PR DESCRIPTION
Handle EVM and BTC accounts withdrawal and deposit of Lightning

Enhance transaction handling by increasing resource limits for transaction creation and updating the Keepsats destination for the testnet environment. Allow non-Hive accounts to participate in Lightning Transfer withdrawals.