### PR TITLE
0.3.10: btc transfer-event fix (#94), swapOptions flatten, QuickSwap badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Altera are documented here.
 
+## [0.3.10] — 2026-05-26
+
+### Fixes
+
+- BTC (sats) **transfer** rows now enrich correctly in the transactions detail view. `fetchBtcTransferEvent` queried `btc_mapping_transfer_events` for `sender`/`recipient`, but that table actually uses `from_addr`/`to_addr` (only the deposit table uses sender/recipient). The bad column names errored, were swallowed as a schema error, and the lookup silently returned `null` — so VSC→VSC sats transfers (e.g. issue #94) always fell back to payload-only display and never showed the indexed counterparties. Aligned the type, query, and the `BtcMappingTr` consumer to `from_addr`/`to_addr`; deposit/unmap were already correct
+
 ## [0.3.9] — 2026-05-26
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to Altera are documented here.
 ### Fixes
 
 - BTC (sats) **transfer** rows now enrich correctly in the transactions detail view. `fetchBtcTransferEvent` queried `btc_mapping_transfer_events` for `sender`/`recipient`, but that table actually uses `from_addr`/`to_addr` (only the deposit table uses sender/recipient). The bad column names errored, were swallowed as a schema error, and the lookup silently returned `null` — so VSC→VSC sats transfers (e.g. issue #94) always fell back to payload-only display and never showed the indexed counterparties. Aligned the type, query, and the `BtcMappingTr` consumer to `from_addr`/`to_addr`; deposit/unmap were already correct
+- QuickSwap token picker: the FROM/TO role badge is no longer suppressed on a dimmed chip. A token that's your current TO but can't be a source on your wallet (e.g. BTC on a Hive wallet) now shows **both** the role badge and the "not supported" tooltip, instead of only the tooltip
+
+### Internals
+
+- Flattened `swapOptions` — `CoinOptions` is now the array itself (`AssetOption[]`, dropping the `{ coins: [...] }` wrapper) and the relic `CoinOptions['coins'][number]` type is replaced by a named `AssetOption`. Added `getFromOption`/`getToOption` helpers that collapse ~20 hand-written `swapOptions.from.coins.find((c) => c.coin.value === v)` lookups (network-filtered finds left as-is). No behavior change — same coins, networks, and from/to data
 
 ## [0.3.9] — 2026-05-26
 

--- a/src/lib/cards/QuickSwap.svelte
+++ b/src/lib/cards/QuickSwap.svelte
@@ -1570,10 +1570,15 @@
 					>
 						<img src={token.icon} alt={token.label} class="chip-icon" />
 						<span>{coinDisplayLabel(token)}</span>
+						<!-- A chip can be both the current FROM/TO *and* blocked as a FROM pick
+						     (e.g. BTC is your TO but can't be a source on a Hive wallet). Show the
+						     role badge whenever selected, and the tooltip independently when blocked,
+						     so the role label isn't suppressed on a dimmed chip. -->
+						{#if isSelected}
+							<span class="chip-role-badge">{isFrom ? 'FROM' : 'TO'}</span>
+						{/if}
 						{#if walletBlocked}
 							<Tooltip>Not supported by your wallet</Tooltip>
-						{:else if isSelected}
-							<span class="chip-role-badge">{isFrom ? 'FROM' : 'TO'}</span>
 						{/if}
 					</button>
 				{/each}

--- a/src/lib/cards/QuickSwap.svelte
+++ b/src/lib/cards/QuickSwap.svelte
@@ -2,7 +2,7 @@
 	import { getAuth } from '$lib/auth/store';
 	import { solveNetworkConstraints, optionsEqual } from '$lib/sendswap/utils/sendUtils';
 	import { SwapTxState, provideTxState } from '$lib/sendswap/utils/txState.svelte';
-	import swapOptions, {
+	import swapOptions, { getFromOption, getToOption,
 		Coin,
 		Network,
 		TransferMethod,
@@ -84,7 +84,7 @@
 		)
 			return Network.hiveMainnet;
 		// Generic fallback: first non-magi, non-lightning network on the coin
-		const opt = swapOptions.from.coins.find((c) => c.coin.value === coinValue);
+		const opt = getFromOption(coinValue);
 		const native = opt?.networks.find(
 			(n) => n.value !== Network.magi.value && n.value !== Network.lightning.value
 		);
@@ -96,10 +96,10 @@
 
 	function applyStartDetails() {
 		const stored = loadSwapSelection(SWAP_QUICK_PREF_KEY);
-		const btcFromOption = swapOptions.from.coins.find((c) => c.coin.value === Coin.btc.value);
-		const hiveFromOption = swapOptions.from.coins.find((c) => c.coin.value === Coin.hive.value);
-		const btcToOption = swapOptions.to.coins.find((c) => c.coin.value === Coin.btc.value);
-		const hiveToOption = swapOptions.to.coins.find((c) => c.coin.value === Coin.hive.value);
+		const btcFromOption = getFromOption(Coin.btc.value);
+		const hiveFromOption = getFromOption(Coin.hive.value);
+		const btcToOption = getToOption(Coin.btc.value);
+		const hiveToOption = getToOption(Coin.hive.value);
 
 		const isReownBtc =
 			auth.value?.provider === 'reown' && auth.value.did?.startsWith('did:pkh:bip122:');
@@ -202,7 +202,7 @@
 
 	// From tokens: all available coins (BTC, HIVE, HBD) — exclude sHBD
 	const fromAssetObjs: AssetObject[] = $derived(
-		swapOptions.from.coins
+		swapOptions.from
 			.filter((opt) => opt.coin.value !== Coin.shbd?.value)
 			.map((opt) => ({
 				...opt.coin,
@@ -216,7 +216,7 @@
 	);
 	// To tokens: all coins Magi supports (show all, not just those with balance) — exclude sHBD
 	const toAssetObjs: AssetObject[] = $derived(
-		swapOptions.to.coins
+		swapOptions.to
 			.filter((opt) => opt.coin.value !== Coin.shbd?.value)
 			.map((opt) => ({
 				...opt.coin,
@@ -705,7 +705,7 @@
 			}
 		}
 
-		const source = currentlyOpen === 'from' ? swapOptions.from.coins : swapOptions.to.coins;
+		const source = currentlyOpen === 'from' ? swapOptions.from : swapOptions.to;
 		const coinOpt = source.find((opt) => opt.coin.value === token.value);
 		if (!coinOpt) return;
 

--- a/src/lib/indexer/btcMappingQueries.ts
+++ b/src/lib/indexer/btcMappingQueries.ts
@@ -24,11 +24,15 @@ export interface BtcUnmapEvent extends BtcMappingEventBase {
 	tx_id: string; // Bitcoin transaction ID (once broadcast)
 }
 
-// btc_mapping_transfer_events — emitted on `transfer` / `transferFrom` (VSC → VSC)
+// btc_mapping_transfer_events — emitted on `transfer` / `transferFrom` (VSC → VSC).
+// NOTE: unlike the deposit table (sender/recipient), this table names its parties
+// `from_addr` / `to_addr` (same as the unmap table). Using sender/recipient here made
+// every query fail with "field not found", which isSchemaError() swallowed → the lookup
+// silently returned null and transfer rows never enriched in the UI.
 export interface BtcTransferEvent extends BtcMappingEventBase {
 	amount: string; // satoshis
-	sender: string; // sender VSC DID
-	recipient: string; // recipient VSC DID
+	from_addr: string; // sender VSC DID
+	to_addr: string; // recipient VSC DID
 }
 
 /**
@@ -113,8 +117,8 @@ export async function fetchBtcTransferEvent(txHash: string): Promise<BtcTransfer
 				indexer_tx_hash
 				indexer_block_height
 				amount
-				sender
-				recipient
+				from_addr
+				to_addr
 			}
 		}
 	`;

--- a/src/lib/sendswap/QuickSend.svelte
+++ b/src/lib/sendswap/QuickSend.svelte
@@ -3,7 +3,7 @@
 	import { scanForBalance } from './utils/sendUtils';
 	import Complete from './stages/Complete.svelte';
 	import ReviewTransfer from './stages/ReviewTransfer.svelte';
-	import swapOptions, { Coin, Network, TransferMethod } from './utils/sendOptions';
+	import { getFromOption, Coin, Network, TransferMethod } from './utils/sendOptions';
 	import QuickTransferOptions from './stages/QuickSendOptions.svelte';
 	import StepsMachine, { type MixedStepsArray } from './StepsMachine.svelte';
 	import { TransferTxState, provideTxState } from './utils/txState.svelte';
@@ -28,7 +28,7 @@
 				network: Network.magi
 			}))
 		);
-		const coinOpt = swapOptions.from.coins.find((c) => c.coin.value === balOpt?.coin.value);
+		const coinOpt = getFromOption(balOpt?.coin.value);
 		txState.fromCoin = coinOpt;
 		txState.fromNetwork = Network.magi;
 		txState.toCoin = coinOpt;

--- a/src/lib/sendswap/SendSwap.svelte
+++ b/src/lib/sendswap/SendSwap.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { getAuth } from '$lib/auth/store';
-	import swapOptions, { Coin, Network, TransferMethod } from '$lib/sendswap/utils/sendOptions';
+	import { getFromOption, getToOption, Coin, Network, TransferMethod } from '$lib/sendswap/utils/sendOptions';
 	import { scanForBalance } from '$lib/sendswap/utils/sendUtils';
 	import {
 		SWAP_PAGE_PREF_KEY,
@@ -35,10 +35,10 @@
 			const stored = loadSwapSelection(SWAP_PAGE_PREF_KEY);
 			const fromOpt =
 				findFromOpt(stored?.fromCoin) ??
-				swapOptions.from.coins.find((c) => c.coin.value === Coin.btc.value);
+				getFromOption(Coin.btc.value);
 			const toOpt =
 				findToOpt(stored?.toCoin) ??
-				swapOptions.to.coins.find((c) => c.coin.value === Coin.hive.value);
+				getToOption(Coin.hive.value);
 			const fromNet = findNetwork(stored?.fromNetwork) ?? Network.magi;
 			const toNet = findNetwork(stored?.toNetwork) ?? Network.magi;
 			txState.toNetwork = toNet;
@@ -50,7 +50,7 @@
 			const balOpt = scanForBalance(
 				[Coin.hive, Coin.hbd, Coin.shbd].map((c) => ({ coin: c, network: Network.magi }))
 			);
-			const coinOpt = swapOptions.from.coins.find((c) => c.coin.value === balOpt?.coin.value);
+			const coinOpt = getFromOption(balOpt?.coin.value);
 			txState.toNetwork = Network.magi;
 			txState.fromNetwork = Network.magi;
 			txState.fromCoin = coinOpt;

--- a/src/lib/sendswap/components/assetSelection/SelectAssetFlattened.svelte
+++ b/src/lib/sendswap/components/assetSelection/SelectAssetFlattened.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import swapOptions, { Coin, Network, type CoinOptions } from '$lib/sendswap/utils/sendOptions';
+	import { getFromOption, Coin, Network, type AssetOption } from '$lib/sendswap/utils/sendOptions';
 	import { untrack, type Snippet } from 'svelte';
 	import AssetList from './AssetList.svelte';
 	import { accountBalance, type AccountBalance } from '$lib/stores/currentBalance';
@@ -31,13 +31,13 @@
 		dialogTitle = 'Select an Asset'
 	}: {
 		availableCoins: Coin[];
-		coin: CoinOptions['coins'][number] | undefined;
+		coin: AssetOption | undefined;
 		network: Network | undefined;
 		max?: CoinAmount<Coin> | undefined;
 		close: () => void;
 		externalNetwork?: Network;
 		isTo?: boolean;
-		onSelect?: (coin: CoinOptions['coins'][number], network: Network) => void;
+		onSelect?: (coin: AssetOption, network: Network) => void;
 		dialogTitle?: string;
 	} = $props();
 
@@ -138,7 +138,7 @@
 	// REMOVE -1 FOR BITCOIN LAUNCH
 	let maxItems = $derived(onMagi.length - 1 + externalTotalLength);
 
-	let tmpAsset: CoinOptions['coins'][number] | undefined = $state();
+	let tmpAsset: AssetOption | undefined = $state();
 
 	let tmpNetwork: Network | undefined = $state();
 	let tmpNetworkVal: string | undefined = $state();
@@ -158,7 +158,7 @@
 		const assetVal = balanceVal.split(':')[0];
 		const networkVal = balanceVal.split(':')[1];
 		const balanceObj = [...magiItems, ...externalItems].find((item) => item.value === balanceVal);
-		tmpAsset = swapOptions.from.coins.find((coinOpts) => coinOpts.coin.value === assetVal);
+		tmpAsset = getFromOption(assetVal);
 		tmpNetwork =
 			[Network.magi, externalNetwork].find((net) => net?.value === networkVal) ?? Network.magi;
 		if (!tmpAsset) {

--- a/src/lib/sendswap/components/info/AssetInfo.svelte
+++ b/src/lib/sendswap/components/info/AssetInfo.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { isValidBalanceField } from '$lib/stores/balanceHistory';
 	import { get } from 'svelte/store';
-	import { Coin, Network, type CoinOptions } from '$lib/sendswap/utils/sendOptions';
+	import { Coin, Network, type AssetOption } from '$lib/sendswap/utils/sendOptions';
 	import InfoSegment from './InfoSegment.svelte';
 	import { accountBalance } from '$lib/stores/currentBalance';
 	import { CoinAmount } from '$lib/currency/CoinAmount';
@@ -15,7 +15,7 @@
 		basic = false,
 		size = 'small'
 	}: {
-		coinOpt: CoinOptions['coins'][number];
+		coinOpt: AssetOption;
 		network?: Network | undefined;
 		lastPaid?: string;
 		disabledMemo?: string;

--- a/src/lib/sendswap/stages/QuickSendOptions.svelte
+++ b/src/lib/sendswap/stages/QuickSendOptions.svelte
@@ -8,7 +8,7 @@
 		Coin,
 		Network,
 		type CoinOnNetwork,
-		type CoinOptions
+		type AssetOption
 	} from '../utils/sendOptions';
 	import { assetCard, type AssetObject } from '../components/info/SendSnippets.svelte';
 	import { untrack } from 'svelte';
@@ -64,7 +64,7 @@
 	});
 
 	const fromAssetObjs: AssetObject[] = $derived(
-		swapOptions.from.coins.map((opt) => ({
+		swapOptions.from.map((opt) => ({
 			...opt.coin,
 			snippet: assetCard,
 			snippetData: { fromOpt: opt, net: txState.toNetwork, size: 'medium' }
@@ -133,8 +133,8 @@
 	);
 
 	const coinsWithBalance = $derived.by(() => {
-		const result: Array<{ coin: Coin; coinOpt: CoinOptions['coins'][number] }> = [];
-		for (const coinOpt of swapOptions.from.coins) {
+		const result: Array<{ coin: Coin; coinOpt: AssetOption }> = [];
+		for (const coinOpt of swapOptions.from) {
 			const coinValue = coinOpt.coin.value;
 			if (coinValue in $accountBalance.bal) {
 				const balance = $accountBalance.bal[coinValue as keyof AccountBalance];

--- a/src/lib/sendswap/stages/SwapOptions.svelte
+++ b/src/lib/sendswap/stages/SwapOptions.svelte
@@ -9,11 +9,11 @@
 	import { useSwapState } from '$lib/sendswap/utils/txState.svelte';
 	import { assetCard, type AssetObject } from '$lib/sendswap/components/info/SendSnippets.svelte';
 	import { onMount, untrack } from 'svelte';
-	import swapOptions, {
+	import swapOptions, { getFromOption, getToOption,
 		Coin,
 		Network,
 		type CoinOnNetwork,
-		type CoinOptions
+		type AssetOption
 	} from '$lib/sendswap/utils/sendOptions';
 	import AmountInput from '$lib/currency/AmountInput.svelte';
 	import PillButton from '$lib/PillButton.svelte';
@@ -533,21 +533,19 @@
 			return bal > 0.001;
 		});
 		if (!(txState.toCoin && txState.toNetwork)) {
-			let nextToCoin: (typeof swapOptions.to.coins)[number] | undefined;
+			let nextToCoin: (typeof swapOptions.to)[number] | undefined;
 			let nextToNetwork: Network | undefined;
 			if (visibleToObjs.length > 0) {
 				const hiveTo = visibleToObjs.find((obj) => obj.value === Coin.hive.value);
 				const firstAvailableTo = visibleToObjs[0];
 				if (hiveTo) {
-					const swapTo = swapOptions.to.coins.find((opt) => opt.coin.value === Coin.hive.value);
+					const swapTo = getToOption(Coin.hive.value);
 					if (swapTo) {
 						nextToCoin = swapTo;
 						nextToNetwork = Array.isArray(swapTo.networks) ? swapTo.networks[0] : undefined;
 					}
 				} else if (firstAvailableTo) {
-					const swapTo = swapOptions.to.coins.find(
-						(opt) => opt.coin.value === firstAvailableTo.value
-					);
+					const swapTo = getToOption(firstAvailableTo.value);
 					if (swapTo) {
 						nextToCoin = swapTo;
 						nextToNetwork = Array.isArray(swapTo.networks) ? swapTo.networks[0] : undefined;
@@ -622,7 +620,7 @@
 		}
 	]);
 	const toAssetObjs: AssetObject[] = $derived(
-		swapOptions.to.coins.map((opt) => ({
+		swapOptions.to.map((opt) => ({
 			...opt.coin,
 			snippet: assetCard,
 			snippetData: { fromOpt: opt, net: txState.toNetwork, size: 'medium' }
@@ -762,7 +760,7 @@
 				}
 			: undefined
 	);
-	let tempCoinOpt: CoinOptions['coins'][number] | undefined = $state();
+	let tempCoinOpt: AssetOption | undefined = $state();
 	let tokenSearch = $state('');
 
 	function openDialog(state: 'from' | 'to') {
@@ -844,9 +842,7 @@
 				const prevFrom = txState.fromCoin;
 				txState.toCoin = prevFrom;
 				// toNetwork stays managed by destChoice effect.
-				const coinOpt = swapOptions.from.coins.find(
-					(opt) => opt.coin.value === token.value
-				);
+				const coinOpt = getFromOption(token.value);
 				if (!coinOpt) return;
 				tempCoinOpt = coinOpt;
 				dialogStep = 'source';
@@ -864,7 +860,7 @@
 			return;
 		}
 
-		const source = currentlyOpen === 'from' ? swapOptions.from.coins : swapOptions.to.coins;
+		const source = currentlyOpen === 'from' ? swapOptions.from : swapOptions.to;
 		const coinOpt = source.find((opt) => opt.coin.value === token.value);
 		if (!coinOpt) return;
 		tempCoinOpt = coinOpt;
@@ -878,13 +874,13 @@
 		}
 	}
 
-	function confirmFromSelection(coinOpt: CoinOptions['coins'][number], network: Network) {
+	function confirmFromSelection(coinOpt: AssetOption, network: Network) {
 		txState.fromCoin = coinOpt;
 		txState.fromNetwork = network;
 		closeDialog();
 	}
 
-	function confirmToSelection(coinOpt: CoinOptions['coins'][number], network: Network) {
+	function confirmToSelection(coinOpt: AssetOption, network: Network) {
 		txState.toCoin = coinOpt;
 		txState.toNetwork = network;
 		closeDialog();

--- a/src/lib/sendswap/stages/TransferOptions.svelte
+++ b/src/lib/sendswap/stages/TransferOptions.svelte
@@ -17,7 +17,7 @@
 		Coin,
 		Network,
 		type CoinOnNetwork,
-		type CoinOptions
+		type AssetOption
 	} from '../utils/sendOptions';
 	import Dialog from '$lib/zag/Dialog.svelte';
 	import SelectContact from '$lib/sendswap/contacts/SelectContact.svelte';
@@ -145,7 +145,7 @@
 
 	// AMOUNT
 	const fromAssetObjs: AssetObject[] = $derived(
-		swapOptions.from.coins.map((opt) => ({
+		swapOptions.from.map((opt) => ({
 			...opt.coin,
 			snippet: assetCard,
 			snippetData: { fromOpt: opt, net: txState.toNetwork, size: 'medium' }
@@ -362,8 +362,8 @@
 	});
 
 	const coinsWithBalance = $derived.by(() => {
-		const result: Array<{ coin: Coin; coinOpt: CoinOptions['coins'][number] }> = [];
-		for (const coinOpt of swapOptions.from.coins) {
+		const result: Array<{ coin: Coin; coinOpt: AssetOption }> = [];
+		for (const coinOpt of swapOptions.from) {
 			const coinValue = coinOpt.coin.value;
 			if (coinValue in $accountBalance.bal) {
 				const balance = $accountBalance.bal[coinValue as keyof AccountBalance];

--- a/src/lib/sendswap/stages/deposit/DepositOptions.svelte
+++ b/src/lib/sendswap/stages/deposit/DepositOptions.svelte
@@ -2,7 +2,7 @@
 	import ClickableCard from '$lib/cards/ClickableCard.svelte';
 	import ImageIconRenderer from '$lib/components/ImageIconRenderer.svelte';
 	import { ArrowLeft, ChevronRight } from '@lucide/svelte';
-	import swapOptions, { Coin, Network, TransferMethod } from '../../utils/sendOptions';
+	import swapOptions, { getFromOption, getToOption, Coin, Network, TransferMethod, type AssetOption } from '../../utils/sendOptions';
 	import { scanForBalance } from '../../utils/sendUtils';
 	import { useDepositState } from '../../utils/txState.svelte';
 	import HiveMainnetDeposit from './HiveMainnetDeposit.svelte';
@@ -54,16 +54,14 @@
 				coin: Coin.sats,
 				networks: [Network.magi]
 			};
-			const btcCoin = swapOptions.from.coins.find(
-				(coinOpt) => coinOpt.coin.value === Coin.btc.value
-			);
+			const btcCoin = getFromOption(Coin.btc.value);
 			const shouldPreserveFromCoin =
 				txState.fromCoin &&
 				txState.fromCoin.networks?.some((n) => n.value === Network.lightning.value);
 
-			const hiveCoin = swapOptions.to.coins.find((c) => c.coin.value === Coin.hive.value);
-			const hbdCoin = swapOptions.to.coins.find((c) => c.coin.value === Coin.hbd.value);
-			let toCoinToUse = satsCoin; // default to Magi SATS
+			const hiveCoin = getToOption(Coin.hive.value);
+			const hbdCoin = getToOption(Coin.hbd.value);
+			let toCoinToUse: AssetOption | undefined = satsCoin; // default to Magi SATS
 			if (
 				txState.toCoin &&
 				(txState.toCoin.coin.value === Coin.hive.value ||
@@ -98,17 +96,17 @@
 		untrack(() => {
 			toggleLightning(false);
 			const hiveCoin =
-				swapOptions.from.coins.find(
+				swapOptions.from.find(
 					(coinOpt) =>
 						coinOpt.coin.value === Coin.hive.value &&
 						coinOpt.networks.some((n) => n.value === Network.hiveMainnet.value)
 				) ||
-				swapOptions.from.coins.find(
+				swapOptions.from.find(
 					(coinOpt) =>
 						coinOpt.coin.value === Coin.hbd.value &&
 						coinOpt.networks.some((n) => n.value === Network.hiveMainnet.value)
 				);
-			const hbdCoin = swapOptions.from.coins.find(
+			const hbdCoin = swapOptions.from.find(
 				(coinOpt) =>
 					coinOpt.coin.value === Coin.hbd.value &&
 					coinOpt.networks.some((n) => n.value === Network.hiveMainnet.value)

--- a/src/lib/sendswap/stages/withdraw/LightningWithdraw.svelte
+++ b/src/lib/sendswap/stages/withdraw/LightningWithdraw.svelte
@@ -3,7 +3,7 @@
 	import { CoinAmount } from '$lib/currency/CoinAmount';
 	import PillButton from '$lib/PillButton.svelte';
 	import BalanceInfo from '$lib/sendswap/components/info/BalanceInfo.svelte';
-	import swapOptions, { Coin, Network, type CoinOptions } from '$lib/sendswap/utils/sendOptions';
+	import { getToOption, Coin, Network, type CoinOptions, type AssetOption } from '$lib/sendswap/utils/sendOptions';
 	import { useTxState } from '$lib/sendswap/utils/txState.svelte';
 	import { accountBalance, getBalanceAmount } from '$lib/stores/currentBalance';
 	import Select from '$lib/zag/Select.svelte';
@@ -72,14 +72,14 @@
 		}
 	});
 
-	let possibleCoins: CoinOptions['coins'] = $derived.by(() => {
-		let result: CoinOptions['coins'] = [{ coin: Coin.usd, networks: [] }];
+	let possibleCoins: CoinOptions = $derived.by(() => {
+		let result: CoinOptions = [{ coin: Coin.usd, networks: [] }];
 		if (txState.toCoin) {
 			result = [txState.toCoin, ...result];
 		}
 		return result;
 	});
-	let lastPossibleCoins: CoinOptions['coins'] = $state([]);
+	let lastPossibleCoins: CoinOptions = $state([]);
 	$effect(() => {
 		possibleCoins;
 		untrack(() => {
@@ -106,7 +106,7 @@
 		});
 	});
 	let shownIndex = $state(0);
-	let shownCoin: CoinOptions['coins'][number] = $state(
+	let shownCoin: AssetOption = $state(
 		txState.toCoin ?? { coin: Coin.usd, networks: [] }
 	);
 	function cycleShown() {
@@ -154,9 +154,7 @@
 				initial={txState.toCoin?.coin.value}
 				onValueChange={(details) => {
 					if (open) {
-						txState.toCoin = txState.fromCoin = swapOptions.to.coins.find(
-							(coinOpt) => coinOpt.coin.value === details.value[0]
-						);
+						txState.toCoin = txState.fromCoin = getToOption(details.value[0]);
 					}
 				}}
 				styleType="dropdown"

--- a/src/lib/sendswap/stages/withdraw/WithdrawOptions.svelte
+++ b/src/lib/sendswap/stages/withdraw/WithdrawOptions.svelte
@@ -2,7 +2,7 @@
 	import ClickableCard from '$lib/cards/ClickableCard.svelte';
 	import ImageIconRenderer from '$lib/components/ImageIconRenderer.svelte';
 	import { ArrowLeft, ChevronRight } from '@lucide/svelte';
-	import swapOptions, { Coin, Network, TransferMethod } from '../../utils/sendOptions';
+	import swapOptions, { getToOption, Coin, Network, TransferMethod } from '../../utils/sendOptions';
 	import { scanForBalance } from '../../utils/sendUtils';
 	import { useWithdrawState } from '../../utils/txState.svelte';
 	import HiveMainnetWithdraw from './HiveMainnetWithdraw.svelte';
@@ -45,17 +45,17 @@
 		if (!hiveMainnetOpen) return;
 		untrack(() => {
 			const hiveCoin =
-				swapOptions.from.coins.find(
+				swapOptions.from.find(
 					(coinOpt) =>
 						coinOpt.coin.value === Coin.hive.value &&
 						coinOpt.networks.some((n) => n.value === Network.magi.value)
 				) ||
-				swapOptions.from.coins.find(
+				swapOptions.from.find(
 					(coinOpt) =>
 						coinOpt.coin.value === Coin.hbd.value &&
 						coinOpt.networks.some((n) => n.value === Network.magi.value)
 				);
-			const hbdCoin = swapOptions.from.coins.find(
+			const hbdCoin = swapOptions.from.find(
 				(coinOpt) =>
 					coinOpt.coin.value === Coin.hbd.value &&
 					coinOpt.networks.some((n) => n.value === Network.magi.value)
@@ -89,7 +89,7 @@
 	$effect(() => {
 		if (!btcMainnetOpen) return;
 		untrack(() => {
-			const btcCoin = swapOptions.from.coins.find(
+			const btcCoin = swapOptions.from.find(
 				(coinOpt) =>
 					coinOpt.coin.value === Coin.btc.value &&
 					coinOpt.networks.some((n) => n.value === Network.magi.value)
@@ -105,16 +105,14 @@
 	$effect(() => {
 		if (!lightningTransferOpen) return;
 		untrack(() => {
-			const btcCoinFrom = swapOptions.from.coins.find(
+			const btcCoinFrom = swapOptions.from.find(
 				(coinOpt) =>
 					coinOpt.coin.value === Coin.btc.value &&
 					coinOpt.networks.some((n) => n.value === Network.magi.value)
 			);
 			// Find BTC in to-coins without requiring lightning in networks,
 			// since lightning is the toNetwork and is set separately below.
-			const btcCoinTo = swapOptions.to.coins.find(
-				(coinOpt) => coinOpt.coin.value === Coin.btc.value
-			);
+			const btcCoinTo = getToOption(Coin.btc.value);
 			txState.method = TransferMethod.lightningTransfer;
 			txState.fromNetwork = Network.magi;
 			txState.fromCoin = btcCoinFrom;

--- a/src/lib/sendswap/utils/sendOptions.ts
+++ b/src/lib/sendswap/utils/sendOptions.ts
@@ -169,12 +169,14 @@ export const Network = {
 	unknown
 };
 
-export type CoinOptions = {
-	coins: {
-		coin: Coin;
-		networks: Network[];
-	}[];
+/** A selectable asset: a coin plus the networks it can move over. */
+export type AssetOption = {
+	coin: Coin;
+	networks: Network[];
 };
+
+/** Ordered list of selectable assets (was `{ coins: AssetOption[] }`). */
+export type CoinOptions = AssetOption[];
 
 /**
  * UI-facing labels for the two transfer rails. `length` is the ETA copy shown
@@ -213,24 +215,30 @@ const swapOptions: {
 	from: CoinOptions;
 	to: CoinOptions;
 } = {
-	from: {
-		coins: [
-			{ coin: hive, networks: [magi, hiveMainnet] },
-			{ coin: hbd, networks: [magi, hiveMainnet] },
-			{ coin: shbd, networks: [magi] },
-			{ coin: btc, networks: [magi, btcMainnet] }
-		]
-	},
-	to: {
-		coins: [
-			{ coin: hive, networks: [magi, hiveMainnet] },
-			{ coin: hbd, networks: [magi, hiveMainnet] },
-			{ coin: btc, networks: [btcMainnet, magi] }
-		]
-	}
+	from: [
+		{ coin: hive, networks: [magi, hiveMainnet] },
+		{ coin: hbd, networks: [magi, hiveMainnet] },
+		{ coin: shbd, networks: [magi] },
+		{ coin: btc, networks: [magi, btcMainnet] }
+	],
+	to: [
+		{ coin: hive, networks: [magi, hiveMainnet] },
+		{ coin: hbd, networks: [magi, hiveMainnet] },
+		{ coin: btc, networks: [btcMainnet, magi] }
+	]
 };
 
 export default swapOptions;
+
+/**
+ * Look up the `from` / `to` asset option by coin value. Replaces the ~20
+ * hand-written `swapOptions.from.coins.find((c) => c.coin.value === v)` calls
+ * scattered across the send/swap stages.
+ */
+export const getFromOption = (coinValue: string | undefined): AssetOption | undefined =>
+	swapOptions.from.find((o) => o.coin.value === coinValue);
+export const getToOption = (coinValue: string | undefined): AssetOption | undefined =>
+	swapOptions.to.find((o) => o.coin.value === coinValue);
 
 // APP-17: only expose internals on globalThis in development builds.
 if (import.meta.env.DEV) {

--- a/src/lib/sendswap/utils/sendUtils.ts
+++ b/src/lib/sendswap/utils/sendUtils.ts
@@ -36,7 +36,7 @@ import swapOptions, {
 	networkMap,
 	TransferMethod,
 	type CoinOnNetwork,
-	type CoinOptions,
+	type AssetOption,
 	type IntermediaryNetwork
 } from './sendOptions'
 import type { TxStateBase } from './txState.svelte'
@@ -366,7 +366,7 @@ export async function getFee(toAmount: string, state: TxStateBase) {
 	}
 }
 
-type CoinOptList = CoinOptions['coins'][number];
+type CoinOptList = AssetOption;
 export interface CoinOptionParam extends CoinOptList {
 	disabled?: boolean;
 	disabledMemo?: string;
@@ -416,7 +416,7 @@ function combineAssetOptions(
 	toNetwork?: Network,
 	fromNetwork?: Network
 ): CoinOptionParam[] {
-	const allObjs = Object.values(swapOptions.from.coins);
+	const allObjs = swapOptions.from;
 	const available = to ? from.intersection(to) : from;
 	const notInFrom = all.difference(from);
 	const notInTo = to ? all.difference(to).difference(notInFrom) : new Set<string>();
@@ -473,7 +473,7 @@ function combineNetworkOptions(
 
 export function solveNetworkConstraints(
 	method: TransferMethod | undefined,
-	fromCoin: CoinOptions['coins'][number] | undefined,
+	fromCoin: AssetOption | undefined,
 	toNetwork: Network | undefined,
 	did: string | undefined,
 	fromNetwork?: Network,
@@ -486,7 +486,7 @@ export function solveNetworkConstraints(
 			networkOptions: []
 		};
 	const inUseNetworks = [Network.magi, Network.hiveMainnet, Network.lightning];
-	const allAssetsSet = createSet(swapOptions.from['coins'].map((item) => item.coin));
+	const allAssetsSet = createSet(swapOptions.from.map((item) => item.coin));
 
 	const networksGivenMethod = createSet(method ? getMethodNetworks(method) : undefined);
 	const networksGivenBoth = createSet(getDidNetworks(did)).intersection(networksGivenMethod);

--- a/src/lib/sendswap/utils/swapPersistence.ts
+++ b/src/lib/sendswap/utils/swapPersistence.ts
@@ -1,5 +1,5 @@
 import { browser } from '$app/environment';
-import swapOptions, { Coin, Network } from './sendOptions';
+import { getFromOption, getToOption, Coin, Network } from './sendOptions';
 
 /**
  * Persists the user's last source/target selection on swap surfaces
@@ -38,14 +38,12 @@ export function saveSwapSelection(key: string, sel: SwapSelection) {
 
 /** Resolve the rich `from` coin option (with networks) by Coin.value. */
 export function findFromOpt(coinValue: string | undefined) {
-	if (!coinValue) return undefined;
-	return swapOptions.from.coins.find((c) => c.coin.value === coinValue);
+	return getFromOption(coinValue);
 }
 
 /** Resolve the rich `to` coin option (with networks) by Coin.value. */
 export function findToOpt(coinValue: string | undefined) {
-	if (!coinValue) return undefined;
-	return swapOptions.to.coins.find((c) => c.coin.value === coinValue);
+	return getToOption(coinValue);
 }
 
 /** Resolve a Network instance by Network.value. */

--- a/src/lib/sendswap/utils/txState.svelte.ts
+++ b/src/lib/sendswap/utils/txState.svelte.ts
@@ -1,15 +1,15 @@
 import { getContext, setContext } from 'svelte';
 import type { CoinAmount } from '$lib/currency/CoinAmount';
 import type { Coin } from './sendOptions';
-import type { CoinOptions, Network, TransferMethod } from './sendOptions';
+import type { AssetOption, Network, TransferMethod } from './sendOptions';
 
 // ─── Base (fields every flow shares) ─────────────────────────────────────────
 
 export class TxStateBase {
-	fromCoin: CoinOptions['coins'][number] | undefined = $state(undefined);
+	fromCoin: AssetOption | undefined = $state(undefined);
 	fromNetwork: Network | undefined = $state(undefined);
 	fromAmount: string = $state('0');
-	toCoin: CoinOptions['coins'][number] | undefined = $state(undefined);
+	toCoin: AssetOption | undefined = $state(undefined);
 	toNetwork: Network | undefined = $state(undefined);
 	toAmount: string = $state('0');
 	toUsername: string = $state('');

--- a/src/routes/(authed)/transactions/Table/tr/BtcMappingTr.svelte
+++ b/src/routes/(authed)/transactions/Table/tr/BtcMappingTr.svelte
@@ -119,14 +119,21 @@
 					// to_addr is null on older unmap rows — fall back to the original
 					// call payload's `to` field (the BTC destination address).
 					toAccount = result.event.to_addr || payloadData?.to || 'Unknown';
-				} else {
+				} else if (result.action === 'map') {
+					// deposit table names its parties sender/recipient
 					fromAccount = result.event.sender || did;
 					toAccount = result.event.recipient || 'Unknown';
+				} else {
+					// transfer / transferFrom (VSC → VSC) — the transfer table uses
+					// from_addr/to_addr, same as unmap.
+					fromAccount = result.event.from_addr || did;
+					toAccount = result.event.to_addr || payloadData?.to || 'Unknown';
 				}
 			} else {
-				// No indexer entry — internal VSC transfers (call/transfer) never produce
-				// an on-chain BTC event so the indexer will always return null for them.
-				// Fall back to what we can read directly from the payload.
+				// No indexer row yet. Internal transfers DO emit a
+				// btc_mapping_transfer_events row, but it can lag the contract-state
+				// finality (and map/unmap rows can also be briefly absent), so fall
+				// back to what we can read directly from the payload meanwhile.
 				fromAccount = did;
 				toAccount = payloadData?.to ?? 'Unknown';
 			}


### PR DESCRIPTION
## Summary
- **fix(indexer): BTC transfer rows enrich correctly (issue #94).** `fetchBtcTransferEvent` queried `btc_mapping_transfer_events` for `sender`/`recipient`, but that table uses `from_addr`/`to_addr` — the bad columns errored, got swallowed as a schema error, and the lookup silently returned null. VSC→VSC sats transfers fell back to payload-only display. Aligned the type, query, and `BtcMappingTr` consumer. (Deposit/unmap were already correct.)
- **refactor(sendswap): flatten `swapOptions`.** `CoinOptions` is now `AssetOption[]` (dropped the `{ coins: [...] }` wrapper); the relic `CoinOptions['coins'][number]` type → named `AssetOption`; added `getFromOption`/`getToOption` helpers collapsing ~20 hand-written `.find()` lookups. **No behavior change** — same coins/networks/from-to data; network-filtered finds left as-is.
- **fix(swap): QuickSwap picker role badge.** A chip that is your current TO but blocked as a FROM (e.g. BTC on a Hive wallet) showed only the "not supported" tooltip — the FROM/TO badge was suppressed. Now shows both.

## Notes
- Type-checks at **194/32**, below the prior 196 baseline (the refactor net-removed 2 errors, introduced none).
- Rebased onto `main` after #97; the `sendUtils.ts` merge (our flatten + #97's EVM lightning-withdraw branch) is verified correct.
- Each commit builds independently.