### PR TITLE
repoint DEX router to current pools + deprecate old-router pools

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -21,9 +21,31 @@ export const DEFAULT_MAGI_INDEXER_URL = 'https://indexer.magi.milohpr.com';
 export const DEX_ROUTER_CONTRACT_ID = (() => {
 	const isTestnet = (browser && localStorage.getItem(keyVscNetworkId)) === 'vsc-testnet';
 	return isTestnet
-		? 'vsc1BmjY9JwFQyvRwYhLpiXFCYeUqxmU8ykrAM'
+		? 'vsc1Bens5nrhnbbHEUftCWaLPYegDx9LGLXEUP'
 		: 'vsc1Brvi4YZHLkocYNAFd7Gf1JpsPjzNnv4i45';
 })();
+
+/** Pools bound to superseded testnet routers. The indexer still lists them, so
+ *  we flag them here to mark them withdraw-only in the UI: the pair name is
+ *  struck through and "Add liquidity" is disabled, while "Remove liquidity"
+ *  stays available so existing LPs can exit. Mainnet has no legacy pools. */
+const TESTNET_DEPRECATED_POOL_IDS = [
+	'vsc1Brm1QpGF8WXvRCvwgbpB6fiHtTBJzyZUC9', // legacy "DEX Router" HIVE/HBD
+	'vsc1BgwiEg8P5u2qYSV7DL8FCqrj5E7hWSYKmf', // legacy "DEX Router" BTC/HBD
+	'vsc1BhV2bjSAt9NY48mRhL9XzBSxnt4aYbfkZR', // superseded dex_router HIVE/HBD (no reserves)
+	'vsc1BVMsKovjCSBiU5V4hD3YcC7x8rN5m9ErSz' // superseded dex_router BTC/HBD
+];
+
+const deprecatedPoolIds: ReadonlySet<string> = new Set(
+	(browser && localStorage.getItem(keyVscNetworkId)) === 'vsc-testnet'
+		? TESTNET_DEPRECATED_POOL_IDS
+		: []
+);
+
+/** True for pools tied to a retired router — shown but withdraw-only. */
+export function isDeprecatedPool(contractId: string): boolean {
+	return deprecatedPoolIds.has(contractId);
+}
 
 export const currentGqlUrl = browser ? resolveNodeUrl('vsc') : DEFAULT_GQL_URL;
 

--- a/src/lib/pools/PoolDetail.svelte
+++ b/src/lib/pools/PoolDetail.svelte
@@ -4,7 +4,7 @@
 	import PillButton from '$lib/PillButton.svelte';
 	import Clipboard from '$lib/zag/Clipboard.svelte';
 	import type { PoolRow, MyPoolRow } from './poolsData';
-	import { getMagiIndexerBaseUrl, GQL_PROXY_INDEXER, gqlUpstreamHeaders } from '../../client';
+	import { getMagiIndexerBaseUrl, GQL_PROXY_INDEXER, gqlUpstreamHeaders, isDeprecatedPool } from '../../client';
 	import moment from 'moment';
 	import AddLiquidityPopup from './AddLiquidityPopup.svelte';
 	import RemoveLiquidityPopup from './RemoveLiquidityPopup.svelte';
@@ -28,6 +28,7 @@
 	let addLiquidityOpen = $state(false);
 	let removeLiquidityOpen = $state(false);
 	const hasUserPosition = $derived(myPools.some((p) => p.contractId === pool.contractId));
+	const deprecated = $derived(isDeprecatedPool(pool.contractId));
 
 	const poolId = pool.contractId;
 	const sym0 = pool.pairSymbols[0];
@@ -248,12 +249,19 @@
 		<PillButton onclick={onback} styleType="icon-subtle">
 			<ArrowLeft size="24" />
 		</PillButton>
-		<h4>{pool.pair}</h4>
+		<h4 class:deprecated>{pool.pair}</h4>
+		{#if deprecated}
+			<span class="deprecated-tag">deprecated</span>
+		{/if}
 		<div class="header-actions">
 			<button
 				type="button"
 				class="header-action header-action-primary"
-				onclick={() => (addLiquidityOpen = true)}
+				disabled={deprecated}
+				title={deprecated ? 'Deprecated pool — adding liquidity is disabled' : undefined}
+				onclick={() => {
+					if (!deprecated) addLiquidityOpen = true;
+				}}
 			>
 				<Plus size={14} />
 				Add Liquidity
@@ -326,7 +334,7 @@
 
 <AddLiquidityPopup
 	bind:open={addLiquidityOpen}
-	pools={pools.length ? pools : [pool]}
+	pools={(pools.length ? pools : [pool]).filter((p) => !isDeprecatedPool(p.contractId))}
 	preselectedPool={pool}
 />
 <RemoveLiquidityPopup
@@ -591,6 +599,21 @@
 			font-weight: 600;
 			color: var(--dash-text-primary);
 		}
+		h4.deprecated {
+			text-decoration: line-through;
+			color: var(--dash-text-muted);
+		}
+	}
+	.deprecated-tag {
+		font-size: 0.55rem;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--dash-text-muted);
+		border: 1px solid var(--dash-card-border);
+		border-radius: 0.75rem;
+		padding: 0.1rem 0.45rem;
+		opacity: 0.8;
 	}
 	.header-actions {
 		margin-left: auto;

--- a/src/lib/pools/PoolsContent.svelte
+++ b/src/lib/pools/PoolsContent.svelte
@@ -7,6 +7,7 @@
 	import RemoveLiquidityPopup from './RemoveLiquidityPopup.svelte';
 	import PoolDetail from './PoolDetail.svelte';
 	import { getAuth } from '$lib/auth/store';
+	import { isDeprecatedPool } from '../../client';
 
 	function getCoinIcon(symbol: string): string | undefined {
 		const s = symbol.toUpperCase();
@@ -244,6 +245,7 @@
 			</thead>
 			<tbody>
 				{#each rows as pool (pool.id)}
+					{@const deprecated = isDeprecatedPool(pool.contractId)}
 					<tr class="clickable" onclick={() => (selectedPool = pool)}>
 						<td class="col-pair">
 							<div class="pair-cell">
@@ -259,7 +261,10 @@
 										<span class="icon icon-b">{pool.pairSymbols[1].slice(0, 3)}</span>
 									{/if}
 								</span>
-								<span class="pair-label">{pool.pair}</span>
+								<span class="pair-label" class:deprecated title={deprecated ? 'Deprecated pool — withdraw only' : undefined}>{pool.pair}</span>
+								{#if deprecated}
+									<span class="deprecated-tag">deprecated</span>
+								{/if}
 							</div>
 						</td>
 						<td class="col-price">
@@ -304,8 +309,11 @@
 									type="button"
 									class="row-action row-action-primary"
 									aria-label="Add liquidity to {pool.pair}"
+									disabled={deprecated}
+									title={deprecated ? 'Deprecated pool — adding liquidity is disabled' : undefined}
 									onclick={(e) => {
 										e.stopPropagation();
+										if (deprecated) return;
 										openAddForPool(pool);
 									}}
 								>
@@ -369,7 +377,7 @@
 										<span class="icon icon-b">{row.pairSymbols[1].slice(0, 3)}</span>
 									{/if}
 								</span>
-								<span class="pair-label">{row.pair}</span>
+								<span class="pair-label" class:deprecated={isDeprecatedPool(row.contractId)}>{row.pair}</span>
 							</div>
 						</td>
 						<td class="col-share">
@@ -392,7 +400,11 @@
 	</div>
 {/snippet}
 
-<AddLiquidityPopup bind:open={addLiquidityOpen} {pools} preselectedPool={addPrefillPool} />
+<AddLiquidityPopup
+	bind:open={addLiquidityOpen}
+	pools={pools.filter((p) => !isDeprecatedPool(p.contractId))}
+	preselectedPool={addPrefillPool}
+/>
 <RemoveLiquidityPopup
 	bind:open={removeLiquidityOpen}
 	pools={myPoolsAsRows}
@@ -570,6 +582,21 @@
 		font-weight: 500;
 		color: var(--dash-text-primary);
 	}
+	.pair-label.deprecated {
+		text-decoration: line-through;
+		color: var(--dash-text-muted);
+	}
+	.deprecated-tag {
+		font-size: 0.55rem;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--dash-text-muted);
+		border: 1px solid var(--dash-card-border);
+		border-radius: 0.75rem;
+		padding: 0.05rem 0.4rem;
+		opacity: 0.8;
+	}
 
 	.price-cell {
 		display: flex;
@@ -674,8 +701,14 @@
 		background: linear-gradient(135deg, #7b74ff 0%, #6f6af8 40%, #5b54e0 100%);
 		box-shadow: 0 2px 8px rgba(111, 106, 248, 0.25);
 	}
-	.row-action-primary:hover {
+	.row-action-primary:hover:not(:disabled) {
 		box-shadow: 0 4px 14px rgba(111, 106, 248, 0.4);
+	}
+	.row-action:disabled {
+		cursor: not-allowed;
+		opacity: 0.4;
+		box-shadow: none;
+		filter: grayscale(0.7);
 	}
 	.row-action-outline {
 		border: 1px solid var(--dash-card-border);


### PR DESCRIPTION
- client.ts: switch the testnet DEX_ROUTER_CONTRACT_ID to vsc1Bens5… (the router whose HIVE/HBD and BTC/HBD pools are seeded and correctly bound). The previous testnet router's HIVE/HBD pool had no reserves, so HIVE→HBD swaps failed with "pool has no reserves".
- client.ts: add TESTNET_DEPRECATED_POOL_IDS + isDeprecatedPool() helper, gated to vsc-testnet (empty set on mainnet), listing the four pools tied to superseded testnet routers.
- PoolsContent/PoolDetail: mark deprecated pools as withdraw-only — strike through the pair name, disable "Add liquidity", and filter them out of the Add-liquidity popup, while keeping "Remove liquidity" so existing LPs exit.
- Mainnet is unaffected: its router id is untouched and the deprecated set is empty off testnet.