### PR TITLE
refactor(txState): method→rail (Network) + Lightning Withdraw balance gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Altera are documented here.
 
+## [0.3.11] — 2026-05-28
+
+### Fixes
+
+- Lightning Withdraw (Keepsats) button no longer enables when the entered amount exceeds the wallet balance. The validation effect only required `amount > 0` and skipped the balance check that the sibling Bitcoin Mainnet withdraw already had — now mirrors the same `amount <= max` gate, with `max.amount` read in the tracked region so it re-runs when the balance loads or the user flips between SATS / BTC views
+
+### Internals
+
+- Replaced the legacy `method` field + `TransferMethod` type with a typed `rail: Network | undefined` on `txState`. Each `Network` now carries a `settlementSeconds` (magi = 0, hiveMainnet = 3, lightning = 60, btcMainnet = 600); the settlement-time copy in ReviewSwap is computed by a new `settlementLabel(networks[])` helper that picks the slowest involved network. No user-visible behavior change — the BTC ~10 min override is preserved (via `btcMainnet`'s 600 s floor), the "No fee" branch fires on the same flows (`rail === magi`), and `solveNetworkConstraints` keeps the same mapping under the renamed `getRailNetworks`
+- Added groundwork for the broader `txState` reshape (#3): `from` / `to` (`CoinOnNetwork`) and `rail` (`Network`) live on `TxStateBase` alongside the legacy `fromCoin` / `fromNetwork` / `toCoin` / `toNetwork`. Consumers migrate in a follow-up; legacy fields stay authoritative until then
+
 ## [0.3.10] — 2026-05-26
 
 ### Fixes

--- a/src/lib/cards/QuickSwap.svelte
+++ b/src/lib/cards/QuickSwap.svelte
@@ -5,7 +5,6 @@
 	import swapOptions, { getFromOption, getToOption,
 		Coin,
 		Network,
-		TransferMethod,
 		type CoinOnNetwork
 	} from '$lib/sendswap/utils/sendOptions';
 	import {
@@ -113,7 +112,7 @@
 		const fromNet = fromOpt ? nativeNetworkFor(fromOpt.coin.value) : undefined;
 		const toNet = toOpt ? nativeNetworkFor(toOpt.coin.value) : undefined;
 
-		txState.method = TransferMethod.lightningTransfer;
+		txState.rail = Network.lightning;
 		txState.fromCoin = fromOpt ?? undefined;
 		txState.fromNetwork = fromNet;
 		txState.toCoin = toOpt ?? undefined;
@@ -188,7 +187,7 @@
 	});
 	$effect(() => {
 		const result = solveNetworkConstraints(
-			txState.method,
+			txState.rail,
 			txState.fromCoin,
 			txState.toNetwork,
 			auth.value?.did,

--- a/src/lib/sendswap/QuickSend.svelte
+++ b/src/lib/sendswap/QuickSend.svelte
@@ -3,7 +3,7 @@
 	import { scanForBalance } from './utils/sendUtils';
 	import Complete from './stages/Complete.svelte';
 	import ReviewTransfer from './stages/ReviewTransfer.svelte';
-	import { getFromOption, Coin, Network, TransferMethod } from './utils/sendOptions';
+	import { getFromOption, Coin, Network } from './utils/sendOptions';
 	import QuickTransferOptions from './stages/QuickSendOptions.svelte';
 	import StepsMachine, { type MixedStepsArray } from './StepsMachine.svelte';
 	import { TransferTxState, provideTxState } from './utils/txState.svelte';
@@ -33,7 +33,7 @@
 		txState.fromNetwork = Network.magi;
 		txState.toCoin = coinOpt;
 		txState.toNetwork = Network.magi;
-		txState.method = TransferMethod.magiTransfer;
+		txState.rail = Network.magi;
 		txState.toUsername = '';
 		txState.toDisplayName = '';
 		txState.memo = '';

--- a/src/lib/sendswap/SendSwap.svelte
+++ b/src/lib/sendswap/SendSwap.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { getAuth } from '$lib/auth/store';
-	import { getFromOption, getToOption, Coin, Network, TransferMethod } from '$lib/sendswap/utils/sendOptions';
+	import { getFromOption, getToOption, Coin, Network } from '$lib/sendswap/utils/sendOptions';
 	import { scanForBalance } from '$lib/sendswap/utils/sendUtils';
 	import {
 		SWAP_PAGE_PREF_KEY,
@@ -42,7 +42,7 @@
 			const fromNet = findNetwork(stored?.fromNetwork) ?? Network.magi;
 			const toNet = findNetwork(stored?.toNetwork) ?? Network.magi;
 			txState.toNetwork = toNet;
-			txState.method = TransferMethod.lightningTransfer;
+			txState.rail = Network.lightning;
 			txState.fromCoin = fromOpt;
 			txState.fromNetwork = fromNet;
 			txState.toCoin = toOpt;

--- a/src/lib/sendswap/components/TransferBar.svelte
+++ b/src/lib/sendswap/components/TransferBar.svelte
@@ -14,7 +14,8 @@
 	const externalPlaceholder: Network = {
 		value: 'external',
 		label: 'External Network',
-		icon: Globe
+		icon: Globe,
+		settlementSeconds: 0
 	};
 </script>
 

--- a/src/lib/sendswap/stages/ReviewSwap.svelte
+++ b/src/lib/sendswap/stages/ReviewSwap.svelte
@@ -2,7 +2,8 @@
 	import { getAuth } from '$lib/auth/store';
 	import Card from '$lib/cards/Card.svelte';
 	import { CoinAmount } from '$lib/currency/CoinAmount';
-	import { Coin, Network, TransferMethod } from '$lib/sendswap/utils/sendOptions';
+	import { Coin, Network } from '$lib/sendswap/utils/sendOptions';
+	import { settlementLabel } from '$lib/sendswap/utils/getNetwork';
 	import moment from 'moment';
 	import { useTxState } from '$lib/sendswap/utils/txState.svelte';
 	import { Dot, EqualApproximately, X } from '@lucide/svelte';
@@ -397,8 +398,13 @@
 	const isBtcSwap = $derived(
 		fromCoin.value === Coin.btc.value || toCoin.value === Coin.btc.value
 	);
+	// Settlement-time copy: the slowest network among those involved in the TX.
+	// `rail` (when set) carries the explicit intermediary; for BTC swaps the
+	// btcMainnet floor preserves the legacy ~10 min override even on
+	// magi-internal sats↔hbd swaps where the chosen networks would otherwise
+	// suggest "Instant".
 	const settlementTime = $derived(
-		isBtcSwap ? 'About 10 minutes' : (txState.method?.length ?? '')
+		settlementLabel([txState.rail, isBtcSwap ? Network.btcMainnet : undefined])
 	);
 
 </script>
@@ -467,7 +473,7 @@
 											{/if}
 										</span>
 									</div>
-								{:else if txState.method?.value === TransferMethod.magiTransfer.value}
+								{:else if txState.rail?.value === Network.magi.value}
 									No fee
 								{:else if !txState.fee || !feeInUsd}
 									<div class="fee-loading"><WaveLoading /></div>

--- a/src/lib/sendswap/stages/SwapOptions.svelte
+++ b/src/lib/sendswap/stages/SwapOptions.svelte
@@ -496,7 +496,7 @@
 	$effect(() => {
 		const { assetOptions: newAssetOptions, networkOptions: newNetworkOptions } =
 			solveNetworkConstraints(
-				txState.method,
+				txState.rail,
 				txState.fromCoin,
 				txState.toNetwork,
 				auth.value?.did,

--- a/src/lib/sendswap/stages/deposit/DepositOptions.svelte
+++ b/src/lib/sendswap/stages/deposit/DepositOptions.svelte
@@ -2,7 +2,7 @@
 	import ClickableCard from '$lib/cards/ClickableCard.svelte';
 	import ImageIconRenderer from '$lib/components/ImageIconRenderer.svelte';
 	import { ArrowLeft, ChevronRight } from '@lucide/svelte';
-	import swapOptions, { getFromOption, getToOption, Coin, Network, TransferMethod, type AssetOption } from '../../utils/sendOptions';
+	import swapOptions, { getFromOption, getToOption, Coin, Network, type AssetOption } from '../../utils/sendOptions';
 	import { scanForBalance } from '../../utils/sendUtils';
 	import { useDepositState } from '../../utils/txState.svelte';
 	import HiveMainnetDeposit from './HiveMainnetDeposit.svelte';
@@ -83,7 +83,7 @@
 							: satsCoin;
 			}
 
-			txState.method = TransferMethod.lightningTransfer;
+			txState.rail = Network.lightning;
 			txState.fromNetwork = Network.lightning;
 			txState.fromCoin = shouldPreserveFromCoin ? txState.fromCoin : btcCoin;
 			txState.toNetwork = Network.magi;
@@ -129,7 +129,7 @@
 				fromCoinToUse = txState.toCoin.coin.value === Coin.hive.value ? hiveCoin : hbdCoin;
 			}
 
-			txState.method = TransferMethod.magiTransfer;
+			txState.rail = Network.magi;
 			txState.fromNetwork = Network.hiveMainnet;
 			txState.toNetwork = Network.magi;
 			txState.fromCoin = fromCoinToUse;

--- a/src/lib/sendswap/stages/withdraw/KeepsatsWithdraw.svelte
+++ b/src/lib/sendswap/stages/withdraw/KeepsatsWithdraw.svelte
@@ -105,9 +105,21 @@
 		const hasCoins = !!_fromCoinValue && !!_toCoinValue;
 		const hasNetwork = !!_fromNetwork;
 		const amt = coinAmount.amount;
+		// Reading max.amount in the tracked region so the effect re-runs when the
+		// balance loads or the user switches between SATS/BTC views. Without this
+		// gate the Withdraw button stayed enabled for amounts exceeding the
+		// available balance (matches the BitcoinMainnetWithdraw pattern).
+		const maxAmt = max.amount;
 		const hasToAmount = !!_toAmount && _toAmount !== '0';
 		untrack(() => {
-			if (hasCoins && txState.fromAmount && hasNetwork && amt > 0 && hasToAmount) {
+			if (
+				hasCoins &&
+				txState.fromAmount &&
+				hasNetwork &&
+				amt > 0 &&
+				amt <= maxAmt &&
+				hasToAmount
+			) {
 				editStage(true);
 			} else {
 				editStage(false);

--- a/src/lib/sendswap/stages/withdraw/WithdrawOptions.svelte
+++ b/src/lib/sendswap/stages/withdraw/WithdrawOptions.svelte
@@ -2,7 +2,7 @@
 	import ClickableCard from '$lib/cards/ClickableCard.svelte';
 	import ImageIconRenderer from '$lib/components/ImageIconRenderer.svelte';
 	import { ArrowLeft, ChevronRight } from '@lucide/svelte';
-	import swapOptions, { getToOption, Coin, Network, TransferMethod } from '../../utils/sendOptions';
+	import swapOptions, { getToOption, Coin, Network } from '../../utils/sendOptions';
 	import { scanForBalance } from '../../utils/sendUtils';
 	import { useWithdrawState } from '../../utils/txState.svelte';
 	import HiveMainnetWithdraw from './HiveMainnetWithdraw.svelte';
@@ -78,7 +78,7 @@
 				fromCoinToUse = txState.fromCoin;
 			}
 
-			txState.method = TransferMethod.magiTransfer;
+			txState.rail = Network.magi;
 			txState.fromNetwork = Network.magi;
 			txState.fromCoin = fromCoinToUse;
 			txState.toNetwork = Network.hiveMainnet;
@@ -94,7 +94,7 @@
 					coinOpt.coin.value === Coin.btc.value &&
 					coinOpt.networks.some((n) => n.value === Network.magi.value)
 			);
-			txState.method = TransferMethod.magiTransfer;
+			txState.rail = Network.magi;
 			txState.fromNetwork = Network.magi;
 			txState.fromCoin = btcCoin;
 			txState.toNetwork = Network.btcMainnet;
@@ -113,7 +113,7 @@
 			// Find BTC in to-coins without requiring lightning in networks,
 			// since lightning is the toNetwork and is set separately below.
 			const btcCoinTo = getToOption(Coin.btc.value);
-			txState.method = TransferMethod.lightningTransfer;
+			txState.rail = Network.lightning;
 			txState.fromNetwork = Network.magi;
 			txState.fromCoin = btcCoinFrom;
 			txState.toNetwork = Network.lightning;

--- a/src/lib/sendswap/utils/getNetwork.ts
+++ b/src/lib/sendswap/utils/getNetwork.ts
@@ -38,3 +38,20 @@ function throughMagi(from: CoinOnNetwork, to: CoinOnNetwork) {
 		magiSupportedNetworks.includes(to.network.value)
 	);
 }
+
+/**
+ * Human-readable ETA for a TX that touches the given networks. Picks the
+ * slowest network's `settlementSeconds` and formats it. `undefined` entries
+ * (e.g. an unset `rail`) are skipped. Returns the empty string when no network
+ * is provided.
+ */
+export function settlementLabel(networks: (Network | undefined)[]): string {
+	const seconds = networks.reduce(
+		(max, n) => (n ? Math.max(max, n.settlementSeconds) : max),
+		-1
+	);
+	if (seconds < 0) return '';
+	if (seconds <= 5) return 'Instant';
+	if (seconds < 300) return 'About a minute';
+	return `About ${Math.round(seconds / 60)} minutes`;
+}

--- a/src/lib/sendswap/utils/sendOptions.ts
+++ b/src/lib/sendswap/utils/sendOptions.ts
@@ -101,6 +101,7 @@ const magi: IntermediaryNetwork = {
 	value: 'magi',
 	label: 'Magi',
 	icon: '/magi.svg',
+	settlementSeconds: 0, // instant
 	feeCalculation: async (input: UnkCoinAmount, outputCoin: Coin) => {
 		// 0 fees (uses HP but HP usage isn't displayed)
 		return new CoinAmount(0, outputCoin);
@@ -110,6 +111,7 @@ const unknown: IntermediaryNetwork = {
 	value: 'unk',
 	label: 'Unknown',
 	icon: '/unk.svg',
+	settlementSeconds: 0,
 	feeCalculation: async (from: UnkCoinAmount, outputCoin: Coin) => {
 		if (from.coin.value == outputCoin.value) {
 			return new CoinAmount(0, from.coin); // no fee if going between same currency type
@@ -121,6 +123,7 @@ const hiveMainnet: IntermediaryNetwork = {
 	value: 'hive_mainnet',
 	label: 'Hive Mainnet',
 	icon: '/hive/hive.svg',
+	settlementSeconds: 3, // ~Hive block; effectively instant for display
 	feeCalculation: async (from, outputCoin) => {
 		return new CoinAmount(0, outputCoin);
 	}
@@ -135,6 +138,13 @@ export type Network = {
 	label: string;
 	icon: ImageIconOption;
 	feeCalculation?: FeeCalculation<UnkCoinAmount, Coin>;
+	/**
+	 * Typical settlement time for a TX touching this network, in seconds. Used
+	 * by `settlementLabel(networks[])` to pick the longest among the networks
+	 * involved in a TX and format the human-readable ETA shown in ReviewSwap.
+	 * 0 = effectively instant.
+	 */
+	settlementSeconds: number;
 };
 
 export type IntermediaryNetwork = Network & { feeCalculation: FeeCalculation<UnkCoinAmount, Coin> };
@@ -142,12 +152,14 @@ export type IntermediaryNetwork = Network & { feeCalculation: FeeCalculation<Unk
 const btcMainnet: Network = {
 	value: 'btc_mainnet',
 	label: 'BTC Mainnet',
-	icon: '/btc/btc.svg'
+	icon: '/btc/btc.svg',
+	settlementSeconds: 600 // ~10 min on L1
 };
 const lightning: IntermediaryNetwork = {
 	value: 'lightning',
 	label: 'Lightning',
 	icon: '/btc/lightning.svg',
+	settlementSeconds: 60, // ~1 min via the v4v gateway
 	feeCalculation: async (input: UnkCoinAmount, outputCoin: Coin) => {
 		const meta = await getV4VMetadata();
 		const amt = await input.convertTo(Coin.sats, Network.lightning);
@@ -177,33 +189,6 @@ export type AssetOption = {
 
 /** Ordered list of selectable assets (was `{ coins: AssetOption[] }`). */
 export type CoinOptions = AssetOption[];
-
-/**
- * UI-facing labels for the two transfer rails. `length` is the ETA copy shown
- * in ReviewSwap; `value` is the discriminator used by store + routing logic.
- */
-export type TransferMethod = {
-	label: string;
-	value: string;
-	length: string;
-};
-
-const magiTransfer: TransferMethod = {
-	label: 'Magi Transfer',
-	value: 'magi-transfer',
-	length: 'Instant'
-};
-
-const lightningTransfer: TransferMethod = {
-	label: 'Lightning Network',
-	value: 'lightning',
-	length: 'About a Minute'
-};
-
-export const TransferMethod = {
-	magiTransfer,
-	lightningTransfer
-};
 
 export const networkMap: Map<string, Coin[]> = new Map([
 	[Network.magi.value, [Coin.hive, Coin.hbd, Coin.shbd, Coin.btc, Coin.sats]],

--- a/src/lib/sendswap/utils/sendUtils.ts
+++ b/src/lib/sendswap/utils/sendUtils.ts
@@ -34,7 +34,6 @@ import swapOptions, {
 	Coin,
 	Network,
 	networkMap,
-	TransferMethod,
 	type CoinOnNetwork,
 	type AssetOption,
 	type IntermediaryNetwork
@@ -171,10 +170,15 @@ export function getRecipientNetworks(did: string): NetworkOptionParam[] {
 	return [];
 }
 
-function getMethodNetworks(method: TransferMethod) {
-	if (method.value === TransferMethod.magiTransfer.value) {
+/**
+ * Networks reachable via a given rail. Mirrors the old `getMethodNetworks`:
+ * `magi` rail → magi + hiveMainnet; `lightning` rail → lightning. Used by
+ * `solveNetworkConstraints` to constrain available networks/assets.
+ */
+function getRailNetworks(rail: Network | undefined) {
+	if (rail?.value === Network.magi.value) {
 		return [Network.magi, Network.hiveMainnet];
-	} else if (method.value === TransferMethod.lightningTransfer.value) {
+	} else if (rail?.value === Network.lightning.value) {
 		return [Network.lightning];
 	}
 	return [];
@@ -472,14 +476,13 @@ function combineNetworkOptions(
 }
 
 export function solveNetworkConstraints(
-	method: TransferMethod | undefined,
+	rail: Network | undefined,
 	fromCoin: AssetOption | undefined,
 	toNetwork: Network | undefined,
 	did: string | undefined,
 	fromNetwork?: Network,
 	allAssets: boolean = false
 ): Constraints {
-	// console.log("parameters to solve constraints", method, fromCoin, did, account);
 	if (!did)
 		return {
 			assetOptions: [],
@@ -488,13 +491,13 @@ export function solveNetworkConstraints(
 	const inUseNetworks = [Network.magi, Network.hiveMainnet, Network.lightning];
 	const allAssetsSet = createSet(swapOptions.from.map((item) => item.coin));
 
-	const networksGivenMethod = createSet(method ? getMethodNetworks(method) : undefined);
-	const networksGivenBoth = createSet(getDidNetworks(did)).intersection(networksGivenMethod);
-	const networkOptions = combineNetworkOptions(networksGivenMethod, networksGivenMethod, did);
+	const networksGivenRail = createSet(rail ? getRailNetworks(rail) : undefined);
+	const networksGivenBoth = createSet(getDidNetworks(did)).intersection(networksGivenRail);
+	const networkOptions = combineNetworkOptions(networksGivenRail, networksGivenRail, did);
 
-	const assetsGivenMethod = (() => {
+	const assetsGivenRail = (() => {
 		const result = new Set<string>();
-		for (const net of method ? getMethodNetworks(method) : inUseNetworks) {
+		for (const net of rail ? getRailNetworks(rail) : inUseNetworks) {
 			const coins = networkMap.get(net.value);
 			if (coins) {
 				for (const coin of coins) {
@@ -525,8 +528,8 @@ export function solveNetworkConstraints(
 		return createSet(coinOpts);
 	})();
 
-	let coinNetworkOptions: Set<string> = method
-		? createSet(getMethodNetworks(method))
+	let coinNetworkOptions: Set<string> = rail
+		? createSet(getRailNetworks(rail))
 		: createSet(Object.values(Network));
 	if (fromCoin) {
 		const coinNetworks = createSet(fromCoin.networks);
@@ -535,9 +538,9 @@ export function solveNetworkConstraints(
 
 	return {
 		assetOptions: combineAssetOptions(
-			allAssets ? allAssetsSet : assetsGivenMethod,
+			allAssets ? allAssetsSet : assetsGivenRail,
 			assetsGivenFromNetworks,
-			method?.value === TransferMethod.lightningTransfer.value ? undefined : assetsGivenToNetwork,
+			rail?.value === Network.lightning.value ? undefined : assetsGivenToNetwork,
 			toNetwork,
 			fromNetwork
 		),

--- a/src/lib/sendswap/utils/txState.svelte.ts
+++ b/src/lib/sendswap/utils/txState.svelte.ts
@@ -1,7 +1,7 @@
 import { getContext, setContext } from 'svelte';
 import type { CoinAmount } from '$lib/currency/CoinAmount';
 import type { Coin } from './sendOptions';
-import type { AssetOption, CoinOnNetwork, Network, TransferMethod } from './sendOptions';
+import type { AssetOption, CoinOnNetwork, Network } from './sendOptions';
 
 // ─── Base (fields every flow shares) ─────────────────────────────────────────
 
@@ -25,7 +25,6 @@ export class TxStateBase {
 	toNetwork: Network | undefined = $state(undefined);
 	toAmount: string = $state('0');
 	toUsername: string = $state('');
-	method: TransferMethod | undefined = $state(undefined);
 }
 
 // ─── Swap (QuickSwap card, /swap page) ───────────────────────────────────────

--- a/src/lib/sendswap/utils/txState.svelte.ts
+++ b/src/lib/sendswap/utils/txState.svelte.ts
@@ -1,11 +1,23 @@
 import { getContext, setContext } from 'svelte';
 import type { CoinAmount } from '$lib/currency/CoinAmount';
 import type { Coin } from './sendOptions';
-import type { AssetOption, Network, TransferMethod } from './sendOptions';
+import type { AssetOption, CoinOnNetwork, Network, TransferMethod } from './sendOptions';
 
 // ─── Base (fields every flow shares) ─────────────────────────────────────────
 
 export class TxStateBase {
+	// ─── #3/#6 migration: new collapsed selection fields ───────────────────────
+	// `from`/`to` carry the user's chosen (coin, network) as a single value —
+	// matching what UI inputs produce (`CoinOnNetwork`). Eventually replaces the
+	// paired `fromCoin`+`fromNetwork` / `toCoin`+`toNetwork` below.
+	// `rail` is the explicit intermediary network — replaces the `method` field
+	// (#6). When set (e.g. Reown-BTC lightning swap), it overrides the
+	// `getIntermediaryNetwork(from, to)` derivation.
+	from: CoinOnNetwork | undefined = $state(undefined);
+	to: CoinOnNetwork | undefined = $state(undefined);
+	rail: Network | undefined = $state(undefined);
+
+	// ─── legacy fields (still authoritative; will be removed once consumers migrate)
 	fromCoin: AssetOption | undefined = $state(undefined);
 	fromNetwork: Network | undefined = $state(undefined);
 	fromAmount: string = $state('0');


### PR DESCRIPTION
## Summary
- **refactor(txState): replace `method` / `TransferMethod` with `rail: Network`.**
  Drops the legacy `TransferMethod` type, the `magiTransfer` / `lightningTransfer`
  consts, and the `txState.method` field. The same information now lives in:
  - `txState.rail: Network | undefined` — explicit intermediary, set by each flow
    at exactly the same points `method` was set before (`magiTransfer → Network.magi`,
    `lightningTransfer → Network.lightning`).
  - `Network.settlementSeconds` — per-network ETA (magi 0 / hiveMainnet 3 /
    lightning 60 / btcMainnet 600).
  - New `settlementLabel(networks[])` helper picks the slowest involved network
    and formats the ReviewSwap copy.
- **fix(withdraw): disable the Lightning Withdraw button when amount > balance.**
  The `KeepsatsWithdraw` validation effect only checked `amt > 0` and skipped the
  `amt <= balance` gate the sibling `BitcoinMainnetWithdraw` already had. Mirrors
  that pattern; `max.amount` is read in the tracked region so the effect re-runs
  when the balance loads or the user flips between SATS / BTC views.
- **groundwork for #3:** added `from` / `to: CoinOnNetwork` and `rail: Network` on
  `TxStateBase` alongside the legacy `fromCoin` / `fromNetwork` / `toCoin` /
  `toNetwork`. Consumers will migrate in a follow-up PR; the legacy fields stay
  authoritative for now.

## Behavior preservation
- ReviewSwap settlement-time copy is computed by
  `settlementLabel([rail, isBtcSwap ? btcMainnet : undefined])` — the `btcMainnet`
  floor preserves the legacy ~10 min override exactly.
- "No fee" branch reads `rail?.value === Network.magi.value`, which fires on
  exactly the same flows the old `method === magiTransfer` did.
- `solveNetworkConstraints` keeps the same mapping under the renamed
  `getRailNetworks`; the lightning exit check reads `rail.value` directly.

## Type-check
At baseline **194 / 32** (2 below the pre-refactor 196 baseline thanks to the
earlier swapOptions flatten). No new errors introduced.