### PR TITLE
feat(swap): refuse BTC settlement to the user's own deposit address

### DIFF
--- a/src/lib/sendswap/stages/SwapDestination.svelte
+++ b/src/lib/sendswap/stages/SwapDestination.svelte
@@ -2,6 +2,7 @@
 	import { getAuth } from '$lib/auth/store';
 	import { Coin, Network } from '$lib/sendswap/utils/sendOptions';
 	import { useSwapState } from '$lib/sendswap/utils/txState.svelte';
+	import { checkBtcRecipient, fetchUserBtcDepositAddress } from '$lib/sendswap/utils/btcAddressGuard';
 	import { Send, Wallet, X } from '@lucide/svelte';
 	import WaveLoading from '$lib/components/WaveLoading.svelte';
 	import PillButton from '$lib/PillButton.svelte';
@@ -44,6 +45,22 @@
 	let destChoice: 'wallet' | 'address' = $state('wallet');
 	let destAddress = $state('');
 
+	// The user's own BTC deposit address (bridge-controlled). Fetched lazily so
+	// we can refuse a swap that would send BTC out to it (vault→vault stranding).
+	let depositAddress = $state<string | null>(null);
+	let fetchedForDid = $state<string | null>(null);
+	$effect(() => {
+		const did = auth.value?.did ?? null;
+		if (!did || did === fetchedForDid) return;
+		fetchedForDid = did;
+		depositAddress = null;
+		fetchUserBtcDepositAddress(did).then((a) => {
+			if (auth.value?.did === did) depositAddress = a;
+		});
+	});
+
+	const recipientBlock = $derived(checkBtcRecipient(destAddress.trim(), depositAddress));
+
 	// Read preferred network from localStorage; default to 'mainnet' if not set
 	function getStoredNetwork(): string {
 		if (!browser) return 'mainnet';
@@ -64,7 +81,7 @@
 		if (destChoice === 'wallet') {
 			editStage(true);
 		} else {
-			editStage(!!destAddress.trim());
+			editStage(!!destAddress.trim() && !recipientBlock.blocked);
 		}
 	});
 
@@ -158,6 +175,9 @@
 		<p class="dest-hint sm-caption">
 			{coinDisplayLabel(toCoin)} arrives on {destNetworkChoice === 'magi' ? 'Magi' : chainLabel} &mdash; accepts Hive, BTC, EVM or DASH addresses
 		</p>
+		{#if destChoice === 'address' && recipientBlock.blocked}
+			<p class="dest-error error sm-caption">{recipientBlock.reason}</p>
+		{/if}
 	</div>
 </div>
 
@@ -385,6 +405,11 @@
 	.dest-hint {
 		margin: 0;
 		color: var(--dash-text-muted);
+	}
+	.dest-error {
+		margin: 0;
+		color: var(--dash-accent-red, #ff6b6b);
+		line-height: 1.3;
 	}
 
 	/* ── Status & Waiting ── */

--- a/src/lib/sendswap/stages/withdraw/BitcoinMainnetWithdraw.svelte
+++ b/src/lib/sendswap/stages/withdraw/BitcoinMainnetWithdraw.svelte
@@ -6,6 +6,7 @@
 	import { useWithdrawState } from '$lib/sendswap/utils/txState.svelte';
 	import { accountBalance, getBalanceAmount } from '$lib/stores/currentBalance';
 	import { validate, Network as BtcNetwork } from 'bitcoin-address-validation';
+	import { checkBtcRecipient, fetchUserBtcDepositAddress } from '$lib/sendswap/utils/btcAddressGuard';
 	import {
 		estimateBtcUnmapFee,
 		type BtcFeeEstimate
@@ -23,6 +24,21 @@
 	let btcAddressError = $state<string | undefined>(undefined);
 	let isBtcAddressValid = $state(false);
 	let previousOpen: boolean | undefined;
+
+	// The user's own BTC deposit address (bridge-controlled). Withdrawing to it
+	// returns funds to the vault and strands them, so we refuse it.
+	let depositAddress = $state<string | null>(null);
+	let fetchedForDid = $state<string | null>(null);
+	$effect(() => {
+		const did = auth.value?.did ?? null;
+		if (!did || did === fetchedForDid) return;
+		fetchedForDid = did;
+		depositAddress = null;
+		fetchUserBtcDepositAddress(did).then((a) => {
+			if (auth.value?.did === did) depositAddress = a;
+		});
+	});
+	const depositBlock = $derived(checkBtcRecipient(btcAddress.trim(), depositAddress));
 
 	// Autofill BTC address when the user is logged in with a Bitcoin wallet
 	$effect(() => {
@@ -100,6 +116,7 @@
 		if (!open) return;
 		const valid = !!(
 			isBtcAddressValid &&
+			!depositBlock.blocked &&
 			txState.fromCoin &&
 			txState.fromNetwork &&
 			coinAmount.amount > 0 &&
@@ -128,6 +145,8 @@
 		/>
 		{#if btcAddressError}
 			<span class="error-message">{btcAddressError}</span>
+		{:else if depositBlock.blocked}
+			<span class="error-message">{depositBlock.reason}</span>
 		{/if}
 	</div>
 	<div class="section">

--- a/src/lib/sendswap/utils/btcAddressGuard.ts
+++ b/src/lib/sendswap/utils/btcAddressGuard.ts
@@ -1,0 +1,83 @@
+// Guard against sending a BTC mainnet output to an address the app itself
+// generated for the user — namely their own Magi BTC **deposit address**.
+//
+// A deposit address is a bridge-controlled P2WSH address: external BTC sent
+// there is credited to the user on Magi. Sending an unmap/withdrawal (or a
+// swap settled on BTC) *out* to that same address produces a vault→vault
+// transfer: the bridge debits the user and the BTC lands back in a
+// bridge-controlled address, never crediting them. The funds are stranded
+// (recoverable only by an operator). This mirrors a real mainnet incident, so
+// the swap control refuses such a destination up front.
+//
+// Note: this is a client-side UX guard. The authoritative protection lives in
+// the btc-mapping contract's HandleUnmap (which rejects an unmap to the bridge
+// vault address). Direct contract callers bypass this check.
+
+/**
+ * Normalizes a BTC address for equality comparison. bech32 (bc1/tb1/bcrt1) is
+ * case-insensitive and canonically lowercase, so trimming + lowercasing is a
+ * safe comparison key for the segwit deposit addresses the app derives.
+ */
+function normalizeBtcAddress(addr: string): string {
+	return addr.trim().toLowerCase();
+}
+
+/**
+ * Fetches the BTC deposit address the app generates for `did`, or null when
+ * the feature is unavailable (no signing pubkey configured — the API returns
+ * 503) or the request fails. Returning null makes the guard fail open rather
+ * than blocking legitimate withdrawals when we simply can't derive the address.
+ */
+export async function fetchUserBtcDepositAddress(
+	did: string,
+	fetchFn: typeof fetch = fetch
+): Promise<string | null> {
+	if (!did) return null;
+	try {
+		const res = await fetchFn(`/api/btcaddress?did=${encodeURIComponent(did)}`);
+		if (!res.ok) return null;
+		const data: unknown = await res.json();
+		const addr = (data as { btc_address?: unknown })?.btc_address;
+		return typeof addr === 'string' && addr.length > 0 ? addr : null;
+	} catch {
+		return null;
+	}
+}
+
+export interface BtcRecipientCheck {
+	blocked: boolean;
+	reason?: string;
+}
+
+const DEPOSIT_ADDRESS_REASON =
+	'This is your own Magi BTC deposit address. Sending BTC out to it would return the funds to the bridge vault and strand them. Use an external Bitcoin wallet address instead.';
+
+/**
+ * Returns blocked=true when `recipient` matches an address the app generated
+ * for this user (their BTC deposit address). When `depositAddress` is null
+ * (feature unavailable) the check is a no-op.
+ */
+export function checkBtcRecipient(
+	recipient: string | undefined,
+	depositAddress: string | null
+): BtcRecipientCheck {
+	if (!recipient || !depositAddress) return { blocked: false };
+	if (normalizeBtcAddress(recipient) === normalizeBtcAddress(depositAddress)) {
+		return { blocked: true, reason: DEPOSIT_ADDRESS_REASON };
+	}
+	return { blocked: false };
+}
+
+/**
+ * Enforcement helper: throws if `recipient` is an app-generated address for
+ * `did`. Call before building any BTC-mainnet settlement/withdrawal op.
+ */
+export async function assertBtcRecipientAllowed(
+	recipient: string | undefined,
+	did: string,
+	fetchFn: typeof fetch = fetch
+): Promise<void> {
+	const deposit = await fetchUserBtcDepositAddress(did, fetchFn);
+	const { blocked, reason } = checkBtcRecipient(recipient, deposit);
+	if (blocked) throw new Error(reason);
+}

--- a/src/lib/sendswap/utils/sendUtils.ts
+++ b/src/lib/sendswap/utils/sendUtils.ts
@@ -11,6 +11,7 @@ import { executeTx, getSendOpGenerator, getSendOpType } from '$lib/magiTransacti
 import { getHiveDepositOp } from '$lib/magiTransactions/hive/vscOperations/deposit'
 import { getKeepsatsDestinationDid, getKeepsatsTransferOp } from '$lib/magiTransactions/hive/vscOperations/keepsatsTransfer'
 import { getBtcApproveOp, getHiveSwapOp } from '$lib/magiTransactions/hive/vscOperations/swap'
+import { assertBtcRecipientAllowed } from './btcAddressGuard'
 import {
 	accountBalance,
 	type AccountBalance,
@@ -585,6 +586,21 @@ export async function send(
 	const raw = details.toAmount;
 	const amount =
 		raw && raw !== '0' ? raw : details.fromAmount && details.fromAmount !== '0' ? details.fromAmount : raw;
+	// Refuse any BTC-mainnet settlement/withdrawal whose recipient is an address
+	// the app generated for this user (their own deposit address). Such a
+	// destination is bridge-controlled, so the funds would return to the vault
+	// and strand. Authoritative guard is in the btc-mapping contract; this fails
+	// the swap up front for a clear UX. (No-op when the deposit address can't be
+	// derived, so legitimate withdrawals are never blocked.)
+	if (toNetwork.value === Network.btcMainnet.value && auth.value?.did) {
+		try {
+			await assertBtcRecipientAllowed(toUsername, auth.value.did);
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : 'Invalid Bitcoin destination address.';
+			setStatus(msg, true);
+			return new Error(msg);
+		}
+	}
 	if (intermediary == Network.magi) {
 		// console.log('intermediary network is Magi');
 		if (auth.value?.provider == 'reown') {


### PR DESCRIPTION
Sending a swap-with-external-settlement or a withdrawal out to a bridge-controlled BTC address (the user's own Magi deposit address) produces a vault->vault transfer: the bridge debits the user and the BTC lands back in a bridge-controlled address, never crediting them. The funds strand (operator-recoverable only). This mirrors a real mainnet incident, so the swap control now refuses such a destination.

- add btcAddressGuard.ts: fetchUserBtcDepositAddress() (via existing /api/btcaddress), checkBtcRecipient() normalized equality, and assertBtcRecipientAllowed() enforcement helper; fails open when the deposit address can't be derived so legit withdrawals aren't blocked
- enforce in sendUtils.send(): guard every BTC-mainnet destination path (swap settlement, withdrawal, reown-BTC) before building the op
- SwapDestination.svelte + BitcoinMainnetWithdraw.svelte: lazily fetch the deposit address, show an inline error, and block proceeding when the entered address matches

Note: UX/defense-in-depth only — the authoritative guard is the btc-mapping contract's HandleUnmap vault-address check. Direct contract callers bypass this client-side check.