### PR TITLE
refactor(sendswap): txState reshape — collapse fromCoin/fromNetwork → from: CoinOnNetwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Altera are documented here.
 
 ## [0.3.12] — 2026-06-01
 
+### Fixes
+
+- Successful **Lightning broadcasts** (deposits, V4V-routed swaps) no longer fail to register in the local transactions list. The V4V popup's `onsuccess` callback in `StepsMachine` referenced an undeclared `toCoin` identifier (carried over from the pre-migration paired API), so `addLocalTransaction()` threw a ReferenceError every time. The Lightning side of the bridge had completed, but the UI silently lost the row. Replaced with `to.coin` using the existing `{@const to = txState.to}` already in scope
+
 ### Internals
 
 - Completed the `txState` reshape started in 0.3.11. `TxStateBase` now exposes a single `from` / `to: CoinOnNetwork` for each side instead of the paired `fromCoin` / `fromNetwork` / `toCoin` / `toNetwork` it had at the start of the cycle. ~340 active legacy refs migrated across 13 components (display surfaces, deposit/withdraw pickers, ReviewSwap, SendSwap, SwapOptions, QuickSwap, the Quick/Transfer pickers, and SelectAssetFlattened) before the `@deprecated` shim getter/setters were removed. No user-visible behavior change; the picker UI, swap flows, and fee math are all unchanged
@@ -12,14 +16,17 @@ All notable changes to Altera are documented here.
 - Added `isValidAmountString(s)` in `CoinAmount` — replaces the four scattered patterns (`Number(amount) > 0`, `parseFloat(amount)`, `!!amount && amount !== '0'`, etc.) used in tx-completion gates. Equivalent only by accident before — the new helper rejects NaN, negatives, Infinity, and `'0'` consistently. Currently consumed by `KeepsatsWithdraw`'s validation gate (which previously let through amounts exceeding the wallet balance — see 0.3.11)
 - `HiveMainnetDeposit` swapped from the generic `useTxState()` (returns `TxState | undefined`) to `useDepositState()` (throws on wrong context) — matches every other deposit/withdraw picker. Drops ~16 pre-existing `'txState' is possibly undefined'` TS warnings
 - `sendUtils.ts` — `getFee`, `solveToNetworks`, and `send()` migrated to read the new `from` / `to` fields; `send()` resolves the AssetOption catalog entries via `getFromOption` / `getToOption` for the downstream `.networks` lookups it needs
+- Extracted `StepsMachine.initSend()`'s decision tree (default-to logic for deposit/withdraw, error-guards, intermediary computation, v4v-vs-broadcast branch) into a pure `decideBroadcast(txState, txType)` helper in `broadcastDecision.ts`. Same behavior, testable boundary — the component's IO (`setStatus`, `openV4V`, `send()`) still lives in the component. Tests now document that `railOverride` is deliberately NOT read on the broadcast path (it's a UI-filtering hint consumed by `solveNetworkConstraints`); if we ever want overrides to affect broadcast routing, the tests flip in one line
 
 ### Testing
 
-- Test suite grew from 74 → 148 tests across 12 suites. New coverage:
+- Test suite grew from 74 → 212 tests across 21 suites (+ 2 skipped). New coverage:
   - `getIntermediaryNetwork` routing rules (every magi / hiveMainnet / lightning / unknown pair) + `settlementLabel` ETA formatting — pins the function now that `rail` derives from it
   - `swapOptions` catalog lookups including the SATS / USD / UNK / sHBD asymmetry that caused the DepositOptions Lightning fallback during the migration
   - `isValidAmountString` edge cases (NaN, Infinity, `'0'`, negatives, whitespace, scientific notation)
   - `txState` from/to source-of-truth + rail derivation (incl. the override-restores-derivation contract)
+  - **Tier-A flow integration**: one file per transaction flow (BTC mainnet, Lightning deposit/withdraw, Hive mainnet deposit/withdraw, internal transfer, swap) — pins the state shape each parent picker writes, the derived rail, and per-flow defaults
+  - **Tier-C broadcast contract**: 18 `decideBroadcast` cases covering every flow's intermediary, both v4v-popup and direct-broadcast branches, the default-to logic for deposit/withdraw, and the railOverride-is-not-read contract
 - Fixed a SvelteKit `$env/dynamic/public` virtual-module crash in client tests via a `vi.mock` in `vitest-setup-client.ts` — previously `txState.svelte.test.ts` couldn't even load
 
 ## [0.3.11] — 2026-05-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to Altera are documented here.
 
+## [0.3.12] — 2026-06-01
+
+### Internals
+
+- Completed the `txState` reshape started in 0.3.11. `TxStateBase` now exposes a single `from` / `to: CoinOnNetwork` for each side instead of the paired `fromCoin` / `fromNetwork` / `toCoin` / `toNetwork` it had at the start of the cycle. ~340 active legacy refs migrated across 13 components (display surfaces, deposit/withdraw pickers, ReviewSwap, SendSwap, SwapOptions, QuickSwap, the Quick/Transfer pickers, and SelectAssetFlattened) before the `@deprecated` shim getter/setters were removed. No user-visible behavior change; the picker UI, swap flows, and fee math are all unchanged
+- `rail` is now a derived getter on `TxStateBase` that computes via `getIntermediaryNetwork(from, to)` instead of being set explicitly by each flow. Six redundant `txState.rail = …` writes deleted across `DepositOptions`, `WithdrawOptions`, and `QuickSend` (the from/to networks already indicate the rail). Two cases keep an explicit `railOverride` — the QuickSwap and `/swap` page Reown swap, which bridges via Lightning even though neither endpoint network is Lightning. `txState.rail` reads return the override when set, otherwise the derived value
+- `SelectAssetFlattened` collapsed its two `$bindable` props (`coin: AssetOption` + `network: Network`) into a single `selected: CoinOnNetwork` to match the new TxState shape. Drops three pieces of dead state (`tmpAsset` / `tmpNetwork` / `tmpNetworkVal`) and a `$effect` that only existed to reconcile paired writes. Eliminates an order-of-write trap where the old shim could silently discard the user's network pick on first-time selection
+- Added `isValidAmountString(s)` in `CoinAmount` — replaces the four scattered patterns (`Number(amount) > 0`, `parseFloat(amount)`, `!!amount && amount !== '0'`, etc.) used in tx-completion gates. Equivalent only by accident before — the new helper rejects NaN, negatives, Infinity, and `'0'` consistently. Currently consumed by `KeepsatsWithdraw`'s validation gate (which previously let through amounts exceeding the wallet balance — see 0.3.11)
+- `HiveMainnetDeposit` swapped from the generic `useTxState()` (returns `TxState | undefined`) to `useDepositState()` (throws on wrong context) — matches every other deposit/withdraw picker. Drops ~16 pre-existing `'txState' is possibly undefined'` TS warnings
+- `sendUtils.ts` — `getFee`, `solveToNetworks`, and `send()` migrated to read the new `from` / `to` fields; `send()` resolves the AssetOption catalog entries via `getFromOption` / `getToOption` for the downstream `.networks` lookups it needs
+
+### Testing
+
+- Test suite grew from 74 → 148 tests across 12 suites. New coverage:
+  - `getIntermediaryNetwork` routing rules (every magi / hiveMainnet / lightning / unknown pair) + `settlementLabel` ETA formatting — pins the function now that `rail` derives from it
+  - `swapOptions` catalog lookups including the SATS / USD / UNK / sHBD asymmetry that caused the DepositOptions Lightning fallback during the migration
+  - `isValidAmountString` edge cases (NaN, Infinity, `'0'`, negatives, whitespace, scientific notation)
+  - `txState` from/to source-of-truth + rail derivation (incl. the override-restores-derivation contract)
+- Fixed a SvelteKit `$env/dynamic/public` virtual-module crash in client tests via a `vi.mock` in `vitest-setup-client.ts` — previously `txState.svelte.test.ts` couldn't even load
+
 ## [0.3.11] — 2026-05-28
 
 ### Fixes

--- a/schema.graphql
+++ b/schema.graphql
@@ -205,13 +205,36 @@ type ContractOutputResult {
 """ISO 8601 (RFC 3339) formatted date-time string."""
 scalar DateTime
 
+"""
+Per-account HBD payout from the pendulum:nodes bucket at settlement time.
+"""
+type DistributionEntry {
+  """Recipient Hive account."""
+  account: String!
+
+  """HBD amount distributed."""
+  hbd_amount: Int64!
+}
+
 """A member of a consensus election committee."""
 type ElectionMember {
   """Hive account of the elected member."""
   account: String!
 
+  """True when per-member version fields were recorded at election time."""
+  has_per_member_version: Boolean!
+
   """Public key of the elected member."""
   key: String!
+
+  """Consensus component at election snapshot for this member."""
+  member_consensus: Uint64!
+
+  """Major component at election snapshot for this member."""
+  member_major: Uint64!
+
+  """Non-consensus component at election snapshot for this member."""
+  member_non_consensus: Uint64!
 }
 
 """Result of a consensus election for a given epoch."""
@@ -237,6 +260,14 @@ type ElectionResult {
   """Protocol version at the time of election."""
   protocol_version: Uint64!
 
+  """
+  Closing committee's settlement record for the epoch that just ended.
+  Null for pre-pendulum elections and for elections that rotate away from
+  the genesis committee (i.e. when the proposer skips composition because
+  there is no prior epoch to settle).
+  """
+  settlement: SettlementRecord
+
   """Total combined weight of all elected members."""
   total_weight: Uint64!
 
@@ -245,6 +276,12 @@ type ElectionResult {
 
   """Election type."""
   type: String!
+
+  """Major component at election time."""
+  version_major: Uint64!
+
+  """Non-consensus component at election time."""
+  version_non_consensus: Uint64!
 
   """Voting weights of each elected member."""
   weights: [Uint64!]!
@@ -442,8 +479,40 @@ input LedgerTxFilter {
 
 """Information about the local Magi node."""
 type LocalNodeInfo {
+  """Active consensus executor implementation identifier at the local head."""
+  active_consensus_executor: String!
+
+  """Active coordinated consensus line (major.consensus) at the local head."""
+  active_consensus_line: String!
+
   """Status of each registered chain oracle."""
   chain_oracles: [ChainOracleStatus!]!
+
+  """
+  Block height where the activation was scheduled (proposal/recovery tx height).
+  """
+  consensus_activation_attested_block: Uint64
+
+  """Transaction id that scheduled the activation."""
+  consensus_activation_attested_txid: String
+
+  """
+  Scheduled activation epoch at/after which the version switch may activate.
+  """
+  consensus_activation_epoch: Uint64
+
+  """
+  Scheduled activation mode for the pending switch-over (normal or recovery).
+  """
+  consensus_activation_mode: String
+
+  """Scheduled activation version display (major.consensus)."""
+  consensus_activation_version: String
+
+  """
+  Consensus triple display (major.consensus.non_consensus), provisional -p during recovery suspension.
+  """
+  consensus_version_display: String!
 
   """Current consensus epoch."""
   epoch: Uint64!
@@ -453,6 +522,11 @@ type LocalNodeInfo {
 
   """Most recent Hive L1 block processed by this node."""
   last_processed_block: Uint64!
+
+  """
+  True while chain processing is suspended until recovery multisig clears the gate.
+  """
+  processing_suspended: Boolean!
 
   """Software version identifier."""
   version_id: String!
@@ -715,6 +789,49 @@ type RcRecord {
 
   """Maximum resource credits for this account (based on staked balance)."""
   max_rcs: Int64!
+}
+
+"""Per-witness consolidated reward reduction applied at settlement time."""
+type RewardReductionEntry {
+  """Hive account whose effective bond was reduced."""
+  account: String!
+
+  """Reduction in basis points applied to the bond."""
+  bps: Int!
+}
+
+"""
+Closing committee's pendulum settlement record for the epoch that just ended.
+Sub-arrays are sorted by account on construction so encoding is byte-stable
+across nodes.
+"""
+type SettlementRecord {
+  """Pendulum:nodes:hbd ledger balance the record was composed against."""
+  bucket_balance_hbd: Int64!
+
+  """Per-account HBD payouts, sorted by account."""
+  distributions: [DistributionEntry!]!
+
+  """Closing epoch — the one whose service the rewards pay for."""
+  epoch: Uint64!
+
+  """Epoch settled in the previous record (chain-continuity check)."""
+  prev_epoch: Uint64!
+
+  """Residual HBD remaining in the bucket after distribution."""
+  residual_hbd: Int64!
+
+  """Per-witness consolidated reductions, sorted by account."""
+  reward_reductions: [RewardReductionEntry!]!
+
+  """Exclusive lower bound of the L2 evidence window (block height)."""
+  snapshot_range_from: Uint64!
+
+  """Inclusive upper bound of the L2 evidence window (block height)."""
+  snapshot_range_to: Uint64!
+
+  """Sum of all per-account distributions."""
+  total_distributed_hbd: Int64!
 }
 
 """Input for a single simulated contract call."""
@@ -1091,6 +1208,14 @@ type Witness {
 
   """Software version identifier of the witness node."""
   version_id: String
+
+  """Major component of major.consensus.non_consensus."""
+  version_major: Uint64!
+
+  """
+  Non-consensus component (optional behavior); may differ without excluding the witness.
+  """
+  version_non_consensus: Uint64!
 }
 
 """A slot in the witness block production schedule."""

--- a/src/lib/cards/QuickSwap.svelte
+++ b/src/lib/cards/QuickSwap.svelte
@@ -113,10 +113,8 @@
 		const toNet = toOpt ? nativeNetworkFor(toOpt.coin.value) : undefined;
 
 		txState.rail = Network.lightning;
-		txState.fromCoin = fromOpt ?? undefined;
-		txState.fromNetwork = fromNet;
-		txState.toCoin = toOpt ?? undefined;
-		txState.toNetwork = toNet;
+		txState.from = fromOpt && fromNet ? { coin: fromOpt.coin, network: fromNet } : undefined;
+		txState.to = toOpt && toNet ? { coin: toOpt.coin, network: toNet } : undefined;
 	}
 
 	let swapDetailsInitialized = $state(false);
@@ -133,10 +131,10 @@
 	// as dependencies on the first (gated) effect run — otherwise this
 	// effect would never re-fire when the user changes a selection.
 	$effect(() => {
-		const fromCoin = txState.fromCoin?.coin.value;
-		const fromNetwork = txState.fromNetwork?.value;
-		const toCoin = txState.toCoin?.coin.value;
-		const toNetwork = txState.toNetwork?.value;
+		const fromCoin = txState.from?.coin.value;
+		const fromNetwork = txState.from?.network.value;
+		const toCoin = txState.to?.coin.value;
+		const toNetwork = txState.to?.network.value;
 		if (!swapDetailsInitialized) return;
 		if (fromCoin || toCoin) {
 			saveSwapSelection(SWAP_QUICK_PREF_KEY, { fromCoin, fromNetwork, toCoin, toNetwork });
@@ -155,7 +153,7 @@
 	$effect(() => {
 		if (!auth.value) return;
 		const provider = auth.value.provider;
-		const toValue = txState.toCoin?.coin.value;
+		const toValue = txState.to?.coin.value;
 
 		const walletMatchesTo =
 			(provider === 'aioha' && (toValue === Coin.hive.value || toValue === Coin.hbd.value)) ||
@@ -188,10 +186,10 @@
 	$effect(() => {
 		const result = solveNetworkConstraints(
 			txState.rail,
-			txState.fromCoin,
-			txState.toNetwork,
+			getFromOption(txState.from?.coin.value),
+			txState.to?.network,
 			auth.value?.did,
-			txState.fromNetwork,
+			txState.from?.network,
 			true
 		);
 		if (!optionsEqual(result.assetOptions, assetOptions)) assetOptions = result.assetOptions;
@@ -226,12 +224,8 @@
 
 	let possibleCoins: CoinOnNetwork[] = $derived.by(() => {
 		const result: CoinOnNetwork[] = [];
-		if (txState.fromCoin && txState.fromNetwork) {
-			result.push({ coin: txState.fromCoin.coin, network: txState.fromNetwork });
-		}
-		if (txState.toCoin && txState.toNetwork) {
-			result.push({ coin: txState.toCoin.coin, network: txState.toNetwork });
-		}
+		if (txState.from) result.push(txState.from);
+		if (txState.to) result.push(txState.to);
 		const btcIndex = result.findIndex((c) => c.coin.value === Coin.btc.value);
 		if (btcIndex !== -1) {
 			result.splice(btcIndex + 1, 0, { coin: Coin.sats, network: result[btcIndex].network });
@@ -240,26 +234,20 @@
 	});
 
 	// Single-option list for From amount input so AmountInput does not show internal dropdown
-	const fromOnlyCoinOpts: CoinOnNetwork[] = $derived.by(() => {
-		if (!txState.fromCoin || !txState.fromNetwork) return [];
-		return [{ coin: txState.fromCoin.coin, network: txState.fromNetwork }];
-	});
+	const fromOnlyCoinOpts: CoinOnNetwork[] = $derived(txState.from ? [txState.from] : []);
 
 	// Single-option list for To amount input
-	const toOnlyCoinOpts: CoinOnNetwork[] = $derived.by(() => {
-		if (!txState.toCoin || !txState.toNetwork) return [];
-		return [{ coin: txState.toCoin.coin, network: txState.toNetwork }];
-	});
+	const toOnlyCoinOpts: CoinOnNetwork[] = $derived(txState.to ? [txState.to] : []);
 
 	let inputAmount = $state(new CoinAmount(0, Coin.unk));
 	let toInputAmount = $state(new CoinAmount(0, Coin.unk));
 	$effect(() => {
-		if (!txState.fromCoin) return;
-		if (inputAmount.coin.value === txState.fromCoin.coin.value) {
+		if (!txState.from) return;
+		if (inputAmount.coin.value === txState.from.coin.value) {
 			const amt = inputAmount.toAmountString();
 			if (amt !== txState.fromAmount) txState.fromAmount = amt;
 		} else {
-			inputAmount.convertTo(txState.fromCoin.coin, Network.lightning).then((amt) => {
+			inputAmount.convertTo(txState.from.coin, Network.lightning).then((amt) => {
 				if (txState.fromAmount !== amt.toAmountString()) {
 					txState.fromAmount = amt.toAmountString();
 				}
@@ -267,12 +255,12 @@
 		}
 	});
 	$effect(() => {
-		if (!txState.toCoin) return;
-		if (toInputAmount.coin.value === txState.toCoin.coin.value) {
+		if (!txState.to) return;
+		if (toInputAmount.coin.value === txState.to.coin.value) {
 			const amt = toInputAmount.toAmountString();
 			if (amt !== txState.toAmount) txState.toAmount = amt;
 		} else {
-			toInputAmount.convertTo(txState.toCoin.coin, Network.lightning).then((amt) => {
+			toInputAmount.convertTo(txState.to.coin, Network.lightning).then((amt) => {
 				if (txState.toAmount !== amt.toAmountString()) {
 					txState.toAmount = amt.toAmountString();
 				}
@@ -282,9 +270,9 @@
 
 	let fromInTo = $state('');
 	$effect(() => {
-		if (txState.fromCoin && txState.toCoin) {
-			new CoinAmount(1, txState.fromCoin.coin)
-				.convertTo(txState.toCoin.coin, Network.lightning)
+		if (txState.from && txState.to) {
+			new CoinAmount(1, txState.from.coin)
+				.convertTo(txState.to.coin, Network.lightning)
 				.then((amt) => {
 					fromInTo = formatRateAmount(amt);
 				});
@@ -293,16 +281,16 @@
 
 	let toPriceUsdRaw = $state(0);
 	$effect(() => {
-		if (txState.toCoin) {
-			new CoinAmount(1, txState.toCoin.coin).convertTo(Coin.usd, Network.lightning).then((amt) => {
+		if (txState.to) {
+			new CoinAmount(1, txState.to.coin).convertTo(Coin.usd, Network.lightning).then((amt) => {
 				toPriceUsdRaw = amt.toNumber();
 			});
 		}
 	});
 
 	let priceImpactPct = $derived.by(() => {
-		const fromCoinDef = txState.fromCoin;
-		const toCoinDef = txState.toCoin;
+		const fromCoinDef = txState.from;
+		const toCoinDef = txState.to;
 		const fromAmount = txState.fromAmount;
 		if (!fromCoinDef || !toCoinDef || !fromAmount || fromAmount === '0') return 0;
 		if (!swapResult || swapResult.expectedOutput <= 0n) return 0;
@@ -346,7 +334,7 @@
 	}
 
 	let exchangeFeePct = $derived(
-		getAlteraFeePct(txState.fromCoin?.coin.value ?? '', txState.toCoin?.coin.value ?? '')
+		getAlteraFeePct(txState.from?.coin.value ?? '', txState.to?.coin.value ?? '')
 	);
 
 	/**
@@ -355,7 +343,7 @@
 	 * HBD (≈ $1 pegged). Final-hop fee is in the output coin.
 	 */
 	let totalProtocolFeeUsd = $derived.by(() => {
-		const toCoinDef = txState.toCoin;
+		const toCoinDef = txState.to;
 		if (!swapResult || toPriceUsdRaw <= 0 || !toCoinDef) return null;
 		const finalHopUsd =
 			(Number(swapResult.baseFee) / 10 ** toCoinDef.coin.decimalPlaces) * toPriceUsdRaw;
@@ -401,8 +389,8 @@
 	}
 
 	$effect(() => {
-		const fromCoin = txState.fromCoin;
-		const toCoin = txState.toCoin;
+		const fromCoin = txState.from;
+		const toCoin = txState.to;
 		const fromAmount = txState.fromAmount;
 		if (!fromCoin || !toCoin || !fromAmount || fromAmount === '0') {
 			resetSwapState();
@@ -517,7 +505,7 @@
 	// user deleted the FROM amount or picked incompatible coins.
 	$effect(() => {
 		const expectedRaw = txState.expectedOutput;
-		const coin = txState.toCoin?.coin;
+		const coin = txState.to?.coin;
 		if (!coin) return;
 		if (expectedRaw && expectedRaw !== '0') return;
 		untrack(() => {
@@ -554,12 +542,11 @@
 	// Hive (from the L1 account) and BTC (from mempool.space via the
 	// reown BitcoinAdapter address).
 	const maxAmount = $derived.by(() => {
-		const coin = txState.fromCoin?.coin;
-		const network = txState.fromNetwork;
-		if (!coin || !network) return undefined;
-		const raw = getBalanceSmallestUnits($accountBalance, coin, network);
+		const from = txState.from;
+		if (!from) return undefined;
+		const raw = getBalanceSmallestUnits($accountBalance, from.coin, from.network);
 		if (raw <= 0) return undefined;
-		return new CoinAmount(raw, coin, true);
+		return new CoinAmount(raw, from.coin, true);
 	});
 
 	let dialogOpen = $state(false);
@@ -639,7 +626,7 @@
 	 * anyway, but disabling it at pick time is clearer to the user.)
 	 */
 	function isToTokenAllowed(value: string): boolean {
-		const fromValue = txState.fromCoin?.coin.value;
+		const fromValue = txState.from?.coin.value;
 		return !fromValue || value !== fromValue;
 	}
 
@@ -649,26 +636,24 @@
 	 * on the FROM side (wallet constraint) and both slots are filled.
 	 */
 	const canSwapPositions = $derived.by(() => {
-		const toValue = txState.toCoin?.coin.value;
-		if (!toValue || !txState.fromCoin) return false;
+		const toValue = txState.to?.coin.value;
+		if (!toValue || !txState.from) return false;
 		return fromAllowedValues.has(toValue);
 	});
 
 	/** Human-readable reason when the swap button is disabled. */
 	const swapBlockedReason = $derived.by(() => {
-		if (!txState.toCoin || !txState.fromCoin) return 'Select both tokens first';
-		return `${txState.toCoin.coin.label} can't be used as source with your wallet`;
+		if (!txState.to || !txState.from) return 'Select both tokens first';
+		return `${txState.to.coin.label} can't be used as source with your wallet`;
 	});
 
 	/** Swap the FROM and TO tokens + networks. */
 	function swapPositions() {
 		if (!canSwapPositions) return;
-		const prevFrom = txState.fromCoin;
-		const prevFromNet = txState.fromNetwork;
-		txState.fromCoin = txState.toCoin;
-		txState.fromNetwork = txState.toNetwork;
-		txState.toCoin = prevFrom;
-		txState.toNetwork = prevFromNet;
+		if (!txState.from || !txState.to) return;
+		const prevFrom = txState.from;
+		txState.from = txState.to;
+		txState.to = prevFrom;
 	}
 
 	function selectToken(token: AssetObject) {
@@ -679,26 +664,25 @@
 		// token on both sides and feels natural (like PancakeSwap).
 		const otherValue =
 			currentlyOpen === 'from'
-				? txState.toCoin?.coin.value
-				: txState.fromCoin?.coin.value;
+				? txState.to?.coin.value
+				: txState.from?.coin.value;
 
 		if (otherValue && token.value === otherValue) {
 			// The user picked the token that's in the other slot → swap positions.
 			// But first check: would the swap put a wallet-incompatible token in FROM?
 			// e.g. TO=BTC, user opens TO picker and clicks HIVE (current FROM) →
 			// swap would move BTC to FROM, which is blocked on a Hive wallet.
-			const wouldBeFrom = currentlyOpen === 'from' ? token.value : txState.toCoin?.coin.value;
+			const wouldBeFrom = currentlyOpen === 'from' ? token.value : txState.to?.coin.value;
 			if (wouldBeFrom && !fromAllowedValues.has(wouldBeFrom)) {
 				// Can't swap — just assign the token to the current slot instead.
 				// This may create a same-token pair; the existing sameCoinSelected
 				// warning will prompt the user to fix the other side.
 			} else {
-				const prevFrom = txState.fromCoin;
-				const prevFromNet = txState.fromNetwork;
-				txState.fromCoin = txState.toCoin;
-				txState.fromNetwork = txState.toNetwork;
-				txState.toCoin = prevFrom;
-				txState.toNetwork = prevFromNet;
+				if (txState.from && txState.to) {
+					const prevFrom = txState.from;
+					txState.from = txState.to;
+					txState.to = prevFrom;
+				}
 				closeDialog();
 				return;
 			}
@@ -713,12 +697,14 @@
 		// asset's native mainnet (btcMainnet for BTC, hiveMainnet for
 		// HIVE/HBD), never Magi.
 		const net = nativeNetworkFor(coinOpt.coin.value);
+		if (!net) {
+			closeDialog();
+			return;
+		}
 		if (currentlyOpen === 'from') {
-			txState.fromCoin = coinOpt;
-			txState.fromNetwork = net;
+			txState.from = { coin: coinOpt.coin, network: net };
 		} else {
-			txState.toCoin = coinOpt;
-			txState.toNetwork = net;
+			txState.to = { coin: coinOpt.coin, network: net };
 		}
 		closeDialog();
 	}
@@ -770,25 +756,24 @@
 		!!txState.fromAmount && txState.fromAmount !== '0' && inputAmount.amount > 0
 	);
 	const sameCoinSelected = $derived(
-		!!txState.fromCoin &&
-			!!txState.toCoin &&
-			txState.fromCoin.coin.value === txState.toCoin.coin.value
+		!!txState.from &&
+			!!txState.to &&
+			txState.from.coin.value === txState.to.coin.value
 	);
 	const missingReceiver = $derived(!txState.toUsername?.trim());
 	const exceedsBalance = $derived.by(() => {
-		const coin = txState.fromCoin?.coin;
-		const network = txState.fromNetwork;
-		if (!coin || !network) return false;
+		const from = txState.from;
+		if (!from) return false;
 		const entered = inputAmount.amount;
 		if (!Number.isFinite(entered) || entered <= 0) return false;
-		const maxSmallest = getBalanceSmallestUnits($accountBalance, coin, network);
+		const maxSmallest = getBalanceSmallestUnits($accountBalance, from.coin, from.network);
 		if (maxSmallest <= 0) return false;
 		return entered > maxSmallest;
 	});
 
 	const exceedsPoolDepth = $derived.by(() => {
-		const fromCoin = txState.fromCoin;
-		const toCoin = txState.toCoin;
+		const fromCoin = txState.from;
+		const toCoin = txState.to;
 		const fromAmount = txState.fromAmount;
 		if (!fromCoin || !toCoin || !fromAmount || fromAmount === '0') return false;
 		const fromAmountInt = new CoinAmount(fromAmount, fromCoin.coin).amount;
@@ -847,7 +832,7 @@
 			setError('Connect your wallet first');
 			return false;
 		}
-		if (!txState.fromCoin || !txState.toCoin) {
+		if (!txState.from || !txState.to) {
 			setError('Select both tokens');
 			return false;
 		}
@@ -866,7 +851,7 @@
 		// BTC target: receiver must be a valid Bitcoin address on the
 		// appropriate network. Reject early so we never send a swap
 		// instruction with a malformed/non-BTC recipient.
-		if (txState.toCoin?.coin.value === Coin.btc.value) {
+		if (txState.to?.coin.value === Coin.btc.value) {
 			const addr = txState.toUsername?.trim() ?? '';
 			const net = isVscTestnet() ? BtcNetwork.testnet : BtcNetwork.mainnet;
 			if (!validateBtcAddr(addr, net)) {
@@ -887,7 +872,7 @@
 			return false;
 		}
 
-		const fromCoinDef = txState.fromCoin.coin;
+		const fromCoinDef = txState.from.coin;
 		const provider = auth.value.provider;
 		const did = auth.value.did ?? '';
 		const isHiveAsset =
@@ -921,7 +906,7 @@
 		if (
 			auth.value?.provider === 'reown' &&
 			auth.value.did?.startsWith('did:pkh:bip122:') &&
-			txState.fromCoin?.coin.value === Coin.btc.value
+			txState.from?.coin.value === Coin.btc.value
 		) {
 			btcDepositAddress = null;
 			btcDepositError = null;
@@ -934,7 +919,7 @@
 					: rawReceiver.startsWith('@')
 						? `hive:${rawReceiver.slice(1)}`
 						: `hive:${rawReceiver}`;
-				const toAsset = txState.toCoin!.coin.value;
+				const toAsset = txState.to!.coin.value;
 				// Map the target coin to the chain the DEX router should
 				// settle on. Without this the swapped funds stay in Magi
 				// instead of being withdrawn to the user's mainnet wallet.
@@ -1010,10 +995,10 @@
 	}
 
 	async function confirmSwap() {
-		if (!auth.value || !txState.fromCoin || !txState.toCoin) return;
+		if (!auth.value || !txState.from || !txState.to) return;
 
-		const fromCoinDef = txState.fromCoin.coin;
-		const toCoinDef = txState.toCoin.coin;
+		const fromCoinDef = txState.from.coin;
+		const toCoinDef = txState.to.coin;
 		const amount = new CoinAmount(txState.fromAmount, fromCoinDef);
 		const caller = auth.value.did;
 
@@ -1211,9 +1196,9 @@
 					openDialog('from');
 				}}
 			>
-				{#if txState.fromCoin}
-					<img src={txState.fromCoin.coin.icon} alt="" class="token-img" />
-					<span class="token-name">{txState.fromCoin.coin.label}</span>
+				{#if txState.from}
+					<img src={txState.from.coin.icon} alt="" class="token-img" />
+					<span class="token-name">{txState.from.coin.label}</span>
 				{:else}
 					<span class="token-name muted">Select token</span>
 				{/if}
@@ -1235,7 +1220,7 @@
 			<div class="balance-row">
 				<span class="balance-label"
 					>Balance: {maxAmount.toPrettyAmountString()}
-					{txState.fromCoin?.coin.label ?? ''}</span
+					{txState.from?.coin.label ?? ''}</span
 				>
 				<button type="button" class="max-btn" onclick={() => (inputAmount = maxAmount!)}>
 					Max
@@ -1267,9 +1252,9 @@
 			<span class="field-label">To:</span>
 			<span class="network-tag">mainnet</span>
 			<button type="button" class="token-select" onclick={() => openDialog('to')}>
-				{#if txState.toCoin}
-					<img src={txState.toCoin.coin.icon} alt="" class="token-img" />
-					<span class="token-name">{txState.toCoin.coin.label}</span>
+				{#if txState.to}
+					<img src={txState.to.coin.icon} alt="" class="token-img" />
+					<span class="token-name">{txState.to.coin.label}</span>
 				{:else}
 					<span class="token-name muted">Select token</span>
 				{/if}
@@ -1370,12 +1355,12 @@
 	<!-- Variable content: grows to fill space, content anchored to bottom so button never moves -->
 	<div class="swap-middle">
 	<!-- Swap Details -->
-	{#if txState.fromCoin && txState.toCoin}
+	{#if txState.from && txState.to}
 		<div class="swap-details">
 			<div class="detail-row">
 				<span class="detail-label">Rate</span>
 				<span class="detail-value"
-					>{fromInTo ? `1 ${txState.fromCoin.coin.label} ≈ ${fromInTo}` : '—'}</span
+					>{fromInTo ? `1 ${txState.from.coin.label} ≈ ${fromInTo}` : '—'}</span
 				>
 			</div>
 			<div class="detail-row">
@@ -1408,20 +1393,20 @@
 			<div class="detail-row">
 				<span class="detail-label">Route</span>
 				<span class="detail-value route">
-					{txState.fromCoin.coin.label}
+					{txState.from.coin.label}
 					→
-					{#if txState.fromCoin.coin.value !== 'hbd' && txState.toCoin.coin.value !== 'hbd'}
+					{#if txState.from.coin.value !== 'hbd' && txState.to.coin.value !== 'hbd'}
 						HBD →
 					{/if}
-					{txState.toCoin.coin.label}
+					{txState.to.coin.label}
 				</span>
 			</div>
 			<div class="detail-row">
 				<span class="detail-label">Min amount received</span>
 				<span class="detail-value">
-					{#if swapResult && swapResult.minAmountOut > 0n && txState.toCoin}
-						{formatFee(swapResult.minAmountOut, txState.toCoin.coin.decimalPlaces)}
-						{txState.toCoin.coin.unit}
+					{#if swapResult && swapResult.minAmountOut > 0n && txState.to}
+						{formatFee(swapResult.minAmountOut, txState.to.coin.decimalPlaces)}
+						{txState.to.coin.unit}
 					{:else}
 						—
 					{/if}
@@ -1497,7 +1482,7 @@
 		<div class="btc-deposit">
 			<p class="btc-deposit-intro">
 				Send exactly the amount below to the address shown. The mapping bot observes the transaction
-				and forwards the swap to <strong>{txState.toUsername ?? ''}</strong> as {txState.toCoin
+				and forwards the swap to <strong>{txState.toUsername ?? ''}</strong> as {txState.to
 					?.coin.label ?? ''} on Magi.
 			</p>
 
@@ -1559,8 +1544,8 @@
 				{#each getFilteredTokens(currentlyOpen === 'from' ? fromAssetObjs : toAssetObjs) as token (token.value)}
 					{@const walletBlocked =
 						currentlyOpen === 'from' && !isFromTokenAllowed(token.value)}
-					{@const isFrom = token.value === txState.fromCoin?.coin.value}
-					{@const isTo = token.value === txState.toCoin?.coin.value}
+					{@const isFrom = token.value === txState.from?.coin.value}
+					{@const isTo = token.value === txState.to?.coin.value}
 					{@const isSelected = isFrom || isTo}
 					<button
 						class={['token-chip', { disabled: walletBlocked, muted: isSelected && !walletBlocked }]}

--- a/src/lib/cards/QuickSwap.svelte
+++ b/src/lib/cards/QuickSwap.svelte
@@ -112,7 +112,10 @@
 		const fromNet = fromOpt ? nativeNetworkFor(fromOpt.coin.value) : undefined;
 		const toNet = toOpt ? nativeNetworkFor(toOpt.coin.value) : undefined;
 
-		txState.rail = Network.lightning;
+		// Reown swap rails through Lightning even though neither from (e.g.
+		// BTC mainnet) nor to (e.g. HIVE mainnet) is the Lightning network.
+		// getIntermediaryNetwork(from, to) would pick magi — override here.
+		txState.railOverride = Network.lightning;
 		txState.from = fromOpt && fromNet ? { coin: fromOpt.coin, network: fromNet } : undefined;
 		txState.to = toOpt && toNet ? { coin: toOpt.coin, network: toNet } : undefined;
 	}

--- a/src/lib/currency/CoinAmount.test.ts
+++ b/src/lib/currency/CoinAmount.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for isValidAmountString.
+ *
+ * Tiny helper but used in tx-completion gates (e.g. KeepsatsWithdraw): a wrong
+ * result either blocks valid transactions or lets through ones with NaN /
+ * negative / zero amounts. Pin the behavior so future "clever" rewrites can't
+ * silently regress.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isValidAmountString } from './CoinAmount';
+
+describe('isValidAmountString', () => {
+	it('rejects empty / nullish input', () => {
+		expect(isValidAmountString('')).toBe(false);
+		expect(isValidAmountString(undefined)).toBe(false);
+		expect(isValidAmountString(null)).toBe(false);
+	});
+
+	it("rejects the string '0' (the txState fromAmount default)", () => {
+		expect(isValidAmountString('0')).toBe(false);
+	});
+
+	it('rejects negative amounts', () => {
+		expect(isValidAmountString('-1')).toBe(false);
+		expect(isValidAmountString('-0.5')).toBe(false);
+	});
+
+	it('rejects non-numeric strings', () => {
+		expect(isValidAmountString('abc')).toBe(false);
+		expect(isValidAmountString('NaN')).toBe(false);
+		expect(isValidAmountString('1.2.3')).toBe(false);
+	});
+
+	it('rejects Infinity', () => {
+		expect(isValidAmountString('Infinity')).toBe(false);
+		expect(isValidAmountString('-Infinity')).toBe(false);
+	});
+
+	it('accepts a small positive amount', () => {
+		expect(isValidAmountString('0.0001')).toBe(true);
+	});
+
+	it('accepts plain positive integers and decimals', () => {
+		expect(isValidAmountString('1')).toBe(true);
+		expect(isValidAmountString('1.23')).toBe(true);
+		expect(isValidAmountString('1000000')).toBe(true);
+	});
+
+	it('accepts strings with surrounding whitespace (Number() trims)', () => {
+		// Pin the implementation choice: Number(' 1 ') === 1. If we ever want to
+		// reject whitespace explicitly, this test will catch the change.
+		expect(isValidAmountString(' 1 ')).toBe(true);
+	});
+
+	it("accepts scientific notation (Number('1e-3') is finite)", () => {
+		expect(isValidAmountString('1e-3')).toBe(true);
+	});
+});

--- a/src/lib/currency/CoinAmount.ts
+++ b/src/lib/currency/CoinAmount.ts
@@ -3,6 +3,23 @@ import { Coin, type IntermediaryNetwork } from '$lib/sendswap/utils/sendOptions'
 import { getExchangeRates } from './convert';
 import { getHiveAssetName, getHbdAssetName } from '../../client';
 export type UnkCoinAmount = CoinAmount<Coin>;
+
+/**
+ * Canonical "the user has entered a usable amount" check for raw amount
+ * strings (the kind bound to AmountInput / stored in txState.fromAmount,
+ * txState.toAmount, etc.). True iff `s` parses to a finite number > 0.
+ *
+ * Replaces ad-hoc `Number(amount) > 0`, `Number(amount) == 0`,
+ * `parseFloat(amount)` and `!!amount && amount !== '0'` patterns scattered
+ * across the send/swap/withdraw flows — those are equivalent only by accident
+ * and all reject NaN/negatives less consistently than this does.
+ */
+export function isValidAmountString(s: string | undefined | null): boolean {
+	if (!s) return false;
+	const n = Number(s);
+	return Number.isFinite(n) && n > 0;
+}
+
 export class CoinAmount<C extends Coin> {
 	coin: C;
 	amount: number;

--- a/src/lib/sendswap/Deposit.svelte
+++ b/src/lib/sendswap/Deposit.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Dialog from '$lib/zag/Dialog.svelte';
 	import DepositOptions from './stages/deposit/DepositOptions.svelte';
-	import { Coin, Network } from './utils/sendOptions';
+	import { Coin } from './utils/sendOptions';
 	import { CoinAmount } from '$lib/currency/CoinAmount';
 	import { DepositTxState, provideTxState } from './utils/txState.svelte';
 	import Complete from './stages/Complete.svelte';
@@ -30,11 +30,12 @@
 	provideTxState(txState);
 
 	function applyDepositDetails() {
-		txState.toNetwork = Network.magi;
+		// `toNetwork = Network.magi` previously lived here but was a no-op when
+		// no `toCoin` was selected yet; DepositOptions sets the full to-side
+		// (coin + network) on user pick, so the hint isn't needed.
 		txState.toUsername = getUsernameFromAuth(auth) ?? '';
-		txState.fromCoin = undefined;
-		txState.fromNetwork = undefined;
-		txState.toCoin = undefined;
+		txState.from = undefined;
+		txState.to = undefined;
 		txState.fromAmount = '0';
 		txState.toAmount = '0';
 		txState.fee = undefined;

--- a/src/lib/sendswap/QuickSend.svelte
+++ b/src/lib/sendswap/QuickSend.svelte
@@ -31,7 +31,7 @@
 		const coinOpt = getFromOption(balOpt?.coin.value);
 		txState.from = coinOpt ? { coin: coinOpt.coin, network: Network.magi } : undefined;
 		txState.to = coinOpt ? { coin: coinOpt.coin, network: Network.magi } : undefined;
-		txState.rail = Network.magi;
+		// rail derives to magi from { magi → magi } — no explicit set needed
 		txState.toUsername = '';
 		txState.toDisplayName = '';
 		txState.memo = '';

--- a/src/lib/sendswap/QuickSend.svelte
+++ b/src/lib/sendswap/QuickSend.svelte
@@ -29,10 +29,8 @@
 			}))
 		);
 		const coinOpt = getFromOption(balOpt?.coin.value);
-		txState.fromCoin = coinOpt;
-		txState.fromNetwork = Network.magi;
-		txState.toCoin = coinOpt;
-		txState.toNetwork = Network.magi;
+		txState.from = coinOpt ? { coin: coinOpt.coin, network: Network.magi } : undefined;
+		txState.to = coinOpt ? { coin: coinOpt.coin, network: Network.magi } : undefined;
 		txState.rail = Network.magi;
 		txState.toUsername = '';
 		txState.toDisplayName = '';

--- a/src/lib/sendswap/SendSwap.svelte
+++ b/src/lib/sendswap/SendSwap.svelte
@@ -41,20 +41,16 @@
 				getToOption(Coin.hive.value);
 			const fromNet = findNetwork(stored?.fromNetwork) ?? Network.magi;
 			const toNet = findNetwork(stored?.toNetwork) ?? Network.magi;
-			txState.toNetwork = toNet;
 			txState.rail = Network.lightning;
-			txState.fromCoin = fromOpt;
-			txState.fromNetwork = fromNet;
-			txState.toCoin = toOpt;
+			txState.from = fromOpt ? { coin: fromOpt.coin, network: fromNet } : undefined;
+			txState.to = toOpt ? { coin: toOpt.coin, network: toNet } : undefined;
 		} else {
 			const balOpt = scanForBalance(
 				[Coin.hive, Coin.hbd, Coin.shbd].map((c) => ({ coin: c, network: Network.magi }))
 			);
 			const coinOpt = getFromOption(balOpt?.coin.value);
-			txState.toNetwork = Network.magi;
-			txState.fromNetwork = Network.magi;
-			txState.fromCoin = coinOpt;
-			txState.toCoin = coinOpt;
+			txState.from = coinOpt ? { coin: coinOpt.coin, network: Network.magi } : undefined;
+			txState.to = coinOpt ? { coin: coinOpt.coin, network: Network.magi } : undefined;
 		}
 	}
 

--- a/src/lib/sendswap/SendSwap.svelte
+++ b/src/lib/sendswap/SendSwap.svelte
@@ -70,10 +70,10 @@
 	// stays independent.
 	$effect(() => {
 		if (txType !== 'swap') return;
-		const fromCoin = txState.fromCoin?.coin.value;
-		const fromNetwork = txState.fromNetwork?.value;
-		const toCoin = txState.toCoin?.coin.value;
-		const toNetwork = txState.toNetwork?.value;
+		const fromCoin = txState.from?.coin.value;
+		const fromNetwork = txState.from?.network.value;
+		const toCoin = txState.to?.coin.value;
+		const toNetwork = txState.to?.network.value;
 		// Only save once both sides are populated; partial state isn't useful.
 		if (fromCoin && toCoin) {
 			saveSwapSelection(SWAP_PAGE_PREF_KEY, { fromCoin, fromNetwork, toCoin, toNetwork });

--- a/src/lib/sendswap/SendSwap.svelte
+++ b/src/lib/sendswap/SendSwap.svelte
@@ -41,7 +41,10 @@
 				getToOption(Coin.hive.value);
 			const fromNet = findNetwork(stored?.fromNetwork) ?? Network.magi;
 			const toNet = findNetwork(stored?.toNetwork) ?? Network.magi;
-			txState.rail = Network.lightning;
+			// /swap page bridges external assets via Lightning even when
+			// neither from nor to is on the Lightning network — override the
+			// from/to-based derivation. See QuickSwap for the parallel case.
+			txState.railOverride = Network.lightning;
 			txState.from = fromOpt ? { coin: fromOpt.coin, network: fromNet } : undefined;
 			txState.to = toOpt ? { coin: toOpt.coin, network: toNet } : undefined;
 		} else {

--- a/src/lib/sendswap/StepsMachine.svelte
+++ b/src/lib/sendswap/StepsMachine.svelte
@@ -11,7 +11,7 @@
 	import { sleep } from 'aninest';
 	import NavButtons from '$lib/sendswap/components/NavButtons.svelte';
 	import { goto } from '$app/navigation';
-	import { getIntermediaryNetwork } from '$lib/sendswap/utils/getNetwork';
+	import { decideBroadcast, type TxType } from '$lib/sendswap/utils/broadcastDecision';
 	import { untrack, type Component, type ComponentProps } from 'svelte';
 	import { getDidFromUsername } from '$lib/getAccountName';
 	import { getSendOpType } from '$lib/magiTransactions/hive';
@@ -173,29 +173,13 @@
 	// START TRANSACTION
 	function initSend() {
 		if (!txState) return new Error('initSend() called without a TxState provider');
-		// For deposit/withdraw: when the user hasn't picked a destination, default
-		// `to` to the same coin as `from` on the txType's canonical network.
-		if (!txState.to && txState.from) {
-			const defaultToNetwork =
-				txType === 'deposit'
-					? Network.magi
-					: txType === 'withdraw'
-						? Network.hiveMainnet
-						: undefined;
-			if (defaultToNetwork) {
-				txState.to = { coin: txState.from.coin, network: defaultToNetwork };
-			}
-		}
-
-		if (!txState.from || !txState.to) {
-			return new Error('Required field undefined.');
-		}
-
-		let intermediary = getIntermediaryNetwork(txState.from, txState.to);
-
-		// console.log('found intermediary network:', intermediary.label);
-
-		if (intermediary === Network.lightning && txType !== 'withdraw') {
+		// `txType` is `string` because pool dialogs / QuickSend pass display
+		// labels ('add liquidity', 'send'). initSend() only fires when no
+		// `onSubmit` override is provided — those code paths reach here with
+		// txType ∈ {swap, transfer, deposit, withdraw}. Cast at the boundary.
+		const decision = decideBroadcast(txState, txType as TxType);
+		if (decision.action === 'error') return new Error(decision.message);
+		if (decision.action === 'v4v') {
 			setStatus('Generating Lightning transfer');
 			openV4V();
 			return;
@@ -203,7 +187,7 @@
 
 		waiting = true;
 		// console.log('waiting for signature');
-		send(txState, auth, intermediary, setStatus, abortSend.signal).then((res) => {
+		send(txState, auth, decision.intermediary, setStatus, abortSend.signal).then((res) => {
 			if (res instanceof Error) {
 				// log the error if it isn't caught
 				console.error(res.message);
@@ -306,8 +290,8 @@
 				ops: [
 					{
 						data: {
-							amount: new CoinAmount(toAmount, toCoin!.coin).toAmountString(),
-							asset: toCoin.coin.unit.toLowerCase(),
+							amount: new CoinAmount(toAmount, to.coin).toAmountString(),
+							asset: to.coin.unit.toLowerCase(),
 							from: `v4vapp`,
 							to: txState.toUsername,
 							memo: `altera_id=${id}`,

--- a/src/lib/sendswap/StepsMachine.svelte
+++ b/src/lib/sendswap/StepsMachine.svelte
@@ -173,25 +173,25 @@
 	// START TRANSACTION
 	function initSend() {
 		if (!txState) return new Error('initSend() called without a TxState provider');
-		// For deposit/withdraw: toCoin mirrors fromCoin; toNetwork defaults based on txType.
-		// Write resolved values back so send() can read them directly from txState.
-		txState.toCoin = txState.toCoin ?? txState.fromCoin;
-		txState.toNetwork =
-			txState.toNetwork ??
-			(txType === 'deposit'
-				? Network.magi
-				: txType === 'withdraw'
-					? Network.hiveMainnet
-					: undefined);
+		// For deposit/withdraw: when the user hasn't picked a destination, default
+		// `to` to the same coin as `from` on the txType's canonical network.
+		if (!txState.to && txState.from) {
+			const defaultToNetwork =
+				txType === 'deposit'
+					? Network.magi
+					: txType === 'withdraw'
+						? Network.hiveMainnet
+						: undefined;
+			if (defaultToNetwork) {
+				txState.to = { coin: txState.from.coin, network: defaultToNetwork };
+			}
+		}
 
-		if (!txState.fromCoin || !txState.fromNetwork || !txState.toCoin || !txState.toNetwork) {
+		if (!txState.from || !txState.to) {
 			return new Error('Required field undefined.');
 		}
 
-		let intermediary = getIntermediaryNetwork(
-			{ coin: txState.fromCoin.coin, network: txState.fromNetwork },
-			{ coin: txState.toCoin.coin, network: txState.toNetwork }
-		);
+		let intermediary = getIntermediaryNetwork(txState.from, txState.to);
 
 		// console.log('found intermediary network:', intermediary.label);
 
@@ -280,14 +280,13 @@
 	</div>
 {/key}
 
-{#if showV4VModal && txState.toCoin && txState.toNetwork && txState.fromAmount}
-	{@const toCoin = txState.toCoin}
-	{@const toNetwork = txState.toNetwork}
+{#if showV4VModal && txState.to && txState.fromAmount}
+	{@const to = txState.to}
 	{@const toAmount = txState.toAmount}
 
 	<V4VPopup
 		from={{ coin: Coin.sats, network: Network.lightning }}
-		to={{ coin: toCoin.coin, network: toNetwork }}
+		{to}
 		{toAmount}
 		{auth}
 		toUsername={txState.toUsername}

--- a/src/lib/sendswap/Withdraw.svelte
+++ b/src/lib/sendswap/Withdraw.svelte
@@ -20,10 +20,8 @@
 
 	function applyWithdrawDetails() {
 		txState.toUsername = '';
-		txState.fromCoin = undefined;
-		txState.fromNetwork = undefined;
-		txState.toCoin = undefined;
-		txState.toNetwork = undefined;
+		txState.from = undefined;
+		txState.to = undefined;
 		txState.fromAmount = '0';
 		txState.toAmount = '0';
 		txState.fee = undefined;

--- a/src/lib/sendswap/components/Instructions.svelte
+++ b/src/lib/sendswap/components/Instructions.svelte
@@ -10,7 +10,7 @@
 	const txState = useTxState();
 
 	let toAccount = $derived(
-		txState.toNetwork?.value === Network.magi.value
+		txState.to?.network.value === Network.magi.value
 			? vscGateway
 			: txState.toUsername
 	);
@@ -20,9 +20,9 @@
 	<div class="blurb">
 		<span><Info /></span>
 		<p>
-			Transfer {txState.toCoin?.coin.label} to the following Hive account with your favorite wallet
+			Transfer {txState.to?.coin.label} to the following Hive account with your favorite wallet
 			or exchange.
-			{#if txState.toNetwork?.value === Network.magi.value}
+			{#if txState.to?.network.value === Network.magi.value}
 				The account {vscGateway} is a dedicated Hive account controlled by the decentralized VSC
 				consensus. Your funds remain within your wallet on VSC at all times. Please make sure to
 				specify the correct memo when sending Hive or HBD.
@@ -44,7 +44,7 @@
 				<td class="sm-caption label">Amount</td>
 				<td class="content"
 					><BasicCopy value={txState.toAmount}>
-						<code>{txState.toAmount}</code> {txState.fromCoin?.coin.label}</BasicCopy
+						<code>{txState.toAmount}</code> {txState.from?.coin.label}</BasicCopy
 					></td
 				>
 			</tr>

--- a/src/lib/sendswap/components/assetSelection/SelectAssetFlattened.svelte
+++ b/src/lib/sendswap/components/assetSelection/SelectAssetFlattened.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { getFromOption, Coin, Network, type AssetOption } from '$lib/sendswap/utils/sendOptions';
+	import { getFromOption, Coin, Network, type CoinOnNetwork } from '$lib/sendswap/utils/sendOptions';
 	import { untrack, type Snippet } from 'svelte';
 	import AssetList from './AssetList.svelte';
 	import { accountBalance, type AccountBalance } from '$lib/stores/currentBalance';
@@ -21,23 +21,19 @@
 
 	let {
 		availableCoins,
-		coin = $bindable(),
-		network = $bindable(),
+		selected = $bindable(),
 		max = $bindable(),
 		close,
 		externalNetwork,
 		isTo = false,
-		onSelect,
 		dialogTitle = 'Select an Asset'
 	}: {
 		availableCoins: Coin[];
-		coin: AssetOption | undefined;
-		network: Network | undefined;
+		selected: CoinOnNetwork | undefined;
 		max?: CoinAmount<Coin> | undefined;
 		close: () => void;
 		externalNetwork?: Network;
 		isTo?: boolean;
-		onSelect?: (coin: AssetOption, network: Network) => void;
 		dialogTitle?: string;
 	} = $props();
 
@@ -138,19 +134,6 @@
 	// REMOVE -1 FOR BITCOIN LAUNCH
 	let maxItems = $derived(onMagi.length - 1 + externalTotalLength);
 
-	let tmpAsset: AssetOption | undefined = $state();
-
-	let tmpNetwork: Network | undefined = $state();
-	let tmpNetworkVal: string | undefined = $state();
-	$effect(() => {
-		const newFromNetwork = network;
-		untrack(() => {
-			if (newFromNetwork === undefined && tmpNetworkVal) {
-				tmpNetworkVal = undefined;
-			}
-		});
-	});
-
 	// $inspect('vscitems', magiItems);
 	// $inspect('externalitems', externalItems);
 
@@ -158,17 +141,14 @@
 		const assetVal = balanceVal.split(':')[0];
 		const networkVal = balanceVal.split(':')[1];
 		const balanceObj = [...magiItems, ...externalItems].find((item) => item.value === balanceVal);
-		tmpAsset = getFromOption(assetVal);
-		tmpNetwork =
+		const nextAsset = getFromOption(assetVal);
+		const nextNetwork =
 			[Network.magi, externalNetwork].find((net) => net?.value === networkVal) ?? Network.magi;
-		if (!tmpAsset) {
-			coin = undefined;
-			network = undefined;
+		if (!nextAsset) {
+			selected = undefined;
 			max = undefined;
 		} else {
-			network = tmpNetwork;
-			coin = tmpAsset;
-			onSelect?.(tmpAsset, tmpNetwork);
+			selected = { coin: nextAsset.coin, network: nextNetwork };
 			if (balanceObj && 'balance' in balanceObj) {
 				const coinObj: Coin = { ...balanceObj, value: assetVal };
 				max = new CoinAmount(balanceObj.balance, coinObj);
@@ -181,13 +161,10 @@
 	$effect(() => {
 		if (
 			availableCoins.length > 0 &&
-			coin &&
-			!availableCoins.map((coin) => coin.value).includes(coin?.coin.value)
+			selected &&
+			!availableCoins.map((c) => c.value).includes(selected.coin.value)
 		) {
-			coin = undefined;
-			if (network) {
-				network = undefined;
-			}
+			selected = undefined;
 		}
 	});
 </script>
@@ -214,7 +191,7 @@
 		<div class="listbox-wrapper">
 			<AssetList
 				items={[...magiItems, ...externalItems]}
-				value={`${coin?.coin.value}:${network?.value}`}
+				value={`${selected?.coin.value}:${selected?.network.value}`}
 				clickAsset={handleAssetClick}
 				type="balance"
 			/>

--- a/src/lib/sendswap/components/assetSelection/SelectAssetFlattened.svelte.test.ts
+++ b/src/lib/sendswap/components/assetSelection/SelectAssetFlattened.svelte.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tier-B component test pilot for SelectAssetFlattened.
+ *
+ * Mounts the component (via a thin wrapper that exposes its $bindable props),
+ * stubs the auth + balance stores, and exercises the user-driven flows:
+ *   - items render with the right balance text
+ *   - clicking an item writes `selected` and invokes `close`
+ *   - the "Show Empty Accounts" pill toggles state correctly
+ *   - clicking SATS in isTo mode silently clears `selected` (pre-existing
+ *     edge — pinned here so the future fix has an obvious failing test)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, screen } from '@testing-library/svelte';
+import { accountBalance, getDefaultBalance } from '$lib/stores/currentBalance';
+import { Coin, Network } from '$lib/sendswap/utils/sendOptions';
+
+// `getAuth()` reads from Svelte context (`getContext('auth')`) which a parent
+// layout normally sets up. Mock the module so the component sees a hive user
+// without us threading setContext through the test wrapper.
+let mockAuthValue: { provider?: string; username?: string; did?: string; address?: string } | undefined = {
+	provider: 'aioha',
+	username: 'alice',
+	did: 'hive:alice',
+	address: 'alice'
+};
+vi.mock('$lib/auth/store', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('$lib/auth/store')>();
+	return {
+		...actual,
+		getAuth: () => () => ({
+			status: mockAuthValue ? 'authenticated' : 'none',
+			value: mockAuthValue
+		})
+	};
+});
+
+// Import after the mock so the wrapper picks up the mocked store.
+const { default: SelectAssetFlattenedTestWrapper } = await import('./SelectAssetFlattenedTestWrapper.svelte');
+
+function seedHiveAuth(username = 'alice') {
+	mockAuthValue = { provider: 'aioha', username, did: `hive:${username}`, address: username };
+}
+
+function seedBalance(opts: { hive?: number; hbd?: number; btc?: number } = {}) {
+	accountBalance.set({
+		bal: { ...getDefaultBalance(), hive: opts.hive ?? 0, hbd: opts.hbd ?? 0, btc: opts.btc ?? 0 },
+		connectedBal: undefined,
+		loading: false
+	});
+}
+
+describe('SelectAssetFlattened — component (Tier B pilot)', () => {
+	beforeEach(() => {
+		mockAuthValue = undefined;
+		accountBalance.set({ bal: getDefaultBalance(), connectedBal: undefined, loading: false });
+	});
+
+	it('renders the dialog title', () => {
+		seedHiveAuth();
+		seedBalance({ hive: 1000 });
+		render(SelectAssetFlattenedTestWrapper, {
+			availableCoins: [Coin.hive],
+			selected: undefined,
+			close: vi.fn(),
+			dialogTitle: 'Pick one'
+		});
+		expect(screen.getByText('Pick one')).toBeInTheDocument();
+	});
+
+	it('renders HIVE as a clickable item when the user has a HIVE balance', () => {
+		seedHiveAuth();
+		seedBalance({ hive: 1000 });
+		render(SelectAssetFlattenedTestWrapper, {
+			availableCoins: [Coin.hive, Coin.hbd],
+			selected: undefined,
+			close: vi.fn()
+		});
+		// The AssetList renders the option labels — HIVE should appear, HBD should
+		// not (no balance, and isTo=false so empty accounts are hidden by default).
+		const items = screen.getAllByRole('option');
+		expect(items.some((el) => el.textContent?.toLowerCase().includes('hive'))).toBe(true);
+		expect(items.some((el) => el.textContent?.toLowerCase().includes('hbd'))).toBe(false);
+	});
+
+	it('shows empty accounts when isTo=true (destinations include zero-balance coins)', () => {
+		seedHiveAuth();
+		seedBalance({ hive: 0, hbd: 0 });
+		render(SelectAssetFlattenedTestWrapper, {
+			availableCoins: [Coin.hive, Coin.hbd],
+			selected: undefined,
+			close: vi.fn(),
+			isTo: true
+		});
+		const items = screen.getAllByRole('option');
+		expect(items.length).toBeGreaterThanOrEqual(2);
+	});
+
+	// Skipped: the pill-render condition depends on a "REMOVE -1 FOR BITCOIN
+	// LAUNCH" magic number in the component (`maxItems = onMagi.length - 1 + ...`)
+	// that makes it hard to construct a stable balance setup. The behavior
+	// itself is straightforward (toggle a `$state`) and not central to the
+	// migration; revisit when the -1 hack is removed.
+	it.skip('"Show Empty Accounts" pill toggles its label after click', async () => {
+		seedHiveAuth();
+		seedBalance({ hive: 1000, hbd: 0, btc: 0 });
+		render(SelectAssetFlattenedTestWrapper, {
+			availableCoins: [Coin.hive, Coin.hbd, Coin.btc],
+			selected: undefined,
+			close: vi.fn()
+		});
+		const pill = screen.getByText(/Show Empty Accounts/i).closest('button')!;
+		await fireEvent.click(pill);
+		expect(screen.getByText(/Hide Empty Accounts/i)).toBeInTheDocument();
+	});
+
+	// Skipped: hits Zag.js listbox-machine timing flakiness in jsdom. The
+	// identical render setup works in the "renders HIVE" test earlier in this
+	// file but reliably returns 0 options on this iteration — likely an
+	// initialization-order quirk between Zag's async state machine and
+	// testing-library's auto-cleanup. Documented as part of the Tier B pilot
+	// findings: full-flow component tests are doable but Zag.js components
+	// require ~1 hour of extra setup per test surface.
+	it.skip('clicking a HIVE item invokes close() (write semantics covered by Tier A)', async () => {
+		seedHiveAuth();
+		seedBalance({ hive: 1000, hbd: 0 });
+		const close = vi.fn();
+		render(SelectAssetFlattenedTestWrapper, {
+			availableCoins: [Coin.hive, Coin.hbd],
+			selected: undefined,
+			close
+		});
+		const items = screen.getAllByRole('option');
+		const hiveItem = items.find((el) => el.textContent?.toLowerCase().includes('hive'))!;
+		await fireEvent.click(hiveItem);
+		expect(close).toHaveBeenCalled();
+	});
+
+	it('pre-existing edge: clicking SATS in isTo mode invokes close (and silently clears selected)', async () => {
+		// getFromOption('sats') returns undefined → the component clears `selected`
+		// rather than synthesizing a SATS CoinOnNetwork. This is the pre-existing
+		// bug flagged during the SelectAssetFlattened refactor. Pinning the
+		// current behavior so the future fix has a contract test to invert.
+		seedHiveAuth();
+		seedBalance({ hive: 0 });
+		const close = vi.fn();
+		render(SelectAssetFlattenedTestWrapper, {
+			availableCoins: [Coin.sats],
+			selected: { coin: Coin.btc, network: Network.lightning },
+			close,
+			isTo: true
+		});
+		const items = screen.getAllByRole('option');
+		const satsItem = items.find((el) => el.textContent?.toLowerCase().includes('sats'));
+		if (satsItem) {
+			await fireEvent.click(satsItem);
+			expect(close).toHaveBeenCalled();
+		}
+	});
+});

--- a/src/lib/sendswap/components/assetSelection/SelectAssetFlattenedTestWrapper.svelte
+++ b/src/lib/sendswap/components/assetSelection/SelectAssetFlattenedTestWrapper.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	/**
+	 * Test wrapper for SelectAssetFlattened — required because @testing-library/svelte
+	 * doesn't let tests directly bind: to a Svelte 5 $bindable prop. The wrapper
+	 * forwards `selected` and `max` as bindable so the test scope can observe writes.
+	 */
+	import SelectAssetFlattened from './SelectAssetFlattened.svelte';
+	import type { CoinOnNetwork, Network, Coin } from '$lib/sendswap/utils/sendOptions';
+	import type { CoinAmount } from '$lib/currency/CoinAmount';
+
+	let {
+		availableCoins,
+		selected = $bindable(),
+		max = $bindable(),
+		close,
+		externalNetwork,
+		isTo = false,
+		dialogTitle
+	}: {
+		availableCoins: Coin[];
+		selected: CoinOnNetwork | undefined;
+		max?: CoinAmount<Coin> | undefined;
+		close: () => void;
+		externalNetwork?: Network;
+		isTo?: boolean;
+		dialogTitle?: string;
+	} = $props();
+</script>
+
+<SelectAssetFlattened
+	{availableCoins}
+	bind:selected
+	bind:max
+	{close}
+	{externalNetwork}
+	{isTo}
+	{dialogTitle}
+/>

--- a/src/lib/sendswap/flows/btcMainnetWithdraw.flow.test.ts
+++ b/src/lib/sendswap/flows/btcMainnetWithdraw.flow.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tier-A integration test for the BTC Mainnet withdraw flow.
+ *
+ * Mirrors what `WithdrawOptions.svelte` writes to txState when the user picks
+ * "Bitcoin Mainnet", plus the BTC-specific fee fields (deductFee / maxFee) the
+ * picker exposes. Then asserts the derived rail and what `getFee` resolves to
+ * — i.e. exactly the values that flow into StepsMachine's broadcast call.
+ *
+ * Per docs.magi.eco, BTC mainnet swaps route through Magi (not Lightning), so
+ * rail must derive to `magi` and getFee must resolve via magi.feeCalculation
+ * (which returns 0).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { WithdrawTxState } from '../utils/txState.svelte';
+import { Coin, Network } from '../utils/sendOptions';
+import { getIntermediaryNetwork } from '../utils/getNetwork';
+import { getFee } from '../utils/sendUtils';
+import { isValidAmountString } from '../../currency/CoinAmount';
+
+/** Mirrors the effect in WithdrawOptions.svelte when `btcMainnetOpen` flips true. */
+function setupBtcMainnetWithdraw(state: WithdrawTxState) {
+	state.from = { coin: Coin.btc, network: Network.magi };
+	state.to = { coin: Coin.btc, network: Network.btcMainnet };
+}
+
+describe('BTC Mainnet withdraw — flow integration', () => {
+	it('parent sets from = btc/magi, to = btc/btcMainnet', () => {
+		const state = new WithdrawTxState();
+		setupBtcMainnetWithdraw(state);
+		expect(state.from).toEqual({ coin: Coin.btc, network: Network.magi });
+		expect(state.to).toEqual({ coin: Coin.btc, network: Network.btcMainnet });
+	});
+
+	it('rail derives to magi (BTC bridge via DEX, not Lightning)', () => {
+		const state = new WithdrawTxState();
+		setupBtcMainnetWithdraw(state);
+		expect(state.rail?.value).toBe(Network.magi.value);
+	});
+
+	it('derived rail matches direct getIntermediaryNetwork call', () => {
+		const state = new WithdrawTxState();
+		setupBtcMainnetWithdraw(state);
+		const direct = getIntermediaryNetwork(state.from!, state.to!);
+		expect(state.rail?.value).toBe(direct.value);
+	});
+
+	it('captures BTC-specific fee fields (deductFee, maxFee)', () => {
+		const state = new WithdrawTxState();
+		setupBtcMainnetWithdraw(state);
+		expect(state.deductFee).toBe(false);
+		expect(state.maxFee).toBeUndefined();
+
+		state.deductFee = true;
+		state.maxFee = 3000;
+		expect(state.deductFee).toBe(true);
+		expect(state.maxFee).toBe(3000);
+	});
+
+	it('amount validation: rejects 0, negatives, NaN; accepts a valid BTC amount', () => {
+		expect(isValidAmountString('0')).toBe(false);
+		expect(isValidAmountString('-0.001')).toBe(false);
+		expect(isValidAmountString('NaN')).toBe(false);
+		expect(isValidAmountString('0.0005')).toBe(true);
+	});
+
+	it('getFee resolves to 0 (magi DEX path, no Lightning gateway fee)', async () => {
+		const state = new WithdrawTxState();
+		setupBtcMainnetWithdraw(state);
+		state.toAmount = '0.0005';
+		const fee = await getFee(state.toAmount, state);
+		expect(fee?.amount).toBe(0);
+	});
+});

--- a/src/lib/sendswap/flows/hiveMainnetDeposit.flow.test.ts
+++ b/src/lib/sendswap/flows/hiveMainnetDeposit.flow.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tier-A integration test for the Hive Mainnet deposit flow.
+ *
+ * Mirrors what `DepositOptions.svelte` writes to txState when the user picks
+ * "Hive Mainnet": from = HIVE-or-HBD on hiveMainnet, to = same coin on magi.
+ *
+ * Per docs.magi.eco, Hive↔Magi bridges via the Magi gateway account, not
+ * Lightning — rail must derive to `magi`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DepositTxState } from '../utils/txState.svelte';
+import { Coin, Network } from '../utils/sendOptions';
+import { getIntermediaryNetwork } from '../utils/getNetwork';
+import { getFee } from '../utils/sendUtils';
+import { isValidAmountString } from '../../currency/CoinAmount';
+
+function setupHiveMainnetDeposit(state: DepositTxState, coin: typeof Coin.hive | typeof Coin.hbd) {
+	state.from = { coin, network: Network.hiveMainnet };
+	state.to = { coin, network: Network.magi };
+}
+
+describe('Hive Mainnet deposit — flow integration', () => {
+	it('HIVE: from = hive/hiveMainnet, to = hive/magi', () => {
+		const state = new DepositTxState();
+		setupHiveMainnetDeposit(state, Coin.hive);
+		expect(state.from).toEqual({ coin: Coin.hive, network: Network.hiveMainnet });
+		expect(state.to).toEqual({ coin: Coin.hive, network: Network.magi });
+	});
+
+	it('HBD: from = hbd/hiveMainnet, to = hbd/magi', () => {
+		const state = new DepositTxState();
+		setupHiveMainnetDeposit(state, Coin.hbd);
+		expect(state.from).toEqual({ coin: Coin.hbd, network: Network.hiveMainnet });
+		expect(state.to).toEqual({ coin: Coin.hbd, network: Network.magi });
+	});
+
+	it('rail derives to magi (Hive gateway path, not Lightning)', () => {
+		const state = new DepositTxState();
+		setupHiveMainnetDeposit(state, Coin.hive);
+		expect(state.rail?.value).toBe(Network.magi.value);
+	});
+
+	it('derived rail matches direct getIntermediaryNetwork call', () => {
+		const state = new DepositTxState();
+		setupHiveMainnetDeposit(state, Coin.hbd);
+		const direct = getIntermediaryNetwork(state.from!, state.to!);
+		expect(state.rail?.value).toBe(direct.value);
+	});
+
+	it('amount validation', () => {
+		expect(isValidAmountString('0')).toBe(false);
+		expect(isValidAmountString('1.000')).toBe(true);
+	});
+
+	it('getFee resolves to 0 (Hive gateway, no Lightning fee)', async () => {
+		const state = new DepositTxState();
+		setupHiveMainnetDeposit(state, Coin.hive);
+		state.toAmount = '1.000';
+		const fee = await getFee(state.toAmount, state);
+		expect(fee?.amount).toBe(0);
+	});
+});

--- a/src/lib/sendswap/flows/hiveMainnetWithdraw.flow.test.ts
+++ b/src/lib/sendswap/flows/hiveMainnetWithdraw.flow.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tier-A integration test for the Hive Mainnet withdraw flow.
+ *
+ * Mirrors what `WithdrawOptions.svelte` writes to txState when the user picks
+ * "Hive Mainnet": from = HIVE-or-HBD on magi, to = same coin on hiveMainnet.
+ * The mirror of the Hive Mainnet deposit flow.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { WithdrawTxState } from '../utils/txState.svelte';
+import { Coin, Network } from '../utils/sendOptions';
+import { getIntermediaryNetwork } from '../utils/getNetwork';
+import { getFee } from '../utils/sendUtils';
+
+function setupHiveMainnetWithdraw(state: WithdrawTxState, coin: typeof Coin.hive | typeof Coin.hbd) {
+	state.from = { coin, network: Network.magi };
+	state.to = { coin, network: Network.hiveMainnet };
+}
+
+describe('Hive Mainnet withdraw — flow integration', () => {
+	it('HIVE: from = hive/magi, to = hive/hiveMainnet', () => {
+		const state = new WithdrawTxState();
+		setupHiveMainnetWithdraw(state, Coin.hive);
+		expect(state.from).toEqual({ coin: Coin.hive, network: Network.magi });
+		expect(state.to).toEqual({ coin: Coin.hive, network: Network.hiveMainnet });
+	});
+
+	it('HBD: from = hbd/magi, to = hbd/hiveMainnet', () => {
+		const state = new WithdrawTxState();
+		setupHiveMainnetWithdraw(state, Coin.hbd);
+		expect(state.from).toEqual({ coin: Coin.hbd, network: Network.magi });
+		expect(state.to).toEqual({ coin: Coin.hbd, network: Network.hiveMainnet });
+	});
+
+	it('rail derives to magi (Hive gateway path)', () => {
+		const state = new WithdrawTxState();
+		setupHiveMainnetWithdraw(state, Coin.hive);
+		expect(state.rail?.value).toBe(Network.magi.value);
+	});
+
+	it('derived rail matches direct getIntermediaryNetwork call', () => {
+		const state = new WithdrawTxState();
+		setupHiveMainnetWithdraw(state, Coin.hbd);
+		const direct = getIntermediaryNetwork(state.from!, state.to!);
+		expect(state.rail?.value).toBe(direct.value);
+	});
+
+	it('BTC-mainnet fee fields stay at defaults (not used for Hive withdraw)', () => {
+		const state = new WithdrawTxState();
+		setupHiveMainnetWithdraw(state, Coin.hive);
+		expect(state.deductFee).toBe(false);
+		expect(state.maxFee).toBeUndefined();
+	});
+
+	it('getFee resolves to 0', async () => {
+		const state = new WithdrawTxState();
+		setupHiveMainnetWithdraw(state, Coin.hive);
+		state.toAmount = '1.000';
+		const fee = await getFee(state.toAmount, state);
+		expect(fee?.amount).toBe(0);
+	});
+});

--- a/src/lib/sendswap/flows/internalTransfer.flow.test.ts
+++ b/src/lib/sendswap/flows/internalTransfer.flow.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tier-A integration test for the internal transfer (QuickSend) flow.
+ *
+ * Internal transfers stay on Magi the whole way: from = X/magi, to = X/magi.
+ * Rail derives to magi naturally (both endpoints supported, neither lightning,
+ * not hiveMainnet-on-both).
+ *
+ * The QuickSend card-specific gate (recipient ≠ sender on the same network)
+ * is exercised by asserting the `toSelf` shape used in QuickSendOptions.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { TransferTxState } from '../utils/txState.svelte';
+import { Coin, Network } from '../utils/sendOptions';
+import { getIntermediaryNetwork } from '../utils/getNetwork';
+import { getFee } from '../utils/sendUtils';
+import { isValidAmountString } from '../../currency/CoinAmount';
+
+function setupInternalTransfer(state: TransferTxState, coin: typeof Coin.hive | typeof Coin.hbd | typeof Coin.shbd | typeof Coin.btc) {
+	state.from = { coin, network: Network.magi };
+	state.to = { coin, network: Network.magi };
+}
+
+describe('Internal transfer (QuickSend) — flow integration', () => {
+	it('HIVE → HIVE on magi', () => {
+		const state = new TransferTxState();
+		setupInternalTransfer(state, Coin.hive);
+		expect(state.from).toEqual({ coin: Coin.hive, network: Network.magi });
+		expect(state.to).toEqual({ coin: Coin.hive, network: Network.magi });
+	});
+
+	it('rail derives to magi (internal — both endpoints on magi)', () => {
+		const state = new TransferTxState();
+		setupInternalTransfer(state, Coin.hive);
+		expect(state.rail?.value).toBe(Network.magi.value);
+	});
+
+	it('derivation works for any magi-supported coin (HBD, sHBD, BTC)', () => {
+		for (const coin of [Coin.hbd, Coin.shbd, Coin.btc]) {
+			const state = new TransferTxState();
+			setupInternalTransfer(state, coin);
+			expect(state.rail?.value).toBe(Network.magi.value);
+			const direct = getIntermediaryNetwork(state.from!, state.to!);
+			expect(direct.value).toBe(Network.magi.value);
+		}
+	});
+
+	it('captures transfer-specific fields (memo, toDisplayName)', () => {
+		const state = new TransferTxState();
+		setupInternalTransfer(state, Coin.hive);
+		state.toUsername = 'alice';
+		state.toDisplayName = 'Alice';
+		state.memo = 'for lunch';
+		expect(state.toUsername).toBe('alice');
+		expect(state.toDisplayName).toBe('Alice');
+		expect(state.memo).toBe('for lunch');
+	});
+
+	it('to-self detection: same username + same network (the QuickSend gate)', () => {
+		const state = new TransferTxState();
+		setupInternalTransfer(state, Coin.hive);
+		state.toUsername = 'alice';
+		const isSelf =
+			state.toUsername === 'alice' && state.from?.network.value === state.to?.network.value;
+		expect(isSelf).toBe(true);
+	});
+
+	it('amount validation rejects 0', () => {
+		expect(isValidAmountString('0')).toBe(false);
+		expect(isValidAmountString('1.5')).toBe(true);
+	});
+
+	it('getFee resolves to 0 (no cross-chain bridge involved)', async () => {
+		const state = new TransferTxState();
+		setupInternalTransfer(state, Coin.hive);
+		state.toAmount = '1.5';
+		const fee = await getFee(state.toAmount, state);
+		expect(fee?.amount).toBe(0);
+	});
+});

--- a/src/lib/sendswap/flows/lightningDeposit.flow.test.ts
+++ b/src/lib/sendswap/flows/lightningDeposit.flow.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tier-A integration test for the Lightning deposit flow.
+ *
+ * Mirrors what `DepositOptions.svelte` writes to txState when the user picks
+ * "Lightning". from.network is `lightning`, to.network is `magi`.
+ *
+ * Per docs.magi.eco, Lightning routes via the v4v gateway; rail must derive
+ * to `lightning` (from.network triggers `throughLightning`). The gateway fee
+ * is computed by `lightning.feeCalculation` which fetches v4v metadata —
+ * stubbed here so the routing is exercised without a live network call.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DepositTxState } from '../utils/txState.svelte';
+import { Coin, Network, type AssetOption } from '../utils/sendOptions';
+import { getIntermediaryNetwork } from '../utils/getNetwork';
+import { isValidAmountString } from '../../currency/CoinAmount';
+
+const SATS_ASSET: AssetOption = { coin: Coin.sats, networks: [Network.magi] };
+
+/** Mirrors the effect in DepositOptions.svelte when `lightningOpen` flips true
+ *  AND the user has nothing already selected — the "BTC in, SATS out" default. */
+function setupLightningDeposit_btcToSats(state: DepositTxState) {
+	state.from = { coin: Coin.btc, network: Network.lightning };
+	state.to = { coin: SATS_ASSET.coin, network: Network.magi };
+}
+
+/** Variant where the user previously selected HIVE as the deposit target. */
+function setupLightningDeposit_btcToHive(state: DepositTxState) {
+	state.from = { coin: Coin.btc, network: Network.lightning };
+	state.to = { coin: Coin.hive, network: Network.magi };
+}
+
+describe('Lightning deposit — flow integration', () => {
+	it('default state: from = btc/lightning, to = sats/magi', () => {
+		const state = new DepositTxState();
+		setupLightningDeposit_btcToSats(state);
+		expect(state.from).toEqual({ coin: Coin.btc, network: Network.lightning });
+		expect(state.to).toEqual({ coin: Coin.sats, network: Network.magi });
+	});
+
+	it('rail derives to lightning whenever from.network is lightning', () => {
+		const state = new DepositTxState();
+		setupLightningDeposit_btcToSats(state);
+		expect(state.rail?.value).toBe(Network.lightning.value);
+
+		setupLightningDeposit_btcToHive(state);
+		expect(state.rail?.value).toBe(Network.lightning.value);
+	});
+
+	it('derived rail matches direct getIntermediaryNetwork call', () => {
+		const state = new DepositTxState();
+		setupLightningDeposit_btcToSats(state);
+		const direct = getIntermediaryNetwork(state.from!, state.to!);
+		expect(state.rail?.value).toBe(direct.value);
+		expect(direct.value).toBe(Network.lightning.value);
+	});
+
+	it('amount validation: rejects 0 and accepts a valid SATS amount', () => {
+		expect(isValidAmountString('0')).toBe(false);
+		expect(isValidAmountString('1000')).toBe(true); // 1000 sats minimum-ish
+	});
+
+	// Note: actual fee math via `getFee()` (which calls `lightning.feeCalculation`)
+	// is covered by `reviewSwapFees.test.ts` / `v4v.test.ts` — those mock both
+	// the v4v metadata fetch AND the CoinGecko prices fetch. We deliberately
+	// skip it here to keep these flow tests fast and dependency-free.
+});

--- a/src/lib/sendswap/flows/lightningWithdraw.flow.test.ts
+++ b/src/lib/sendswap/flows/lightningWithdraw.flow.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tier-A integration test for the Lightning (Keepsats) withdraw flow.
+ *
+ * Mirrors what `WithdrawOptions.svelte` writes to txState when the user picks
+ * "Lightning Transfer" (Keepsats): from = btc/magi, to = btc/lightning. The
+ * rail derives to `lightning` because to.network is Lightning.
+ *
+ * The picker also allows the user to flip the display between BTC and SATS;
+ * that's a presentation concern (handled in `KeepsatsWithdraw.svelte`) and
+ * doesn't change the underlying tx state shape.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { WithdrawTxState } from '../utils/txState.svelte';
+import { Coin, Network } from '../utils/sendOptions';
+import { getIntermediaryNetwork } from '../utils/getNetwork';
+import { isValidAmountString } from '../../currency/CoinAmount';
+
+/** Mirrors the effect in WithdrawOptions.svelte when `lightningTransferOpen` flips true. */
+function setupLightningWithdraw(state: WithdrawTxState) {
+	state.from = { coin: Coin.btc, network: Network.magi };
+	state.to = { coin: Coin.btc, network: Network.lightning };
+}
+
+describe('Lightning (Keepsats) withdraw — flow integration', () => {
+	it('parent sets from = btc/magi, to = btc/lightning', () => {
+		const state = new WithdrawTxState();
+		setupLightningWithdraw(state);
+		expect(state.from).toEqual({ coin: Coin.btc, network: Network.magi });
+		expect(state.to).toEqual({ coin: Coin.btc, network: Network.lightning });
+	});
+
+	it('rail derives to lightning (to.network triggers throughLightning)', () => {
+		const state = new WithdrawTxState();
+		setupLightningWithdraw(state);
+		expect(state.rail?.value).toBe(Network.lightning.value);
+	});
+
+	it('derived rail matches direct getIntermediaryNetwork call', () => {
+		const state = new WithdrawTxState();
+		setupLightningWithdraw(state);
+		const direct = getIntermediaryNetwork(state.from!, state.to!);
+		expect(state.rail?.value).toBe(direct.value);
+	});
+
+	it('does NOT carry deductFee/maxFee semantics like BTC mainnet does', () => {
+		// Lightning withdraw is settled by the v4v gateway, not the BTC unmap
+		// contract — the BTC-mainnet fee controls don't apply. The fields exist
+		// on WithdrawTxState but should stay at defaults for this flow.
+		const state = new WithdrawTxState();
+		setupLightningWithdraw(state);
+		expect(state.deductFee).toBe(false);
+		expect(state.maxFee).toBeUndefined();
+	});
+
+	it('amount validation: same gate as other withdraws', () => {
+		expect(isValidAmountString('0')).toBe(false);
+		expect(isValidAmountString('')).toBe(false);
+		expect(isValidAmountString('500')).toBe(true);
+	});
+
+	// Note: actual fee math via `getFee()` (which calls `lightning.feeCalculation`)
+	// is covered by `reviewSwapFees.test.ts` / `v4v.test.ts` — those mock both
+	// the v4v metadata fetch AND the CoinGecko prices fetch. We deliberately
+	// skip it here to keep these flow tests fast and dependency-free.
+});

--- a/src/lib/sendswap/flows/swap.flow.test.ts
+++ b/src/lib/sendswap/flows/swap.flow.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tier-A integration test for cross-chain swap flows (QuickSwap + /swap page).
+ *
+ * Three representative cases:
+ *  1. Internal magi swap (HIVE → HBD on magi) — both endpoints on Magi, simple
+ *     HBD-paired DEX swap. Rail derives to magi.
+ *  2. Cross-chain swap (BTC mainnet → HIVE hiveMainnet) — endpoints on
+ *     different chains, but per docs.magi.eco this still routes through Magi
+ *     (HBD-paired DEX), not Lightning. Rail derives to magi.
+ *  3. The `railOverride` case — QuickSwap / /swap page force rail = lightning
+ *     on Reown-BTC swaps as a UI hint even when the from/to-derived rail is
+ *     magi. We verify the override behavior and the contract that clearing
+ *     it restores the derived value.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SwapTxState } from '../utils/txState.svelte';
+import { Coin, Network } from '../utils/sendOptions';
+import { getIntermediaryNetwork } from '../utils/getNetwork';
+
+describe('Swap flows — flow integration', () => {
+	describe('internal Magi swap (HIVE → HBD)', () => {
+		function setup(state: SwapTxState) {
+			state.from = { coin: Coin.hive, network: Network.magi };
+			state.to = { coin: Coin.hbd, network: Network.magi };
+		}
+
+		it('rail derives to magi (HBD-paired DEX)', () => {
+			const state = new SwapTxState();
+			setup(state);
+			expect(state.rail?.value).toBe(Network.magi.value);
+		});
+
+		it('matches direct getIntermediaryNetwork call', () => {
+			const state = new SwapTxState();
+			setup(state);
+			expect(state.rail?.value).toBe(getIntermediaryNetwork(state.from!, state.to!).value);
+		});
+	});
+
+	describe('cross-chain swap (BTC mainnet → HIVE hiveMainnet)', () => {
+		function setup(state: SwapTxState) {
+			state.from = { coin: Coin.btc, network: Network.btcMainnet };
+			state.to = { coin: Coin.hive, network: Network.hiveMainnet };
+		}
+
+		it('rail derives to magi per docs (HBD-paired DEX, not Lightning)', () => {
+			const state = new SwapTxState();
+			setup(state);
+			expect(state.rail?.value).toBe(Network.magi.value);
+		});
+
+		it('does NOT trigger the throughLightning branch', () => {
+			const state = new SwapTxState();
+			setup(state);
+			const direct = getIntermediaryNetwork(state.from!, state.to!);
+			expect(direct.value).not.toBe(Network.lightning.value);
+		});
+	});
+
+	describe('railOverride contract (QuickSwap / /swap Reown case)', () => {
+		it('railOverride wins when set; derivation restores when cleared', () => {
+			const state = new SwapTxState();
+			state.from = { coin: Coin.btc, network: Network.btcMainnet };
+			state.to = { coin: Coin.hive, network: Network.hiveMainnet };
+			expect(state.rail?.value).toBe(Network.magi.value);
+
+			state.railOverride = Network.lightning;
+			expect(state.rail?.value).toBe(Network.lightning.value);
+
+			state.railOverride = undefined;
+			expect(state.rail?.value).toBe(Network.magi.value);
+		});
+
+		it('override does NOT change from/to', () => {
+			const state = new SwapTxState();
+			state.from = { coin: Coin.btc, network: Network.btcMainnet };
+			state.to = { coin: Coin.hive, network: Network.hiveMainnet };
+			state.railOverride = Network.lightning;
+			expect(state.from.network.value).toBe(Network.btcMainnet.value);
+			expect(state.to.network.value).toBe(Network.hiveMainnet.value);
+		});
+	});
+
+	describe('swap-specific fields', () => {
+		it('SwapTxState defaults slippageBps to 100 and minAmountOut undefined', () => {
+			const state = new SwapTxState();
+			expect(state.slippageBps).toBe(100);
+			expect(state.minAmountOut).toBeUndefined();
+			expect(state.kind).toBe('swap');
+		});
+
+		it('expectedOutput and minAmountOut round-trip', () => {
+			const state = new SwapTxState();
+			state.expectedOutput = '4800';
+			state.minAmountOut = '4750';
+			expect(state.expectedOutput).toBe('4800');
+			expect(state.minAmountOut).toBe('4750');
+		});
+	});
+});

--- a/src/lib/sendswap/stages/Complete.svelte
+++ b/src/lib/sendswap/stages/Complete.svelte
@@ -69,8 +69,8 @@
 
 	const isSend = $derived(txState.toUsername !== getUsernameFromAuth(getAuth()()));
 
-	let fromCoin = $derived(txState.fromCoin?.coin ?? Coin.unk);
-	let toCoin = $derived(txState.toCoin?.coin ?? Coin.unk);
+	let fromCoin = $derived(txState.from?.coin ?? Coin.unk);
+	let toCoin = $derived(txState.to?.coin ?? Coin.unk);
 	function prettyWithDisplayUnit(amt: CoinAmount<Coin>): string {
 		const isNegative = amt.amount < 0;
 		const n = Math.abs(amt.amount) / 10 ** amt.coin.decimalPlaces;
@@ -97,8 +97,8 @@
 			});
 	});
 	const alteraFeeApplies = $derived(
-		!!txState.toNetwork &&
-			txState.toNetwork.value !== Network.magi.value &&
+		!!txState.to &&
+			txState.to.network.value !== Network.magi.value &&
 			toCoin.value !== Coin.hive.value &&
 			toCoin.value !== Coin.hbd.value &&
 			grossInUsdNum >= ALTERA_FEE_USD_THRESHOLD
@@ -160,10 +160,10 @@
 					{prettyWithDisplayUnit(new CoinAmount(txState.fromAmount, fromCoin))}
 					{`(\$US ${inUsd})`}
 				</h4>
-			{:else if txState.toNetwork && txState.fromNetwork}
+			{:else if txState.to && txState.from}
 				<div class="swap-header">
 					<span class="from-icon">
-						<CoinNetworkIcon coin={fromCoin} network={txState.fromNetwork!} size={32} />
+						<CoinNetworkIcon coin={fromCoin} network={txState.from.network} size={32} />
 					</span>
 					<span class="from-amt">
 						{prettyWithDisplayUnit(new CoinAmount(txState.fromAmount, fromCoin))}
@@ -175,7 +175,7 @@
 					</span>
 
 					<span class="to-icon">
-						<CoinNetworkIcon coin={toCoin} network={txState.toNetwork!} size={32} />
+						<CoinNetworkIcon coin={toCoin} network={txState.to.network} size={32} />
 					</span>
 					<span class="to-amt">
 						{prettyWithDisplayUnit(new CoinAmount(txState.toAmount, toCoin))}

--- a/src/lib/sendswap/stages/QuickSendOptions.svelte
+++ b/src/lib/sendswap/stages/QuickSendOptions.svelte
@@ -40,19 +40,18 @@
 	// EDIT STAGE
 	let toSelf = $derived(
 		txState.toUsername === getUsernameFromAuth(auth) &&
-			txState.fromNetwork?.value === txState.toNetwork?.value
+			txState.from?.network.value === txState.to?.network.value
 	);
 	// AMOUNT SECTION
 	let coinAmount = $state(new CoinAmount(0, Coin.hive));
 
 	// EDIT STAGE
 	let stageComplete = $derived(
-		!!txState.fromCoin &&
-			!!txState.fromNetwork &&
+		!!txState.from &&
 			coinAmount.amount !== 0 &&
 			!toSelf &&
 			!!txState.toUsername &&
-			!!txState.toNetwork
+			!!txState.to
 	);
 	$effect(() => {
 		editStage(stageComplete);
@@ -67,7 +66,7 @@
 		swapOptions.from.map((opt) => ({
 			...opt.coin,
 			snippet: assetCard,
-			snippetData: { fromOpt: opt, net: txState.toNetwork, size: 'medium' }
+			snippetData: { fromOpt: opt, net: txState.to?.network, size: 'medium' }
 		}))
 	);
 
@@ -77,16 +76,16 @@
 	let lastMaxBalance = -1;
 	let lastMaxCoin = '';
 	$effect(() => {
-		if (!txState.fromCoin || !txState.fromNetwork) return;
-		if (txState.fromNetwork.value !== Network.magi.value) return;
+		if (!txState.from) return;
+		if (txState.from.network.value !== Network.magi.value) return;
 
-		const coinValue = txState.fromCoin.coin.value;
+		const coinValue = txState.from.coin.value;
 		if (coinValue in $accountBalance.bal) {
 			const balance = $accountBalance.bal[coinValue as keyof AccountBalance];
 			if (balance !== lastMaxBalance || coinValue !== lastMaxCoin) {
 				lastMaxBalance = balance;
 				lastMaxCoin = coinValue;
-				max = new CoinAmount(balance, txState.fromCoin.coin, true);
+				max = new CoinAmount(balance, txState.from.coin, true);
 			}
 		}
 	});
@@ -96,10 +95,13 @@
 		assetOpen = open;
 	};
 
+	// QuickSend is magi-internal: keep `to`'s coin in sync with `from`'s coin.
 	$effect(() => {
-		const fromCoin = txState.fromCoin;
-		if (txState.toCoin?.coin.value !== fromCoin?.coin.value) {
-			txState.toCoin = fromCoin;
+		const fromVal = txState.from;
+		if (txState.to?.coin.value !== fromVal?.coin.value) {
+			txState.to = fromVal
+				? { coin: fromVal.coin, network: txState.to?.network ?? Network.magi }
+				: undefined;
 		}
 	});
 
@@ -127,9 +129,7 @@
 	let inputId = $state('');
 
 	const inputCoinOpt: CoinOnNetwork[] = $derived(
-		txState.fromCoin && txState.fromNetwork
-			? [{ coin: txState.fromCoin.coin, network: txState.fromNetwork }]
-			: [{ coin: Coin.unk, network: Network.unknown }]
+		txState.from ? [txState.from] : [{ coin: Coin.unk, network: Network.unknown }]
 	);
 
 	const coinsWithBalance = $derived.by(() => {
@@ -154,18 +154,16 @@
 		if (balanceCount === 0) return;
 
 		const currentCoinHasBalance =
-			txState.fromCoin &&
-			coinsWithBalance.some((item) => item.coin.value === txState.fromCoin?.coin.value);
+			txState.from &&
+			coinsWithBalance.some((item) => item.coin.value === txState.from?.coin.value);
 		if (currentCoinHasBalance) return;
 
 		const hiveCoin = coinsWithBalance.find((item) => item.coin.value === Coin.hive.value);
 		const coinToSelect = hiveCoin || coinsWithBalance[0];
 
 		if (coinToSelect) {
-			txState.fromCoin = coinToSelect.coinOpt;
-			txState.fromNetwork = Network.magi;
-			txState.toCoin = coinToSelect.coinOpt;
-			txState.toNetwork = Network.magi;
+			txState.from = { coin: coinToSelect.coin, network: Network.magi };
+			txState.to = { coin: coinToSelect.coin, network: Network.magi };
 		}
 	});
 </script>
@@ -231,10 +229,10 @@
 					<div class="error">
 						No balance found on your account. Please make a deposit to get started.
 					</div>
-				{:else if txState.fromCoin && txState.fromNetwork}
+				{:else if txState.from}
 					<BalanceInfo
-						coin={txState.fromCoin.coin}
-						network={txState.fromNetwork}
+						coin={txState.from.coin}
+						network={txState.from.network}
 						size="large"
 						styleType="vertical"
 					/>
@@ -254,7 +252,7 @@
 					<AmountInput
 						bind:coinAmount
 						coinOpts={inputCoinOpt}
-						expressIn={txState.fromCoin?.coin}
+						expressIn={txState.from?.coin}
 						maxAmount={max}
 						bind:id={inputId}
 					/>

--- a/src/lib/sendswap/stages/QuickSendOptions.svelte
+++ b/src/lib/sendswap/stages/QuickSendOptions.svelte
@@ -191,8 +191,7 @@
 	<SelectAssetFlattened
 		availableCoins={fromAssetObjs}
 		close={toggleAsset}
-		bind:coin={txState.fromCoin}
-		bind:network={txState.fromNetwork}
+		bind:selected={txState.from}
 		bind:max
 	/>
 {/if}

--- a/src/lib/sendswap/stages/QuickSendOptions.svelte
+++ b/src/lib/sendswap/stages/QuickSendOptions.svelte
@@ -235,7 +235,6 @@
 						size="large"
 						styleType="vertical"
 					/>
-					<!-- <AssetInfo coinOpt={txState.fromCoin} size="medium" /> -->
 				{:else}
 					<span class="user-icon-placeholder"><Coins size="40" absoluteStrokeWidth={true} /></span>
 					Select Asset

--- a/src/lib/sendswap/stages/ReviewSwap.svelte
+++ b/src/lib/sendswap/stages/ReviewSwap.svelte
@@ -91,8 +91,8 @@
 		}
 	});
 
-	let toCoin = $derived(txState.toCoin?.coin ?? Coin.unk);
-	let fromCoin = $derived(txState.fromCoin?.coin ?? Coin.unk);
+	let toCoin = $derived(txState.to?.coin ?? Coin.unk);
+	let fromCoin = $derived(txState.from?.coin ?? Coin.unk);
 	let effectiveFromAmount = $derived(txState.fromAmount || '0');
 	// Pool fees are now denominated in the OUTPUT asset: the full input
 	// enters the pool and fees are carved off the gross output. So the
@@ -103,8 +103,8 @@
 	const isLightningWithdraw = $derived(
 		isLightningWithdrawFlow({
 			kind: txState.kind,
-			fromNetwork: txState.fromNetwork?.value,
-			toNetwork: txState.toNetwork?.value,
+			fromNetwork: txState.from?.network.value,
+			toNetwork: txState.to?.network.value,
 			fromCoin: fromCoin.value,
 			toCoin: toCoin.value
 		})
@@ -213,8 +213,8 @@
 	// user sees what will be deducted from `expectedOutput` and `minAmountOut`.
 	let btcFeeEstimate = $state<BtcFeeEstimate | null>(null);
 	const isToBtcMainnet = $derived(
-		txState.toNetwork?.value === Network.btcMainnet.value &&
-			txState.toCoin?.coin.value === Coin.btc.value
+		txState.to?.network.value === Network.btcMainnet.value &&
+			txState.to?.coin.value === Coin.btc.value
 	);
 	$effect(() => {
 		if (!isToBtcMainnet) {
@@ -252,7 +252,7 @@
 	});
 	let fromInTo = $state<CoinAmount<Coin>>();
 	$effect(() => {
-		if (!txState.fromCoin || !txState.toCoin) return;
+		if (!txState.from || !txState.to) return;
 
 		// Prefer the pool-math effective rate (expectedOutput / input)
 		// over the lightning off-chain reference rate. Fees are
@@ -268,15 +268,15 @@
 			}
 		}
 
-		new CoinAmount(1, txState.fromCoin.coin)
-			.convertTo(txState.toCoin.coin, Network.lightning)
+		new CoinAmount(1, txState.from.coin)
+			.convertTo(txState.to.coin, Network.lightning)
 			.then((amt) => {
 				fromInTo = amt;
 			});
 	});
 	let isInstructions = $derived(
 		auth.value?.provider === 'reown' &&
-			txState.fromNetwork?.value === Network.hiveMainnet.value
+			txState.from?.network.value === Network.hiveMainnet.value
 	);
 	$effect(() => {
 		netSwapFromAmountCa.convertTo(Coin.usd, Network.lightning).then((amt) => {
@@ -299,8 +299,8 @@
 	});
 	const alteraFeeApplies = $derived(
 		effectiveAlteraFeeBps > 0 &&
-		!!txState.toNetwork &&
-			txState.toNetwork.value !== Network.magi.value &&
+		!!txState.to &&
+			txState.to.network.value !== Network.magi.value &&
 			toCoin.value !== Coin.hive.value &&
 			toCoin.value !== Coin.hbd.value &&
 			!!grossInUsd &&
@@ -331,7 +331,7 @@
 	$effect(() => {
 		const totalFeeRaw = asSwap?.swapTotalFee;
 		const hop1 = asSwap?.swapHop1Fee;
-		if (!totalFeeRaw || !txState.toCoin) {
+		if (!totalFeeRaw || !txState.to) {
 			swapFeeInUsd = undefined;
 			return;
 		}
@@ -376,7 +376,7 @@
 	let minAmountInUsd = $state<CoinAmount<Coin>>();
 	$effect(() => {
 		const minRaw = asSwap?.minAmountOut;
-		if (!minRaw || !txState.toCoin) { minAmountInUsd = undefined; return; }
+		if (!minRaw || !txState.to) { minAmountInUsd = undefined; return; }
 		const minNet = alteraFeeApplies
 			? Math.floor((Number(minRaw) * (10000 - effectiveAlteraFeeBps)) / 10000)
 			: Number(minRaw);
@@ -426,13 +426,13 @@
 				</svg>
 				<table>
 					<tbody>
-						{#if txState.fromCoin && txState.fromNetwork}
+						{#if txState.from}
 							<tr>
 								<td class="icon">
-									<CoinNetworkIcon coin={fromCoin} network={txState.fromNetwork} size={32} />
+									<CoinNetworkIcon coin={fromCoin} network={txState.from.network} size={32} />
 								</td>
 								<td class="sm-caption label"
-									>From {fromCoinDisplayLabel} on {txState.fromNetwork?.label}{senderAddress
+									>From {fromCoinDisplayLabel} on {txState.from.network.label}{senderAddress
 										? ` (${senderAddress})`
 										: ''}</td
 								>
@@ -452,7 +452,7 @@
 							<td class="icon"><Dot size="32" /></td>
 							<td class="sm-caption label">{isLightningWithdraw ? 'V4V Fee' : 'Fee'}</td>
 							<td class="content">
-								{#if asSwap?.swapTotalFee && txState.toCoin}
+								{#if asSwap?.swapTotalFee && txState.to}
 									{@const hop1 = asSwap.swapHop1Fee}
 									{@const hop1Coin = hop1
 										? hop1.asset === Coin.hbd.value
@@ -493,7 +493,7 @@
 								</td>
 							</tr>
 						{/if}
-						{#if txState.toCoin && txState.toNetwork}
+						{#if txState.to}
 							{@const rawTo = convertedToAmount ?? new CoinAmount(effectiveToAmount, toCoin)}
 							{@const netToAmount = computeNetToAmountSmallest({
 								rawToAmount: rawTo.amount,
@@ -535,10 +535,10 @@
 							{/if}
 							<tr>
 								<td class="icon">
-									<CoinNetworkIcon coin={toCoin} network={txState.toNetwork} size={32} />
+									<CoinNetworkIcon coin={toCoin} network={txState.to.network} size={32} />
 								</td>
 								<td class="sm-caption label"
-									>To {toCoinDisplayLabel} on {txState.toNetwork?.label}{receiverAddress
+									>To {toCoinDisplayLabel} on {txState.to.network.label}{receiverAddress
 										? ` (${receiverAddress})`
 										: ''}</td
 								>
@@ -572,7 +572,7 @@
 									<td class="content">
 										{#if asSwap.swapCalcPending}
 											<div class="fee-loading"><WaveLoading size={16} /></div>
-										{:else if asSwap.minAmountOut && txState.toCoin}
+										{:else if asSwap.minAmountOut && txState.to}
 											{@const minRaw = alteraFeeApplies
 												? Math.floor(
 														(Number(asSwap.minAmountOut) * (10000 - effectiveAlteraFeeBps)) /

--- a/src/lib/sendswap/stages/ReviewTransfer.svelte
+++ b/src/lib/sendswap/stages/ReviewTransfer.svelte
@@ -39,11 +39,11 @@
 		}
 	});
 
-	let toCoin = $derived(txState.toCoin?.coin ?? Coin.unk);
+	let toCoin = $derived(txState.to?.coin ?? Coin.unk);
 	let inUsd = $state('');
 	let isInstructions = $derived(
 		auth.value?.provider === 'reown' &&
-			txState.fromNetwork?.value === Network.hiveMainnet.value
+			txState.from?.network.value === Network.hiveMainnet.value
 	);
 	$effect(() => {
 		new CoinAmount(txState.toAmount, toCoin)
@@ -54,13 +54,14 @@
 	});
 	let today = moment().format('MMM D, YYYY');
 	let fromNetwork = $derived.by(() => {
-		if (txState.fromNetwork?.value === Network.hiveMainnet.value) {
-			return `Deposit from ${txState.fromNetwork.label}`;
+		const net = txState.from?.network;
+		if (net?.value === Network.hiveMainnet.value) {
+			return `Deposit from ${net.label}`;
 		}
-		if (txState.fromNetwork?.value === Network.lightning.value) {
-			return `Swap from ${txState.fromNetwork.label}`;
+		if (net?.value === Network.lightning.value) {
+			return `Swap from ${net.label}`;
 		}
-		return txState.fromNetwork?.label ?? 'UNK';
+		return net?.label ?? 'UNK';
 	});
 	let toDid = $derived(getDidFromUsername(txState.toUsername));
 
@@ -110,7 +111,7 @@
 				</tr>
 				<tr>
 					<td class="sm-caption label">Network</td>
-					<td class="content">{txState.toNetwork?.label}</td>
+					<td class="content">{txState.to?.network.label}</td>
 				</tr>
 			</tbody>
 		</table>

--- a/src/lib/sendswap/stages/SwapDestination.svelte
+++ b/src/lib/sendswap/stages/SwapDestination.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { getAuth } from '$lib/auth/store';
-	import { Coin, Network } from '$lib/sendswap/utils/sendOptions';
+	import { Coin, getToOption, Network } from '$lib/sendswap/utils/sendOptions';
 	import { useSwapState } from '$lib/sendswap/utils/txState.svelte';
 	import { checkBtcRecipient, fetchUserBtcDepositAddress } from '$lib/sendswap/utils/btcAddressGuard';
 	import { Send, Wallet, X } from '@lucide/svelte';
@@ -29,7 +29,7 @@
 		abort?: () => void;
 	} = $props();
 
-	let toCoin = $derived(txState.toCoin?.coin ?? Coin.unk);
+	let toCoin = $derived(txState.to?.coin ?? Coin.unk);
 
 	function coinDisplayLabel(coin: (typeof Coin)[keyof typeof Coin]): string {
 		return coin.value === Coin.hive.value
@@ -85,22 +85,22 @@
 		}
 	});
 
-	// Update toNetwork based on destination choice
+	// Update `to.network` based on destination choice. Needs `to.coin` already
+	// chosen by SwapOptions — guard so we don't try to set just a network.
 	$effect(() => {
-		if (destChoice === 'wallet') {
-			if (txState.toNetwork?.value !== Network.magi.value) {
-				txState.toNetwork = Network.magi;
-			}
-		} else {
-			const net =
-				destNetworkChoice === 'magi'
+		const coin = txState.to?.coin;
+		if (!coin) return;
+
+		const net: Network =
+			destChoice === 'wallet'
+				? Network.magi
+				: destNetworkChoice === 'magi'
 					? Network.magi
-					: txState.toCoin?.networks?.find(
-							(n: Network) => n.value !== Network.magi.value
-						) ?? Network.hiveMainnet;
-			if (txState.toNetwork?.value !== net.value) {
-				txState.toNetwork = net;
-			}
+					: (getToOption(coin.value)?.networks?.find((n) => n.value !== Network.magi.value) ??
+						Network.hiveMainnet);
+
+		if (txState.to?.network.value !== net.value) {
+			txState.to = { coin, network: net };
 		}
 	});
 
@@ -115,9 +115,9 @@
 <div class="swap-dest-wrapper">
 	<span class="deliver-label">DELIVER TO</span>
 
-	{#if txState.toCoin}
+	{#if txState.to}
 		<div class="dest-header">
-			<CoinNetworkIcon coin={toCoin} network={txState.toNetwork ?? Network.magi} size={32} />
+			<CoinNetworkIcon coin={toCoin} network={txState.to.network} size={32} />
 			<h3>Where should {coinDisplayLabel(toCoin)} go?</h3>
 		</div>
 	{/if}

--- a/src/lib/sendswap/stages/SwapOptions.svelte
+++ b/src/lib/sendswap/stages/SwapOptions.svelte
@@ -162,8 +162,8 @@
 
 	// Recalculate swap whenever input amount, coins, or slippage changes.
 	$effect(() => {
-		const fromCoin = txState.fromCoin;
-		const toCoin = txState.toCoin;
+		const fromCoin = txState.from;
+		const toCoin = txState.to;
 		const fromAmount = txState.fromAmount;
 		if (!fromCoin || !toCoin || !fromAmount || fromAmount === '0') {
 			swapResult = null;
@@ -312,21 +312,21 @@
 	}
 
 	let expectedOutputUsd = $derived.by(() => {
-		const toCoinDef = txState.toCoin;
+		const toCoinDef = txState.to;
 		if (!swapResult || swapResult.expectedOutput <= 0n || toPriceUsdRaw <= 0 || !toCoinDef)
 			return null;
 		return (Number(swapResult.expectedOutput) / 10 ** toCoinDef.coin.decimalPlaces) * toPriceUsdRaw;
 	});
 
 	let minAmountOutUsd = $derived.by(() => {
-		const toCoinDef = txState.toCoin;
+		const toCoinDef = txState.to;
 		if (!swapResult || swapResult.minAmountOut <= 0n || toPriceUsdRaw <= 0 || !toCoinDef)
 			return null;
 		return (Number(swapResult.minAmountOut) / 10 ** toCoinDef.coin.decimalPlaces) * toPriceUsdRaw;
 	});
 
 	let inputAmountUsd = $derived.by(() => {
-		const fromCoinDef = txState.fromCoin;
+		const fromCoinDef = txState.from;
 		const fromAmount = txState.fromAmount;
 		if (!fromCoinDef || !fromAmount || fromAmount === '0' || fromPriceUsdRaw <= 0) return null;
 		const amt = new CoinAmount(fromAmount, fromCoinDef.coin).toNumber();
@@ -336,8 +336,8 @@
 
 	let exchangeFeePct = $derived(
 		getAlteraFeePct(
-			txState.fromCoin?.coin.value ?? '',
-			txState.toCoin?.coin.value ?? ''
+			txState.from?.coin.value ?? '',
+			txState.to?.coin.value ?? ''
 		)
 	);
 
@@ -347,7 +347,7 @@
 	 * HBD (≈ $1 pegged). Final-hop fee is in the output coin.
 	 */
 	let totalProtocolFeeUsd = $derived.by(() => {
-		const toCoinDef = txState.toCoin;
+		const toCoinDef = txState.to;
 		if (!swapResult || toPriceUsdRaw <= 0 || !toCoinDef) return null;
 		const finalHopUsd =
 			(Number(swapResult.baseFee) / 10 ** toCoinDef.coin.decimalPlaces) * toPriceUsdRaw;
@@ -382,18 +382,18 @@
 	// Update toNetwork based on destination choice
 	$effect(() => {
 		if (destChoice === 'wallet') {
-			if (txState.toNetwork?.value !== Network.magi.value) {
-				txState.toNetwork = Network.magi;
+			if (txState.to && txState.to.network.value !== Network.magi.value) {
+				txState.to = { coin: txState.to.coin, network: Network.magi };
 			}
 		} else {
 			const net =
 				destNetworkChoice === 'magi'
 					? Network.magi
-					: (txState.toCoin?.networks?.find(
+					: (getToOption(txState.to?.coin.value)?.networks?.find(
 							(n: Network) => n.value !== Network.magi.value
 						) ?? Network.hiveMainnet);
-			if (txState.toNetwork?.value !== net.value) {
-				txState.toNetwork = net;
+			if (txState.to && txState.to.network.value !== net.value) {
+				txState.to = { coin: txState.to.coin, network: net };
 			}
 		}
 	});
@@ -409,14 +409,12 @@
 	let swapFieldsValid = $state(false);
 	$effect(() => {
 		const valid = !!(
-			txState.toNetwork &&
+			txState.to &&
 			txState.toAmount &&
 			txState.toAmount !== '0' &&
-			txState.toCoin &&
-			txState.fromNetwork &&
+			txState.from &&
 			txState.fromAmount &&
-			txState.fromAmount !== '0' &&
-			txState.fromCoin
+			txState.fromAmount !== '0'
 		);
 		swapFieldsValid = valid;
 		untrack(() => {
@@ -440,7 +438,7 @@
 		if (destChoice === 'wallet') return true;
 		const addr = destAddress.trim();
 		if (!addr) return false;
-		const isBtcTarget = txState.toCoin?.coin.value === Coin.btc.value;
+		const isBtcTarget = txState.to?.coin.value === Coin.btc.value;
 		const wantsMainnet = destNetworkChoice === 'mainnet';
 		if (isBtcTarget && wantsMainnet) {
 			const net = isVscTestnet() ? BtcNetwork.testnet : BtcNetwork.mainnet;
@@ -457,8 +455,8 @@
 	 * the estimated intermediate amount vs pool2's input reserve.
 	 */
 	let exceedsPoolDepth = $derived.by(() => {
-		const fromCoin = txState.fromCoin;
-		const toCoin = txState.toCoin;
+		const fromCoin = txState.from;
+		const toCoin = txState.to;
 		const fromAmount = txState.fromAmount;
 		if (!fromCoin || !toCoin || !fromAmount || fromAmount === '0') return false;
 
@@ -497,10 +495,10 @@
 		const { assetOptions: newAssetOptions, networkOptions: newNetworkOptions } =
 			solveNetworkConstraints(
 				txState.rail,
-				txState.fromCoin,
-				txState.toNetwork,
+				getFromOption(txState.from?.coin.value),
+				txState.to?.network,
 				auth.value?.did,
-				txState.fromNetwork,
+				txState.from?.network,
 				true
 			);
 		if (!optionsEqual(newAssetOptions, assetOptions)) {
@@ -513,15 +511,14 @@
 
 	$effect(() => {
 		// FROM auto selection
-		if (!(txState.fromCoin && txState.fromNetwork) && assetOptions.length > 0) {
+		if (!(txState.from) && assetOptions.length > 0) {
 			const btcOption = assetOptions.find(
 				(opt) => opt.coin.value === Coin.btc.value && !opt.disabled
 			);
 			const firstAvailable = assetOptions.find((opt) => !opt.disabled);
 			const fromOpt = btcOption ?? firstAvailable;
 			if (fromOpt) {
-				txState.fromCoin = fromOpt;
-				txState.fromNetwork = Network.magi;
+				txState.from = { coin: fromOpt.coin, network: Network.magi };
 			}
 		}
 
@@ -532,7 +529,7 @@
 			const bal = getBalanceSmallestUnits($accountBalance, coinDef, Network.magi);
 			return bal > 0.001;
 		});
-		if (!(txState.toCoin && txState.toNetwork)) {
+		if (!(txState.to)) {
 			let nextToCoin: (typeof swapOptions.to)[number] | undefined;
 			let nextToNetwork: Network | undefined;
 			if (visibleToObjs.length > 0) {
@@ -555,34 +552,31 @@
 				nextToCoin = undefined;
 				nextToNetwork = undefined;
 			}
-			const prevToCoin = txState.toCoin;
-			const prevToNetwork = txState.toNetwork;
-			const changed =
-				prevToCoin?.coin.value !== nextToCoin?.coin.value ||
-				prevToNetwork?.value !== nextToNetwork?.value;
-			if (changed) {
-				txState.toCoin = nextToCoin;
-				txState.toNetwork = nextToNetwork;
+			// Block only entered when `to` is undefined, so the previous-value
+			// comparison from the legacy code is no-op here — just set when we
+			// have a complete next pair.
+			if (nextToCoin && nextToNetwork) {
+				txState.to = { coin: nextToCoin.coin, network: nextToNetwork };
 			}
 		}
 	});
 
 	// Same-coin error: show when from and to are the same asset
 	let sameCoinError = $derived(
-		txState.fromCoin && txState.toCoin
-			? txState.fromCoin.coin.value === txState.toCoin.coin.value
+		txState.from && txState.to
+			? txState.from.coin.value === txState.to.coin.value
 			: false
 	);
 
 	// Insufficient balance: check if from amount exceeds available balance
 	let insufficientBalance = $derived.by(() => {
-		const from = txState.fromCoin;
+		const from = txState.from;
 		const fromAmount = txState.fromAmount;
 		if (!from || !fromAmount || fromAmount === '0') return false;
 		const bal = getBalanceSmallestUnits(
 			$accountBalance,
 			from.coin,
-			txState.fromNetwork ?? Network.magi
+			from.network
 		);
 		if (bal <= 0) return true;
 		const inputNum = new CoinAmount(fromAmount, from.coin).toNumber();
@@ -623,25 +617,23 @@
 		swapOptions.to.map((opt) => ({
 			...opt.coin,
 			snippet: assetCard,
-			snippetData: { fromOpt: opt, net: txState.toNetwork, size: 'medium' }
+			snippetData: { fromOpt: opt, net: txState.to?.network, size: 'medium' }
 		}))
 	);
 
 	// Only the from coin for the amount input – no dropdown; from is changed only via the left card.
 	let amountInputCoinOpts: CoinOnNetwork[] = $derived(
-		txState.fromCoin && txState.fromNetwork
-			? [{ coin: txState.fromCoin.coin, network: txState.fromNetwork }]
-			: []
+		txState.from ? [txState.from] : []
 	);
 
 	let inputAmount = $state(new CoinAmount(0, Coin.unk));
 	$effect(() => {
-		if (!txState.fromCoin) return;
-		if (inputAmount.coin.value === txState.fromCoin.coin.value) {
+		if (!txState.from) return;
+		if (inputAmount.coin.value === txState.from.coin.value) {
 			const amt = inputAmount.toAmountString();
 			if (amt !== txState.fromAmount) txState.fromAmount = amt;
 		} else {
-			inputAmount.convertTo(txState.fromCoin.coin, Network.lightning).then((amt) => {
+			inputAmount.convertTo(txState.from.coin, Network.lightning).then((amt) => {
 				if (txState.fromAmount !== amt.toAmountString()) {
 					txState.fromAmount = amt.toAmountString();
 				}
@@ -650,15 +642,15 @@
 	});
 
 	$effect(() => {
-		if (!txState.toCoin) return;
+		if (!txState.to) return;
 		// When pool-based swap calc is active, it sets toAmount directly
 		// (even when expectedOutput is 0 — e.g. amount exceeds pool reserves)
 		if (swapResult) return;
-		if (inputAmount.coin.value === txState.toCoin.coin.value) {
+		if (inputAmount.coin.value === txState.to.coin.value) {
 			const amt = inputAmount.toAmountString();
 			if (amt !== txState.toAmount) txState.toAmount = amt;
 		} else {
-			inputAmount.convertTo(txState.toCoin.coin, Network.lightning).then((amt) => {
+			inputAmount.convertTo(txState.to.coin, Network.lightning).then((amt) => {
 				// Discard stale exchange-rate estimate if pool calc resolved while we waited
 				if (swapResult) return;
 				if (txState.toAmount !== amt.toAmountString()) {
@@ -671,24 +663,22 @@
 	// TO field — derives a CoinAmount from the calculated toAmount for the AmountInput.
 	// Currently read-only (disabled); will become editable when reverse swap calc is added.
 	const outputAmount = $derived.by(() => {
-		const toCoin = txState.toCoin?.coin ?? Coin.unk;
+		const toCoin = txState.to?.coin ?? Coin.unk;
 		const raw = txState.toAmount;
 		const fromEmpty = !txState.fromAmount || txState.fromAmount === '0';
 		if (raw && raw !== '0' && !fromEmpty) return new CoinAmount(raw, toCoin);
 		return new CoinAmount(0, toCoin);
 	});
 	const toAmountCoinOpts: CoinOnNetwork[] = $derived(
-		txState.toCoin && txState.toNetwork
-			? [{ coin: txState.toCoin.coin, network: txState.toNetwork }]
-			: []
+		txState.to ? [txState.to] : []
 	);
 
 	let fromPriceUsdRaw = $state(0);
 	let toPriceUsdRaw = $state(0);
 	let pricesFailed = $state(false);
 	$effect(() => {
-		if (txState.fromCoin) {
-			new CoinAmount(1, txState.fromCoin.coin)
+		if (txState.from) {
+			new CoinAmount(1, txState.from.coin)
 				.convertTo(Coin.usd, Network.lightning)
 				.then((amt) => {
 					fromPriceUsdRaw = amt.toNumber();
@@ -698,8 +688,8 @@
 					pricesFailed = true;
 				});
 		}
-		if (txState.toCoin) {
-			new CoinAmount(1, txState.toCoin.coin)
+		if (txState.to) {
+			new CoinAmount(1, txState.to.coin)
 				.convertTo(Coin.usd, Network.lightning)
 				.then((amt) => {
 					toPriceUsdRaw = amt.toNumber();
@@ -714,7 +704,7 @@
 	let minAmount: CoinAmount<Coin> | undefined = $state();
 	$effect(() => {
 		const amt =
-			txState.fromCoin?.coin.value === Coin.btc.value
+			txState.from?.coin.value === Coin.btc.value
 				? new CoinAmount(0.00000001, Coin.btc)
 				: undefined;
 		untrack(() => {
@@ -729,11 +719,10 @@
 	// reads from `$accountBalance.connectedBal` (the L1 account
 	// snapshot populated by aioha).
 	const maxAmount: CoinAmount<Coin> | undefined = $derived.by(() => {
-		const from = txState.fromCoin;
-		const fromNet = txState.fromNetwork;
+		const from = txState.from;
 		if (!from) return undefined;
 		const coinValue = from.coin.value;
-		if (fromNet?.value === Network.hiveMainnet.value) {
+		if (from.network.value === Network.hiveMainnet.value) {
 			const connected = $accountBalance.connectedBal;
 			if (!connected) return undefined;
 			const bal = connected[coinValue as keyof typeof connected];
@@ -817,44 +806,45 @@
 	 * different source). TO network is owned by the destChoice effect.
 	 */
 	function swapPositions() {
-		if (!txState.fromCoin || !txState.toCoin) return;
-		const prevFrom = txState.fromCoin;
-		const prevFromNet = txState.fromNetwork;
-		txState.fromCoin = txState.toCoin;
-		txState.fromNetwork = prevFromNet;
-		txState.toCoin = prevFrom;
-		// toNetwork is managed by the destChoice $effect — don't set it here.
+		if (!txState.from || !txState.to) return;
+		const prevFromCoin = txState.from.coin;
+		const prevFromNet = txState.from.network;
+		const prevToCoin = txState.to.coin;
+		// Tokens swap; FROM keeps its source network. TO network is managed
+		// by the destChoice $effect — don't set it here (preserve it).
+		txState.from = { coin: prevToCoin, network: prevFromNet };
+		txState.to = { coin: prevFromCoin, network: txState.to.network };
 	}
 
-	const canSwapPositions = $derived(!!(txState.fromCoin && txState.toCoin));
+	const canSwapPositions = $derived(!!(txState.from && txState.to));
 
 	function selectToken(token: AssetObject) {
 		// If the user picks the token already in the OTHER slot, swap tokens.
 		const otherValue =
 			currentlyOpen === 'from'
-				? txState.toCoin?.coin.value
-				: txState.fromCoin?.coin.value;
+				? txState.to?.coin.value
+				: txState.from?.coin.value;
 
 		if (otherValue && token.value === otherValue) {
 			if (currentlyOpen === 'from') {
 				// User is picking FROM and clicked the current TO token.
-				// Move old FROM → TO, show network picker for the new FROM.
-				const prevFrom = txState.fromCoin;
-				txState.toCoin = prevFrom;
-				// toNetwork stays managed by destChoice effect.
+				// Move old FROM → TO (keep TO network), show network picker for new FROM.
+				if (txState.from && txState.to) {
+					txState.to = { coin: txState.from.coin, network: txState.to.network };
+				}
 				const coinOpt = getFromOption(token.value);
 				if (!coinOpt) return;
 				tempCoinOpt = coinOpt;
 				dialogStep = 'source';
 			} else {
 				// User is picking TO and clicked the current FROM token.
-				// Swap tokens: old FROM → TO, old TO → FROM (keep FROM network).
-				const prevFrom = txState.fromCoin;
-				const prevFromNet = txState.fromNetwork;
-				const prevTo = txState.toCoin;
-				txState.toCoin = prevFrom;
-				txState.fromCoin = prevTo;
-				txState.fromNetwork = prevFromNet;
+				// Swap tokens: old FROM ↔ old TO (each keeps its own network).
+				if (txState.from && txState.to) {
+					const prevFromCoin = txState.from.coin;
+					const prevToCoin = txState.to.coin;
+					txState.to = { coin: prevFromCoin, network: txState.to.network };
+					txState.from = { coin: prevToCoin, network: txState.from.network };
+				}
 				closeDialog();
 			}
 			return;
@@ -875,14 +865,12 @@
 	}
 
 	function confirmFromSelection(coinOpt: AssetOption, network: Network) {
-		txState.fromCoin = coinOpt;
-		txState.fromNetwork = network;
+		txState.from = { coin: coinOpt.coin, network };
 		closeDialog();
 	}
 
 	function confirmToSelection(coinOpt: AssetOption, network: Network) {
-		txState.toCoin = coinOpt;
-		txState.toNetwork = network;
+		txState.to = { coin: coinOpt.coin, network };
 		closeDialog();
 	}
 
@@ -894,11 +882,11 @@
 				: coin.label;
 	}
 
-	let toCoin = $derived(txState.toCoin?.coin ?? Coin.unk);
+	let toCoin = $derived(txState.to?.coin ?? Coin.unk);
 
 	let priceImpactPct = $derived.by(() => {
-		const fromCoinDef = txState.fromCoin;
-		const toCoinDef = txState.toCoin;
+		const fromCoinDef = txState.from;
+		const toCoinDef = txState.to;
 		const fromAmount = txState.fromAmount;
 		if (!fromCoinDef || !toCoinDef || !fromAmount || fromAmount === '0') return 0;
 		if (!swapResult || swapResult.expectedOutput <= 0n) return 0;
@@ -926,8 +914,8 @@
 				</div>
 				<div class="token-chip-grid">
 					{#each getFilteredTokens(currentlyOpen === 'from' ? fromAssetObjs : toAssetObjs) as token (token.value)}
-						{@const isFrom = token.value === txState.fromCoin?.coin.value}
-						{@const isTo = token.value === txState.toCoin?.coin.value}
+						{@const isFrom = token.value === txState.from?.coin.value}
+						{@const isTo = token.value === txState.to?.coin.value}
 						{@const isSelected = isFrom || isTo}
 						<button
 							class={['token-chip', { muted: isSelected }]}
@@ -949,8 +937,8 @@
 			<div class="dialog-content">
 				<div class="token-chip-grid">
 					{#each getFilteredTokens(currentlyOpen === 'from' ? fromAssetObjs : toAssetObjs) as token (token.value)}
-						{@const isFrom = token.value === txState.fromCoin?.coin.value}
-						{@const isTo = token.value === txState.toCoin?.coin.value}
+						{@const isFrom = token.value === txState.from?.coin.value}
+						{@const isTo = token.value === txState.to?.coin.value}
 						{@const isSelected = isFrom || isTo}
 						<button
 							class={['token-chip', { active: token.value === tempCoinOpt.coin.value, muted: isSelected && token.value !== tempCoinOpt.coin.value }]}
@@ -997,14 +985,14 @@
 				<div class="section-header">
 					<span class="section-label">From</span>
 					<span class="section-header-center">
-						{#if txState.fromNetwork}
-							<span class={['network-pill', { external: txState.fromNetwork.value !== 'magi' }]}>{txState.fromNetwork.label}</span>
+						{#if txState.from}
+							<span class={['network-pill', { external: txState.from.network.value !== 'magi' }]}>{txState.from.network.label}</span>
 						{/if}
 					</span>
 					<span class="section-balance sm-caption">
-						{#if txState.fromCoin && maxAmount}
+						{#if txState.from && maxAmount}
 							Balance: {maxAmount.toPrettyAmountString()}
-							{coinDisplayLabel(txState.fromCoin.coin)}
+							{coinDisplayLabel(txState.from.coin)}
 						{/if}
 					</span>
 				</div>
@@ -1021,13 +1009,13 @@
 						/>
 					</div>
 					<button class="token-selector-btn" onclick={() => openDialog('from')}>
-						{#if txState.fromCoin}
+						{#if txState.from}
 							<img
-								src={txState.fromCoin.coin.icon}
-								alt={coinDisplayLabel(txState.fromCoin.coin)}
+								src={txState.from.coin.icon}
+								alt={coinDisplayLabel(txState.from.coin)}
 								class="token-icon"
 							/>
-							<span class="token-name">{coinDisplayLabel(txState.fromCoin.coin)}</span>
+							<span class="token-name">{coinDisplayLabel(txState.from.coin)}</span>
 						{:else}
 							<span class="token-name">Select</span>
 						{/if}
@@ -1038,15 +1026,15 @@
 					<span class="section-usd-approx">
 						{#if inputAmountUsd !== null}
 							≈ ${formatUsd(inputAmountUsd)}
-						{:else if pricesFailed && txState.fromCoin && txState.fromAmount && txState.fromAmount !== '0'}
+						{:else if pricesFailed && txState.from && txState.fromAmount && txState.fromAmount !== '0'}
 							<span class="price-unavailable">Price unavailable</span>
 						{/if}
 					</span>
 					{#if sameCoinError}
 						<span class="section-error-inline">Select a different token</span>
-					{:else if insufficientBalance && txState.fromCoin}
+					{:else if insufficientBalance && txState.from}
 						<span class="section-error-inline"
-							>Insufficient {coinDisplayLabel(txState.fromCoin.coin)} balance</span
+							>Insufficient {coinDisplayLabel(txState.from.coin)} balance</span
 						>
 					{:else if exceedsPoolDepth}
 						<span class="section-error-inline">Amount exceeds pool depth</span>
@@ -1073,8 +1061,8 @@
 				<div class="section-header">
 					<span class="section-label">You Receive</span>
 					<span class="section-header-center">
-						{#if txState.toNetwork}
-							<span class={['network-pill', { external: txState.toNetwork.value !== 'magi' }]}>{txState.toNetwork.label}</span>
+						{#if txState.to}
+							<span class={['network-pill', { external: txState.to.network.value !== 'magi' }]}>{txState.to.network.label}</span>
 						{/if}
 					</span>
 					<span class="section-balance sm-caption"></span>
@@ -1095,13 +1083,13 @@
 						{/key}
 					</div>
 					<button class="token-selector-btn" onclick={() => openDialog('to')}>
-						{#if txState.toCoin}
+						{#if txState.to}
 							<img
-								src={txState.toCoin.coin.icon}
-								alt={coinDisplayLabel(txState.toCoin.coin)}
+								src={txState.to.coin.icon}
+								alt={coinDisplayLabel(txState.to.coin)}
 								class="token-icon"
 							/>
-							<span class="token-name">{coinDisplayLabel(txState.toCoin.coin)}</span>
+							<span class="token-name">{coinDisplayLabel(txState.to.coin)}</span>
 						{:else}
 							<span class="token-name">Select</span>
 						{/if}
@@ -1112,7 +1100,7 @@
 					<span class="section-usd-approx">
 						{#if expectedOutputUsd !== null}
 							≈ ${formatUsd(expectedOutputUsd)}
-						{:else if pricesFailed && txState.toCoin && txState.toAmount && txState.toAmount !== '0'}
+						{:else if pricesFailed && txState.to && txState.toAmount && txState.toAmount !== '0'}
 							<span class="price-unavailable">Price unavailable</span>
 						{/if}
 					</span>
@@ -1120,7 +1108,7 @@
 			</div>
 
 			<!-- Route Info -->
-			{#if txState.fromCoin && txState.toCoin}
+			{#if txState.from && txState.to}
 				<div class="route-info">
 					<span class="route-tags">
 						<span class="tag native">Native</span>
@@ -1138,11 +1126,11 @@
 		<div class="deliver-to-card">
 			<span class="deliver-label">DELIVER TO</span>
 
-			{#if txState.toCoin}
+			{#if txState.to}
 				<div class="dest-header">
 					<CoinNetworkIcon
 						coin={toCoin}
-						network={txState.toNetwork ?? Network.magi}
+						network={txState.to?.network ?? Network.magi}
 						size={28}
 					/>
 					<h3>Where should {coinDisplayLabel(toCoin)} go?</h3>
@@ -1234,11 +1222,11 @@
 			</div>
 		</div>
 		<!-- Fees Section (collapsible) -->
-		{#if txState.fromCoin && txState.toCoin}
-			{@const fromDec = txState.fromCoin.coin.decimalPlaces}
-			{@const toDec = txState.toCoin.coin.decimalPlaces}
-			{@const fromUnit = coinDisplayLabel(txState.fromCoin.coin)}
-			{@const toUnit = coinDisplayLabel(txState.toCoin.coin)}
+		{#if txState.from && txState.to}
+			{@const fromDec = txState.from.coin.decimalPlaces}
+			{@const toDec = txState.to.coin.decimalPlaces}
+			{@const fromUnit = coinDisplayLabel(txState.from.coin)}
+			{@const toUnit = coinDisplayLabel(txState.to.coin)}
 			{@const hop1FeeCoin = swapResult?.hop1Fee
 				? swapResult.hop1Fee.asset === Coin.hbd.value
 					? Coin.hbd

--- a/src/lib/sendswap/stages/TransferOptions.svelte
+++ b/src/lib/sendswap/stages/TransferOptions.svelte
@@ -93,10 +93,8 @@
 	$effect(() => {
 		if (
 			txState.toUsername &&
-			txState.toNetwork &&
-			txState.toCoin &&
-			txState.fromCoin &&
-			txState.fromNetwork &&
+			txState.to &&
+			txState.from &&
 			txState.toAmount &&
 			inputAmt.amount > 0 &&
 			inputAmt.amount <= (max?.amount ?? Number.MAX_SAFE_INTEGER) &&
@@ -115,7 +113,7 @@
 		if (!auth.value) return;
 		Promise.all([
 			getLastPaidContact(toDid),
-			getLastPaidNetwork(txState.toNetwork?.value)
+			getLastPaidNetwork(txState.to?.network.value)
 		]).then(([paid, net]) => {
 			lastPaid = momentToLastPaidString(paid);
 			lastNetwork = momentToLastPaidString(net);
@@ -123,10 +121,10 @@
 	});
 
 	$effect(() => {
-		const newNetwork = txState.toNetwork;
+		const newNetwork = txState.to?.network;
 		const userNetworks = getRecipientNetworks(getDidFromUsername(txState.toUsername));
 		if (userNetworks.find((net) => net.value === newNetwork?.value)?.disabled) {
-			txState.toNetwork = Network.magi;
+			if (txState.to) txState.to = { coin: txState.to.coin, network: Network.magi };
 		}
 	});
 
@@ -148,23 +146,20 @@
 		swapOptions.from.map((opt) => ({
 			...opt.coin,
 			snippet: assetCard,
-			snippetData: { fromOpt: opt, net: txState.toNetwork, size: 'medium' }
+			snippetData: { fromOpt: opt, net: txState.to?.network, size: 'medium' }
 		}))
 	);
 
 	let isSwap = $derived(
-		txState.fromCoin &&
-			txState.toCoin &&
-			txState.fromCoin?.coin.value !== txState.toCoin?.coin.value
+		txState.from &&
+			txState.to &&
+			txState.from.coin.value !== txState.to.coin.value
 	);
 
 	// default to USD
 	$effect(() => {
-		if (isSwap && !txState.toCoin) {
-			txState.toCoin = {
-				coin: coins.usd,
-				networks: []
-			};
+		if (isSwap && !txState.to) {
+			txState.to = { coin: coins.usd, network: Network.magi };
 		}
 	});
 
@@ -175,12 +170,12 @@
 	// True when the selected from-asset is BTC on the Magi network so we know
 	// to offer SATS as an alternate denomination and sync max accordingly.
 	const isBtcOnMagi = $derived(
-		txState.fromCoin?.coin.value === Coin.btc.value &&
-			txState.fromNetwork?.value === Network.magi.value
+		txState.from?.coin.value === Coin.btc.value &&
+			txState.from?.network.value === Network.magi.value
 	);
 
 	$effect(() => {
-		const fromCoin = txState.fromCoin?.coin;
+		const fromCoin = txState.from?.coin;
 		let amountStr: string;
 		// SATS and BTC share the same raw integer unit — rewrap in BTC denomination
 		// before storing so the transaction builder always receives a BTC-format string.
@@ -197,13 +192,13 @@
 	// balance display stay visible for both SATS and BTC on Magi.
 	$effect(() => {
 		if (!isBtcOnMagi || inputAmt.coin.value === Coin.unk.value) return;
-		const balance = getBalanceAmount($accountBalance, txState.fromCoin!.coin, txState.fromNetwork!);
+		const balance = getBalanceAmount($accountBalance, txState.from!.coin, txState.from!.network);
 		max = new CoinAmount(balance.amount, inputAmt.coin, true);
 	});
 
 	let toSelf = $derived(
 		txState.toUsername === getUsernameFromAuth(auth) &&
-			txState.fromNetwork?.value === txState.toNetwork?.value
+			txState.from?.network.value === txState.to?.network.value
 	);
 
 	let assetOpen = $state(false);
@@ -220,14 +215,14 @@
 		if (getDidFromUsername(txState.toUsername).startsWith('did:pkh:eip155:1:')) {
 			return 'EVM accounts may only receive funds on Magi.';
 		}
-		if (txState.fromCoin?.coin.value === Coin.shbd.value) {
+		if (txState.from?.coin.value === Coin.shbd.value) {
 			return 'Cannot transfer sHBD to external networks.';
 		}
 		return 'This option is not available given your parameters.';
 	}
 	$effect(() => {
 		// read reactive fields to track changes
-		txState.toUsername; txState.fromCoin; txState.fromNetwork; txState.toCoin;
+		txState.toUsername; txState.from; txState.to?.coin;
 		untrack(() => {
 			const newOptions = solveToNetworks(txState);
 			const oldSet = new Set(toNetworkOptions.map((net) => net.value));
@@ -235,11 +230,10 @@
 			if (
 				newOptions.length === 0 &&
 				txState.toUsername &&
-				txState.fromCoin &&
-				txState.fromNetwork
+				txState.from
 			) {
-				transferError = `Cannot transfer ${txState.fromCoin.coin.label}
-					from ${txState.fromNetwork.label}
+				transferError = `Cannot transfer ${txState.from.coin.label}
+					from ${txState.from.network.label}
 					to ${txState.toDisplayName}.`;
 			} else {
 				transferError = '';
@@ -265,15 +259,28 @@
 				currentType === 'internal'
 					? Network.magi
 					: toNetworkOptions.find((net) => net.value !== Network.magi.value);
-			if (network?.value === txState.toNetwork?.value) return;
-			txState.toNetwork = network;
+			if (network?.value === txState.to?.network.value) return;
+			if (!network) {
+				txState.to = undefined;
+			} else if (txState.to) {
+				txState.to = { coin: txState.to.coin, network };
+			} else if (txState.from) {
+				txState.to = { coin: txState.from.coin, network };
+			}
 		});
 	});
 	$effect(() => {
-		txState.fromCoin;
+		txState.from?.coin;
 		untrack(() => {
-			if (txState.toCoin?.coin.value !== txState.fromCoin?.coin.value) {
-				txState.toCoin = txState.fromCoin;
+			if (txState.to?.coin.value !== txState.from?.coin.value) {
+				if (!txState.from) {
+					txState.to = undefined;
+				} else {
+					txState.to = {
+						coin: txState.from.coin,
+						network: txState.to?.network ?? Network.magi
+					};
+				}
 			}
 		});
 	});
@@ -300,7 +307,7 @@
 						| 'external',
 					label: `${net.value === Network.magi.value ? 'Internal' : 'External'} Transfer`,
 					to: net,
-					from: txState.fromNetwork,
+					from: txState.from?.network,
 					snippet: transferBar
 				}))
 				.sort((a, b) => (a.value === b.value ? 0 : a.value === 'internal' ? -1 : 1));
@@ -319,8 +326,8 @@
 	// BTC network-fee estimate (only relevant when the transfer settles out
 	// to BTC mainnet). Matches the math the VSC contract uses at unmap time.
 	const isToBtcMainnet = $derived(
-		txState.fromCoin?.coin.value === Coin.btc.value &&
-			txState.toNetwork?.value === Network.btcMainnet.value
+		txState.from?.coin.value === Coin.btc.value &&
+			txState.to?.network.value === Network.btcMainnet.value
 	);
 	let btcFeeEstimate = $state<BtcFeeEstimate | null>(null);
 	$effect(() => {
@@ -347,10 +354,10 @@
 	let inputId = $state('');
 
 	const coinOpts: CoinOnNetwork[] = $derived.by(() => {
-		if (!txState.fromCoin || !txState.fromNetwork) {
+		if (!txState.from) {
 			return [{ coin: Coin.unk, network: Network.unknown }];
 		}
-		const base: CoinOnNetwork[] = [{ coin: txState.fromCoin.coin, network: txState.fromNetwork }];
+		const base: CoinOnNetwork[] = [txState.from];
 		// Offer SATS as an alternate denomination alongside BTC on Magi
 		if (isBtcOnMagi) {
 			base.push({ coin: Coin.sats, network: Network.magi });
@@ -383,8 +390,8 @@
 		if (balanceCount === 0) return;
 
 		const currentCoinHasBalance =
-			txState.fromCoin &&
-			coinsWithBalance.some((item) => item.coin.value === txState.fromCoin?.coin.value);
+			txState.from &&
+			coinsWithBalance.some((item) => item.coin.value === txState.from?.coin.value);
 
 		if (currentCoinHasBalance) return;
 
@@ -392,10 +399,8 @@
 		const coinToSelect = hiveCoin || coinsWithBalance[0];
 
 		if (coinToSelect) {
-			txState.fromCoin = coinToSelect.coinOpt;
-			txState.fromNetwork = Network.magi;
-			txState.toCoin = coinToSelect.coinOpt;
-			txState.toNetwork = Network.magi;
+			txState.from = { coin: coinToSelect.coin, network: Network.magi };
+			txState.to = { coin: coinToSelect.coin, network: Network.magi };
 		}
 	});
 </script>
@@ -418,10 +423,10 @@
 				<div class="error">
 					No balance found on your account. Please make a deposit to get started.
 				</div>
-			{:else if txState.fromCoin && txState.fromNetwork}
+			{:else if txState.from}
 				<BalanceInfo
-					coin={txState.fromCoin.coin}
-					network={txState.fromNetwork}
+					coin={txState.from.coin}
+					network={txState.from.network}
 					size="large"
 					styleType="vertical"
 				/>
@@ -439,7 +444,7 @@
 			<AmountInput
 				bind:coinAmount={inputAmt}
 				{coinOpts}
-				expressIn={isBtcOnMagi ? undefined : txState.fromCoin?.coin}
+				expressIn={isBtcOnMagi ? undefined : txState.from?.coin}
 				maxAmount={max}
 				bind:id={inputId}
 			/>

--- a/src/lib/sendswap/stages/TransferOptions.svelte
+++ b/src/lib/sendswap/stages/TransferOptions.svelte
@@ -430,7 +430,6 @@
 					size="large"
 					styleType="vertical"
 				/>
-				<!-- <AssetInfo coinOpt={txState.fromCoin} size="medium" /> -->
 			{:else}
 				<span class="user-icon-placeholder"><Coins size="40" absoluteStrokeWidth={true} /></span>
 				Select Asset

--- a/src/lib/sendswap/stages/TransferOptions.svelte
+++ b/src/lib/sendswap/stages/TransferOptions.svelte
@@ -539,8 +539,7 @@
 		<SelectAssetFlattened
 			availableCoins={fromAssetObjs}
 			close={toggleAsset}
-			bind:coin={txState.fromCoin}
-			bind:network={txState.fromNetwork}
+			bind:selected={txState.from}
 			bind:max
 			externalNetwork={Network.hiveMainnet}
 		/>

--- a/src/lib/sendswap/stages/deposit/DepositOptions.svelte
+++ b/src/lib/sendswap/stages/deposit/DepositOptions.svelte
@@ -50,44 +50,52 @@
 		if (!lightningOpen) return;
 		untrack(() => {
 			toggleHiveMainnet(false);
-			const satsCoin = {
+			const satsCoin: AssetOption = {
 				coin: Coin.sats,
 				networks: [Network.magi]
 			};
 			const btcCoin = getFromOption(Coin.btc.value);
-			const shouldPreserveFromCoin =
-				txState.fromCoin &&
-				txState.fromCoin.networks?.some((n) => n.value === Network.lightning.value);
+
+			const fromAsset = txState.from ? getFromOption(txState.from.coin.value) : undefined;
+			const shouldPreserveFromCoin = !!fromAsset?.networks?.some(
+				(n) => n.value === Network.lightning.value
+			);
 
 			const hiveCoin = getToOption(Coin.hive.value);
 			const hbdCoin = getToOption(Coin.hbd.value);
 			let toCoinToUse: AssetOption | undefined = satsCoin; // default to Magi SATS
 			if (
-				txState.toCoin &&
-				(txState.toCoin.coin.value === Coin.hive.value ||
-					txState.toCoin.coin.value === Coin.hbd.value ||
-					txState.toCoin.coin.value === Coin.sats.value)
+				txState.to &&
+				(txState.to.coin.value === Coin.hive.value ||
+					txState.to.coin.value === Coin.hbd.value ||
+					txState.to.coin.value === Coin.sats.value)
 			) {
-				toCoinToUse = txState.toCoin;
+				// SATS isn't in swapOptions.to, so fall back to the local satsCoin
+				// rather than calling getToOption (which would return undefined).
+				toCoinToUse =
+					txState.to.coin.value === Coin.sats.value
+						? satsCoin
+						: getToOption(txState.to.coin.value);
 			} else if (
-				txState.fromCoin &&
-				(txState.fromCoin.coin.value === Coin.hive.value ||
-					txState.fromCoin.coin.value === Coin.hbd.value ||
-					txState.fromCoin.coin.value === Coin.sats.value)
+				txState.from &&
+				(txState.from.coin.value === Coin.hive.value ||
+					txState.from.coin.value === Coin.hbd.value ||
+					txState.from.coin.value === Coin.sats.value)
 			) {
 				toCoinToUse =
-					txState.fromCoin.coin.value === Coin.hive.value
+					txState.from.coin.value === Coin.hive.value
 						? hiveCoin
-						: txState.fromCoin.coin.value === Coin.hbd.value
+						: txState.from.coin.value === Coin.hbd.value
 							? hbdCoin
 							: satsCoin;
 			}
 
 			txState.rail = Network.lightning;
-			txState.fromNetwork = Network.lightning;
-			txState.fromCoin = shouldPreserveFromCoin ? txState.fromCoin : btcCoin;
-			txState.toNetwork = Network.magi;
-			txState.toCoin = toCoinToUse;
+			const newFromCoin = shouldPreserveFromCoin ? fromAsset : btcCoin;
+			txState.from = newFromCoin
+				? { coin: newFromCoin.coin, network: Network.lightning }
+				: undefined;
+			txState.to = toCoinToUse ? { coin: toCoinToUse.coin, network: Network.magi } : undefined;
 		});
 	});
 
@@ -115,25 +123,24 @@
 			// For Hive Mainnet deposit, default to HIVE (or HBD) without
 			// requiring a Magi balance — user deposits precisely because
 			// their Magi balance may be 0.
+			const fromAsset = txState.from ? getFromOption(txState.from.coin.value) : undefined;
 			let fromCoinToUse = hiveCoin;
-			if (
-				txState.fromCoin &&
-				txState.fromCoin.networks?.some((n) => n.value === Network.hiveMainnet.value)
-			) {
-				fromCoinToUse = txState.fromCoin;
+			if (fromAsset?.networks?.some((n) => n.value === Network.hiveMainnet.value)) {
+				fromCoinToUse = fromAsset;
 			} else if (
-				txState.toCoin &&
-				(txState.toCoin.coin.value === Coin.hive.value ||
-					txState.toCoin.coin.value === Coin.hbd.value)
+				txState.to &&
+				(txState.to.coin.value === Coin.hive.value || txState.to.coin.value === Coin.hbd.value)
 			) {
-				fromCoinToUse = txState.toCoin.coin.value === Coin.hive.value ? hiveCoin : hbdCoin;
+				fromCoinToUse = txState.to.coin.value === Coin.hive.value ? hiveCoin : hbdCoin;
 			}
 
 			txState.rail = Network.magi;
-			txState.fromNetwork = Network.hiveMainnet;
-			txState.toNetwork = Network.magi;
-			txState.fromCoin = fromCoinToUse;
-			txState.toCoin = fromCoinToUse;
+			txState.from = fromCoinToUse
+				? { coin: fromCoinToUse.coin, network: Network.hiveMainnet }
+				: undefined;
+			txState.to = fromCoinToUse
+				? { coin: fromCoinToUse.coin, network: Network.magi }
+				: undefined;
 		});
 	});
 

--- a/src/lib/sendswap/stages/deposit/DepositOptions.svelte
+++ b/src/lib/sendswap/stages/deposit/DepositOptions.svelte
@@ -90,7 +90,7 @@
 							: satsCoin;
 			}
 
-			txState.rail = Network.lightning;
+			// rail derives to lightning from from.network = lightning
 			const newFromCoin = shouldPreserveFromCoin ? fromAsset : btcCoin;
 			txState.from = newFromCoin
 				? { coin: newFromCoin.coin, network: Network.lightning }
@@ -134,7 +134,7 @@
 				fromCoinToUse = txState.to.coin.value === Coin.hive.value ? hiveCoin : hbdCoin;
 			}
 
-			txState.rail = Network.magi;
+			// rail derives to magi from { hiveMainnet → magi }
 			txState.from = fromCoinToUse
 				? { coin: fromCoinToUse.coin, network: Network.hiveMainnet }
 				: undefined;

--- a/src/lib/sendswap/stages/deposit/HiveMainnetDeposit.svelte
+++ b/src/lib/sendswap/stages/deposit/HiveMainnetDeposit.svelte
@@ -119,7 +119,6 @@
 							size="large"
 							styleType="vertical"
 						/>
-						<!-- <AssetInfo coinOpt={txState.fromCoin} size="medium" /> -->
 					{:else}
 						<span class="user-icon-placeholder"><Coins size="40" absoluteStrokeWidth={true} /></span
 						>

--- a/src/lib/sendswap/stages/deposit/HiveMainnetDeposit.svelte
+++ b/src/lib/sendswap/stages/deposit/HiveMainnetDeposit.svelte
@@ -45,19 +45,18 @@
 
 	let max = $state(new CoinAmount(0, Coin.hive));
 
-	// Update max when fromCoin or connectedBal changes (skip while asset picker is open)
+	// Update max when from or connectedBal changes (skip while asset picker is open)
 	$effect(() => {
 		if (assetOpen) return;
-		const fromCoin = txState.fromCoin;
-		const fromNetwork = txState.fromNetwork;
-		if (!open || !fromCoin || !fromNetwork) return;
-		if (fromNetwork.value !== Network.hiveMainnet.value) return;
+		const from = txState.from;
+		if (!open || !from) return;
+		if (from.network.value !== Network.hiveMainnet.value) return;
 
-		const coinValue = fromCoin.coin.value;
+		const coinValue = from.coin.value;
 		if (coinValue === Coin.hive.value || coinValue === Coin.hbd.value) {
 			const balance = $accountBalance.connectedBal?.[coinValue as 'hive' | 'hbd'];
 			if (balance !== undefined) {
-				max = new CoinAmount(balance, fromCoin.coin, true);
+				max = new CoinAmount(balance, from.coin, true);
 			}
 		}
 	});
@@ -73,18 +72,19 @@
 
 	const unkOpt = { coin: Coin.unk, network: Network.unknown };
 	const coinOptions: CoinOnNetwork[] = $derived(
-		txState.fromCoin && txState.fromNetwork
-			? [{ coin: txState.fromCoin.coin, network: txState.fromNetwork }]
-			: [unkOpt]
+		txState.from ? [txState.from] : [unkOpt]
 	);
 
 	let assetOpen = $state(false);
 	function toggleAsset(open = false) {
 		assetOpen = open;
-		// When closing asset picker, sync toCoin to match the newly selected fromCoin
+		// When closing asset picker, sync `to` coin to match the newly selected `from`
 		if (!open) {
-			if (txState.fromCoin && txState.toCoin?.coin?.value !== txState.fromCoin?.coin?.value) {
-				txState.toCoin = txState.fromCoin;
+			if (txState.from && txState.to?.coin.value !== txState.from.coin.value) {
+				txState.to = {
+					coin: txState.from.coin,
+					network: txState.to?.network ?? Network.magi
+				};
 			}
 		}
 	}
@@ -113,10 +113,10 @@
 			<label for="asset-card">Deposit From</label>
 			<ClickableCard onclick={() => toggleAsset(true)}>
 				<div class="asset-card">
-					{#if txState.fromCoin && txState.fromNetwork}
+					{#if txState.from}
 						<BalanceInfo
-							coin={txState.fromCoin.coin}
-							network={txState.fromNetwork}
+							coin={txState.from.coin}
+							network={txState.from.network}
 							size="large"
 							styleType="vertical"
 						/>
@@ -137,7 +137,7 @@
 					<AmountInput
 						bind:coinAmount
 						coinOpts={coinOptions}
-						expressIn={txState.fromCoin?.coin}
+						expressIn={txState.from?.coin}
 						maxAmount={max}
 						bind:id={inputId}
 					/>

--- a/src/lib/sendswap/stages/deposit/HiveMainnetDeposit.svelte
+++ b/src/lib/sendswap/stages/deposit/HiveMainnetDeposit.svelte
@@ -14,7 +14,7 @@
 		type CoinOnNetwork,
 		type CoinOptions
 	} from '$lib/sendswap/utils/sendOptions';
-	import { useTxState } from '$lib/sendswap/utils/txState.svelte';
+	import { useDepositState } from '$lib/sendswap/utils/txState.svelte';
 	import { accountBalance } from '$lib/stores/currentBalance';
 	import Select from '$lib/zag/Select.svelte';
 	import { ArrowLeft, ArrowRightLeft, Coins } from '@lucide/svelte';
@@ -26,7 +26,7 @@
 		secondaryMenu = $bindable()
 	}: { editStage: (complete: boolean) => void; open: boolean; secondaryMenu: boolean } = $props();
 
-	const txState = useTxState();
+	const txState = useDepositState();
 	const auth = $derived(getAuth()());
 
 	let coinAmount = $state(new CoinAmount(0, Coin.unk));

--- a/src/lib/sendswap/stages/deposit/HiveMainnetDeposit.svelte
+++ b/src/lib/sendswap/stages/deposit/HiveMainnetDeposit.svelte
@@ -102,8 +102,7 @@
 	<SelectAssetFlattened
 		availableCoins={[]}
 		close={toggleAsset}
-		bind:coin={txState.fromCoin}
-		bind:network={txState.fromNetwork}
+		bind:selected={txState.from}
 		bind:max
 		externalNetwork={Network.hiveMainnet}
 	/>

--- a/src/lib/sendswap/stages/deposit/LightningDeposit.svelte
+++ b/src/lib/sendswap/stages/deposit/LightningDeposit.svelte
@@ -170,7 +170,6 @@
 						size="large"
 						styleType="vertical"
 					/>
-					<!-- <AssetInfo coinOpt={txState.fromCoin} size="medium" /> -->
 				{:else}
 					<span class="user-icon-placeholder"><Coins size="40" absoluteStrokeWidth={true} /></span>
 					Select Destination Account

--- a/src/lib/sendswap/stages/deposit/LightningDeposit.svelte
+++ b/src/lib/sendswap/stages/deposit/LightningDeposit.svelte
@@ -154,8 +154,7 @@
 	<SelectAssetFlattened
 		availableCoins={[Coin.hive, Coin.hbd, Coin.sats]}
 		close={toggleAsset}
-		bind:coin={txState.toCoin}
-		bind:network={txState.toNetwork}
+		bind:selected={txState.to}
 		isTo
 	/>
 {/if}

--- a/src/lib/sendswap/stages/deposit/LightningDeposit.svelte
+++ b/src/lib/sendswap/stages/deposit/LightningDeposit.svelte
@@ -24,10 +24,10 @@
 
 	// Derived primitives from state — only change when the actual values change,
 	// preventing effects from re-running on every unrelated state mutation
-	const _fromCoinValue = $derived(txState.fromCoin?.coin?.value);
-	const _toCoinValue = $derived(txState.toCoin?.coin?.value);
-	const _fromNetwork = $derived(txState.fromNetwork?.value);
-	const _toNetwork = $derived(txState.toNetwork?.value);
+	const _fromCoinValue = $derived(txState.from?.coin.value);
+	const _toCoinValue = $derived(txState.to?.coin.value);
+	const _fromNetwork = $derived(txState.from?.network.value);
+	const _toNetwork = $derived(txState.to?.network.value);
 	// Track toAmount so validation blocks Review until async conversion completes
 	const _toAmount = $derived(txState.toAmount);
 
@@ -42,7 +42,7 @@
 		const coinVal = coinAmount.coin.value;
 		const coinAmountSnapshot = coinAmount;
 		untrack(() => {
-			if (!txState.fromCoin) return;
+			if (!txState.from) return;
 
 			// Compute fromAmount
 			if (coinVal === fromCoinVal) {
@@ -51,7 +51,7 @@
 				}
 			} else {
 				coinAmountSnapshot
-					.convertTo(txState.fromCoin.coin, Network.lightning)
+					.convertTo(txState.from.coin, Network.lightning)
 					.then((converted) => {
 						const convertedAmt = converted.toAmountString();
 						if (txState.fromAmount !== convertedAmt) {
@@ -61,7 +61,7 @@
 			}
 
 			// Compute toAmount
-			if (!txState.toCoin || !toCoinVal) return;
+			if (!txState.to || !toCoinVal) return;
 			if (coinVal === toCoinVal) {
 				if (amt !== txState.toAmount) {
 					txState.toAmount = amt;
@@ -76,7 +76,7 @@
 				});
 			} else {
 				coinAmountSnapshot
-					.convertTo(txState.toCoin.coin, Network.lightning)
+					.convertTo(txState.to.coin, Network.lightning)
 					.then((converted) => {
 						const convertedAmt = converted.toAmountString();
 						if (txState.toAmount !== convertedAmt) {
@@ -119,11 +119,8 @@
 		// Read derived primitives to track only actual value changes
 		const fCoin = _fromCoinValue;
 		const fNet = _fromNetwork;
-		if (fCoin && fNet && txState.fromCoin && txState.fromNetwork) {
-			result.push({
-				coin: txState.fromCoin.coin,
-				network: txState.fromNetwork
-			});
+		if (fCoin && fNet && txState.from) {
+			result.push(txState.from);
 		}
 		if (result.map((coinOpt) => coinOpt.coin.value).includes(Coin.btc.value)) {
 			result.push({ coin: Coin.sats, network: Network.lightning });
@@ -167,10 +164,10 @@
 		<label for="asset-card">Deposit To</label>
 		<ClickableCard onclick={() => toggleAsset(true)}>
 			<div class="asset-card">
-				{#if txState.toCoin && txState.toNetwork}
+				{#if txState.to}
 					<BalanceInfo
-						coin={txState.toCoin.coin}
-						network={txState.toNetwork}
+						coin={txState.to.coin}
+						network={txState.to.network}
 						size="large"
 						styleType="vertical"
 					/>

--- a/src/lib/sendswap/stages/withdraw/BitcoinMainnetWithdraw.svelte
+++ b/src/lib/sendswap/stages/withdraw/BitcoinMainnetWithdraw.svelte
@@ -92,12 +92,8 @@
 
 	let max = $state(new CoinAmount(0, Coin.btc));
 	$effect(() => {
-		if (!open || !txState.fromCoin || !txState.fromNetwork) return;
-		max = getBalanceAmount(
-			$accountBalance,
-			txState.fromCoin.coin,
-			txState.fromNetwork
-		);
+		if (!open || !txState.from) return;
+		max = getBalanceAmount($accountBalance, txState.from.coin, txState.from.network);
 	});
 
 	// Sync coinAmount → state
@@ -117,8 +113,7 @@
 		const valid = !!(
 			isBtcAddressValid &&
 			!depositBlock.blocked &&
-			txState.fromCoin &&
-			txState.fromNetwork &&
+			txState.from &&
 			coinAmount.amount > 0 &&
 			coinAmount.amount <= (max?.amount ?? Number.MAX_SAFE_INTEGER)
 		);
@@ -126,9 +121,7 @@
 	});
 
 	const coinOptions: CoinOnNetwork[] = $derived(
-		txState.fromCoin && txState.fromNetwork
-			? [{ coin: txState.fromCoin.coin, network: txState.fromNetwork }]
-			: [{ coin: Coin.btc, network: Network.magi }]
+		txState.from ? [txState.from] : [{ coin: Coin.btc, network: Network.magi }]
 	);
 </script>
 
@@ -156,7 +149,7 @@
 				<AmountInput
 					bind:coinAmount
 					coinOpts={coinOptions}
-					expressIn={txState.fromCoin?.coin ?? Coin.btc}
+					expressIn={txState.from?.coin ?? Coin.btc}
 					maxAmount={max}
 					bind:id={inputId}
 				/>

--- a/src/lib/sendswap/stages/withdraw/HiveMainnetWithdraw.svelte
+++ b/src/lib/sendswap/stages/withdraw/HiveMainnetWithdraw.svelte
@@ -129,18 +129,14 @@
 
 	let max = $state(new CoinAmount(0, Coin.hive));
 
-	// Update max when fromCoin changes for magi network
+	// Update max when from changes for magi network
 	$effect(() => {
-		if (!open || !txState.fromCoin || !txState.fromNetwork) return;
-		if (txState.fromNetwork.value !== Network.magi.value) return;
+		if (!open || !txState.from) return;
+		if (txState.from.network.value !== Network.magi.value) return;
 
-		const coinValue = txState.fromCoin.coin.value;
+		const coinValue = txState.from.coin.value;
 		if (coinValue === Coin.hive.value || coinValue === Coin.hbd.value) {
-			max = getBalanceAmount(
-				$accountBalance,
-				txState.fromCoin.coin,
-				txState.fromNetwork
-			);
+			max = getBalanceAmount($accountBalance, txState.from.coin, txState.from.network);
 		}
 	});
 	// Validate Hive account for EVM users
@@ -192,9 +188,8 @@
 	$effect(() => {
 		if (!open) return;
 		const baseValidation = !!(
-			txState.fromCoin &&
-			txState.toCoin &&
-			txState.fromNetwork &&
+			txState.from &&
+			txState.to &&
 			coinAmount.amount > 0 &&
 			coinAmount.amount <= (max?.amount ?? Number.MAX_SAFE_INTEGER)
 		);
@@ -210,18 +205,19 @@
 
 	const unkOpt = { coin: Coin.unk, network: Network.unknown };
 	const coinOptions: CoinOnNetwork[] = $derived(
-		txState.fromCoin && txState.fromNetwork
-			? [{ coin: txState.fromCoin.coin, network: txState.fromNetwork }]
-			: [unkOpt]
+		txState.from ? [txState.from] : [unkOpt]
 	);
 
 	let assetOpen = $state(false);
 	function toggleAsset(open = false) {
 		assetOpen = open;
-		// When closing asset picker, sync toCoin to match the newly selected fromCoin
+		// When closing asset picker, sync `to` coin to match the newly selected `from`
 		if (!open) {
-			if (txState.fromCoin && txState.toCoin?.coin?.value !== txState.fromCoin?.coin?.value) {
-				txState.toCoin = txState.fromCoin;
+			if (txState.from && txState.to?.coin.value !== txState.from.coin.value) {
+				txState.to = {
+					coin: txState.from.coin,
+					network: txState.to?.network ?? Network.hiveMainnet
+				};
 			}
 		}
 	}
@@ -264,10 +260,10 @@
 				<label for="asset-card">Withdraw From</label>
 				<ClickableCard onclick={() => toggleAsset(true)}>
 					<div class="asset-card">
-						{#if txState.fromCoin && txState.fromNetwork}
+						{#if txState.from}
 							<BalanceInfo
-								coin={txState.fromCoin.coin}
-								network={txState.fromNetwork}
+								coin={txState.from.coin}
+								network={txState.from.network}
 								size="large"
 								styleType="vertical"
 							/>
@@ -288,7 +284,7 @@
 						<AmountInput
 							bind:coinAmount
 							coinOpts={coinOptions}
-							expressIn={txState.fromCoin?.coin}
+							expressIn={txState.from?.coin}
 							maxAmount={max}
 							onAmountChange={syncAmountFromInput}
 							bind:id={inputId}

--- a/src/lib/sendswap/stages/withdraw/HiveMainnetWithdraw.svelte
+++ b/src/lib/sendswap/stages/withdraw/HiveMainnetWithdraw.svelte
@@ -235,8 +235,7 @@
 	<SelectAssetFlattened
 		availableCoins={[Coin.hive, Coin.hbd]}
 		close={toggleAsset}
-		bind:coin={txState.fromCoin}
-		bind:network={txState.fromNetwork}
+		bind:selected={txState.from}
 		bind:max
 	/>
 {:else}

--- a/src/lib/sendswap/stages/withdraw/KeepsatsWithdraw.svelte
+++ b/src/lib/sendswap/stages/withdraw/KeepsatsWithdraw.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import AmountInput from '$lib/currency/AmountInput.svelte';
-	import { CoinAmount } from '$lib/currency/CoinAmount';
+	import { CoinAmount, isValidAmountString } from '$lib/currency/CoinAmount';
 	import { Coin, Network, type CoinOnNetwork } from '$lib/sendswap/utils/sendOptions';
 	import { getFee } from '$lib/sendswap/utils/sendUtils';
 	import { useWithdrawState } from '$lib/sendswap/utils/txState.svelte';
@@ -110,7 +110,7 @@
 		// gate the Withdraw button stayed enabled for amounts exceeding the
 		// available balance (matches the BitcoinMainnetWithdraw pattern).
 		const maxAmt = max.amount;
-		const hasToAmount = !!_toAmount && _toAmount !== '0';
+		const hasToAmount = isValidAmountString(_toAmount);
 		untrack(() => {
 			if (
 				hasCoins &&

--- a/src/lib/sendswap/stages/withdraw/KeepsatsWithdraw.svelte
+++ b/src/lib/sendswap/stages/withdraw/KeepsatsWithdraw.svelte
@@ -15,10 +15,10 @@
 	let inputId = $state('');
 
 	// Derived primitives from state
-	const _fromCoinValue = $derived(txState.fromCoin?.coin?.value);
-	const _toCoinValue = $derived(txState.toCoin?.coin?.value);
-	const _fromNetwork = $derived(txState.fromNetwork?.value);
-	const _toNetwork = $derived(txState.toNetwork?.value);
+	const _fromCoinValue = $derived(txState.from?.coin.value);
+	const _toCoinValue = $derived(txState.to?.coin.value);
+	const _fromNetwork = $derived(txState.from?.network.value);
+	const _toNetwork = $derived(txState.to?.network.value);
 	const _toAmount = $derived(txState.toAmount);
 
 	// Sync coinAmount → fromAmount, toAmount, fee atomically (following LightningDeposit pattern)
@@ -31,7 +31,7 @@
 		const coinVal = coinAmount.coin.value;
 		const coinAmountSnapshot = coinAmount;
 		untrack(() => {
-			if (!txState.fromCoin) return;
+			if (!txState.from) return;
 
 			// Compute fromAmount
 			if (coinVal === fromCoinVal) {
@@ -40,7 +40,7 @@
 				}
 			} else {
 				coinAmountSnapshot
-					.convertTo(txState.fromCoin.coin, Network.lightning)
+					.convertTo(txState.from.coin, Network.lightning)
 					.then((converted) => {
 						const convertedAmt = converted.toAmountString();
 						if (txState.fromAmount !== convertedAmt) {
@@ -50,7 +50,7 @@
 			}
 
 			// Compute toAmount
-			if (!txState.toCoin || !toCoinVal) return;
+			if (!txState.to || !toCoinVal) return;
 			if (coinVal === toCoinVal) {
 				if (amt !== txState.toAmount) {
 					txState.toAmount = amt;
@@ -66,7 +66,7 @@
 				});
 			} else {
 				coinAmountSnapshot
-					.convertTo(txState.toCoin.coin, Network.lightning)
+					.convertTo(txState.to.coin, Network.lightning)
 					.then((converted) => {
 						const convertedAmt = converted.toAmountString();
 						if (txState.toAmount !== convertedAmt) {
@@ -91,9 +91,9 @@
 	let max = $state(new CoinAmount(0, Coin.sats));
 
 	$effect(() => {
-		if (!open || !txState.fromCoin || !txState.fromNetwork) return;
+		if (!open || !txState.from) return;
 		const isSats = coinAmount.coin.value === Coin.sats.value;
-		const balance = getBalanceAmount($accountBalance, txState.fromCoin.coin, txState.fromNetwork);
+		const balance = getBalanceAmount($accountBalance, txState.from.coin, txState.from.network);
 		max = isSats
 			? new CoinAmount(balance.amount, Coin.sats, true)
 			: new CoinAmount(balance.amount, Coin.btc, true);
@@ -132,11 +132,8 @@
 		let result: CoinOnNetwork[] = [];
 		const fCoin = _fromCoinValue;
 		const fNet = _fromNetwork;
-		if (fCoin && fNet && txState.fromCoin && txState.fromNetwork) {
-			result.push({
-				coin: txState.fromCoin.coin,
-				network: txState.fromNetwork
-			});
+		if (fCoin && fNet && txState.from) {
+			result.push(txState.from);
 		}
 		if (result.map((coinOpt) => coinOpt.coin.value).includes(Coin.btc.value)) {
 			result.push({ coin: Coin.sats, network: Network.magi });

--- a/src/lib/sendswap/stages/withdraw/LightningWithdraw.svelte
+++ b/src/lib/sendswap/stages/withdraw/LightningWithdraw.svelte
@@ -4,7 +4,7 @@
 	import PillButton from '$lib/PillButton.svelte';
 	import BalanceInfo from '$lib/sendswap/components/info/BalanceInfo.svelte';
 	import { getToOption, Coin, Network, type CoinOptions, type AssetOption } from '$lib/sendswap/utils/sendOptions';
-	import { useTxState } from '$lib/sendswap/utils/txState.svelte';
+	import { useWithdrawState } from '$lib/sendswap/utils/txState.svelte';
 	import { accountBalance, getBalanceAmount } from '$lib/stores/currentBalance';
 	import Select from '$lib/zag/Select.svelte';
 	import { ArrowRightLeft } from '@lucide/svelte';
@@ -12,21 +12,22 @@
 
 	let { editStage, open }: { editStage: (complete: boolean) => void; open: boolean } = $props();
 
-	const txState = useTxState();
+	const txState = useWithdrawState();
 
 	let amount = $state('');
 	let lightningAddress = $state('');
 
 	$effect(() => {
 		if (!open) return;
-		if (!txState.toCoin) return;
-		if (shownCoin.coin.value === txState.toCoin.coin.value) {
-			const amt = new CoinAmount(amount, txState.toCoin.coin).toAmountString();
+		if (!txState.to) return;
+		const toCoin = txState.to.coin;
+		if (shownCoin.coin.value === toCoin.value) {
+			const amt = new CoinAmount(amount, toCoin).toAmountString();
 			if (amt !== txState.toAmount)
 				txState.toAmount = txState.fromAmount = amt;
 		} else {
 			new CoinAmount(amount, shownCoin.coin)
-				.convertTo(txState.toCoin.coin, Network.lightning)
+				.convertTo(toCoin, Network.lightning)
 				.then((amt) => {
 					if (txState.toAmount !== amt.toAmountString()) {
 						txState.toAmount = txState.fromAmount = amt.toAmountString();
@@ -48,20 +49,18 @@
 	];
 
 	const max = $derived.by(() => {
-		const coin = txState.fromCoin?.coin;
-		const network = txState.fromNetwork;
-		if (!coin || !network) return;
-		return getBalanceAmount($accountBalance, coin, network);
+		const from = txState.from;
+		if (!from) return;
+		return getBalanceAmount($accountBalance, from.coin, from.network);
 	});
 
 	const amountNumber = $derived(parseFloat(amount));
 	$effect(() => {
 		if (!open) return;
 		if (
-			txState.fromCoin &&
-			txState.toCoin &&
+			txState.from &&
+			txState.to &&
 			txState.toAmount &&
-			txState.toNetwork &&
 			lightningAddress &&
 			amountNumber > 0 &&
 			amountNumber <= (max?.toNumber() ?? Number.MAX_SAFE_INTEGER)
@@ -74,8 +73,10 @@
 
 	let possibleCoins: CoinOptions = $derived.by(() => {
 		let result: CoinOptions = [{ coin: Coin.usd, networks: [] }];
-		if (txState.toCoin) {
-			result = [txState.toCoin, ...result];
+		if (txState.to) {
+			// Synthesize an AssetOption from the CoinOnNetwork so downstream
+			// (shownCoin, AmountInput) keeps the {coin, networks} shape it expects.
+			result = [{ coin: txState.to.coin, networks: [txState.to.network] }, ...result];
 		}
 		return result;
 	});
@@ -107,7 +108,9 @@
 	});
 	let shownIndex = $state(0);
 	let shownCoin: AssetOption = $state(
-		txState.toCoin ?? { coin: Coin.usd, networks: [] }
+		txState.to
+			? { coin: txState.to.coin, networks: [txState.to.network] }
+			: { coin: Coin.usd, networks: [] }
 	);
 	function cycleShown() {
 		shownIndex = (shownIndex + 1) % possibleCoins.length;
@@ -116,8 +119,11 @@
 
 	$effect(() => {
 		if (open) {
-			txState.fromNetwork = Network.magi;
-			txState.toNetwork = Network.lightning;
+			// Lightning withdraw rail: from on magi → to on lightning. Parent
+			// (WithdrawOptions) sets both before this mounts; these writes are
+			// defensive in case the network drifts mid-flow.
+			if (txState.from) txState.from = { coin: txState.from.coin, network: Network.magi };
+			if (txState.to) txState.to = { coin: txState.to.coin, network: Network.lightning };
 			txState.toUsername = lightningAddress;
 		}
 	});
@@ -134,7 +140,7 @@
 				<AmountInput
 					bind:amount
 					coinOpt={shownCoin}
-					network={txState.toNetwork}
+					network={txState.to?.network}
 					maxAmount={max}
 					id="withdraw-amount"
 				/>
@@ -151,11 +157,23 @@
 			<span class="label-like">Withdraw Asset</span>
 			<Select
 				items={toOptions}
-				initial={txState.toCoin?.coin.value}
+				initial={txState.to?.coin.value}
 				onValueChange={(details) => {
-					if (open) {
-						txState.toCoin = txState.fromCoin = getToOption(details.value[0]);
+					if (!open) return;
+					const opt = getToOption(details.value[0]);
+					if (!opt) {
+						txState.to = undefined;
+						txState.from = undefined;
+						return;
 					}
+					txState.to = {
+						coin: opt.coin,
+						network: txState.to?.network ?? Network.lightning
+					};
+					txState.from = {
+						coin: opt.coin,
+						network: txState.from?.network ?? Network.magi
+					};
 				}}
 				styleType="dropdown"
 				placeholder="Select Asset"

--- a/src/lib/sendswap/stages/withdraw/WithdrawOptions.svelte
+++ b/src/lib/sendswap/stages/withdraw/WithdrawOptions.svelte
@@ -84,7 +84,7 @@
 				coinToUse = txState.from.coin;
 			}
 
-			txState.rail = Network.magi;
+			// rail derives to magi from { magi → hiveMainnet }
 			txState.from = coinToUse ? { coin: coinToUse, network: Network.magi } : undefined;
 			txState.to = coinToUse ? { coin: coinToUse, network: Network.hiveMainnet } : undefined;
 		});
@@ -98,7 +98,7 @@
 					coinOpt.coin.value === Coin.btc.value &&
 					coinOpt.networks.some((n) => n.value === Network.magi.value)
 			);
-			txState.rail = Network.magi;
+			// rail derives to magi from { magi → btcMainnet }
 			txState.from = btcCoin ? { coin: btcCoin.coin, network: Network.magi } : undefined;
 			txState.to = btcCoin ? { coin: btcCoin.coin, network: Network.btcMainnet } : undefined;
 		});
@@ -115,7 +115,7 @@
 			// Find BTC in to-coins without requiring lightning in networks,
 			// since lightning is the toNetwork and is set separately below.
 			const btcCoinTo = getToOption(Coin.btc.value);
-			txState.rail = Network.lightning;
+			// rail derives to lightning from to.network = lightning
 			txState.from = btcCoinFrom ? { coin: btcCoinFrom.coin, network: Network.magi } : undefined;
 			txState.to = btcCoinTo ? { coin: btcCoinTo.coin, network: Network.lightning } : undefined;
 		});

--- a/src/lib/sendswap/stages/withdraw/WithdrawOptions.svelte
+++ b/src/lib/sendswap/stages/withdraw/WithdrawOptions.svelte
@@ -68,21 +68,25 @@
 				hbdCoin && scanForBalance([{ coin: hbdCoin.coin, network: Network.magi }]) !== undefined
 			);
 
-			let fromCoinToUse = hiveHasBalance ? hiveCoin : hbdHasBalance ? hbdCoin : hiveCoin;
+			// Prefer the user's current selection if it's a valid Magi HIVE/HBD;
+			// otherwise default by balance.
+			let coinToUse: Coin | undefined = hiveHasBalance
+				? hiveCoin?.coin
+				: hbdHasBalance
+					? hbdCoin?.coin
+					: hiveCoin?.coin;
 			if (
-				txState.fromCoin &&
-				txState.fromCoin.networks?.some((n) => n.value === Network.magi.value) &&
-				(txState.fromCoin.coin.value === Coin.hive.value ||
-					txState.fromCoin.coin.value === Coin.hbd.value)
+				txState.from &&
+				txState.from.network.value === Network.magi.value &&
+				(txState.from.coin.value === Coin.hive.value ||
+					txState.from.coin.value === Coin.hbd.value)
 			) {
-				fromCoinToUse = txState.fromCoin;
+				coinToUse = txState.from.coin;
 			}
 
 			txState.rail = Network.magi;
-			txState.fromNetwork = Network.magi;
-			txState.fromCoin = fromCoinToUse;
-			txState.toNetwork = Network.hiveMainnet;
-			txState.toCoin = fromCoinToUse;
+			txState.from = coinToUse ? { coin: coinToUse, network: Network.magi } : undefined;
+			txState.to = coinToUse ? { coin: coinToUse, network: Network.hiveMainnet } : undefined;
 		});
 	});
 
@@ -95,10 +99,8 @@
 					coinOpt.networks.some((n) => n.value === Network.magi.value)
 			);
 			txState.rail = Network.magi;
-			txState.fromNetwork = Network.magi;
-			txState.fromCoin = btcCoin;
-			txState.toNetwork = Network.btcMainnet;
-			txState.toCoin = btcCoin;
+			txState.from = btcCoin ? { coin: btcCoin.coin, network: Network.magi } : undefined;
+			txState.to = btcCoin ? { coin: btcCoin.coin, network: Network.btcMainnet } : undefined;
 		});
 	});
 
@@ -114,10 +116,8 @@
 			// since lightning is the toNetwork and is set separately below.
 			const btcCoinTo = getToOption(Coin.btc.value);
 			txState.rail = Network.lightning;
-			txState.fromNetwork = Network.magi;
-			txState.fromCoin = btcCoinFrom;
-			txState.toNetwork = Network.lightning;
-			txState.toCoin = btcCoinTo;
+			txState.from = btcCoinFrom ? { coin: btcCoinFrom.coin, network: Network.magi } : undefined;
+			txState.to = btcCoinTo ? { coin: btcCoinTo.coin, network: Network.lightning } : undefined;
 		});
 	});
 

--- a/src/lib/sendswap/utils/broadcastDecision.test.ts
+++ b/src/lib/sendswap/utils/broadcastDecision.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tier-C test for the broadcast decision logic extracted from StepsMachine.
+ *
+ * Each test pins what `send()` would be invoked with (or whether the v4v
+ * popup opens, or whether we bail with an error) for a given (txState, txType)
+ * combination. These are the contracts that every transaction flow must
+ * satisfy at broadcast time — a migration regression here ships a swap to
+ * the wrong rail.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { decideBroadcast } from './broadcastDecision';
+import {
+	SwapTxState,
+	TransferTxState,
+	DepositTxState,
+	WithdrawTxState
+} from './txState.svelte';
+import { Coin, Network } from './sendOptions';
+
+// ─── Error cases ─────────────────────────────────────────────────────────────
+
+describe('decideBroadcast — error cases', () => {
+	it('returns error when both from and to are unset (transfer)', () => {
+		const state = new TransferTxState();
+		const d = decideBroadcast(state, 'transfer');
+		expect(d).toEqual({ action: 'error', message: 'Required field undefined.' });
+	});
+
+	it('returns error when from is unset (swap — no auto-default for swap)', () => {
+		const state = new SwapTxState();
+		state.to = { coin: Coin.hbd, network: Network.magi };
+		const d = decideBroadcast(state, 'swap');
+		expect(d.action).toBe('error');
+	});
+});
+
+// ─── Default-to logic for deposit/withdraw ───────────────────────────────────
+
+describe('decideBroadcast — default-to logic', () => {
+	it('deposit with from set but to undefined → defaults to.network = magi', () => {
+		const state = new DepositTxState();
+		state.from = { coin: Coin.hive, network: Network.hiveMainnet };
+		const d = decideBroadcast(state, 'deposit');
+		expect(state.to).toEqual({ coin: Coin.hive, network: Network.magi });
+		expect(d.action).toBe('send');
+	});
+
+	it('withdraw with from set but to undefined → defaults to.network = hiveMainnet', () => {
+		const state = new WithdrawTxState();
+		state.from = { coin: Coin.hive, network: Network.magi };
+		const d = decideBroadcast(state, 'withdraw');
+		expect(state.to).toEqual({ coin: Coin.hive, network: Network.hiveMainnet });
+		expect(d.action).toBe('send');
+	});
+
+	it('swap with from set but to undefined → error (no auto-default for swap)', () => {
+		const state = new SwapTxState();
+		state.from = { coin: Coin.hive, network: Network.magi };
+		const d = decideBroadcast(state, 'swap');
+		expect(state.to).toBeUndefined();
+		expect(d.action).toBe('error');
+	});
+
+	it('transfer with from set but to undefined → error (no auto-default for transfer)', () => {
+		const state = new TransferTxState();
+		state.from = { coin: Coin.hive, network: Network.magi };
+		const d = decideBroadcast(state, 'transfer');
+		expect(state.to).toBeUndefined();
+		expect(d.action).toBe('error');
+	});
+});
+
+// ─── Broadcast intermediary by flow ──────────────────────────────────────────
+
+describe('decideBroadcast — broadcast intermediary per flow', () => {
+	it('internal transfer (HIVE magi→magi) → send via magi', () => {
+		const state = new TransferTxState();
+		state.from = { coin: Coin.hive, network: Network.magi };
+		state.to = { coin: Coin.hive, network: Network.magi };
+		expect(decideBroadcast(state, 'transfer')).toEqual({
+			action: 'send',
+			intermediary: Network.magi
+		});
+	});
+
+	it('internal swap (HIVE→HBD on magi) → send via magi', () => {
+		const state = new SwapTxState();
+		state.from = { coin: Coin.hive, network: Network.magi };
+		state.to = { coin: Coin.hbd, network: Network.magi };
+		expect(decideBroadcast(state, 'swap')).toEqual({
+			action: 'send',
+			intermediary: Network.magi
+		});
+	});
+
+	it('cross-chain swap (BTC mainnet → HIVE hiveMainnet) → send via magi (per docs.magi.eco)', () => {
+		const state = new SwapTxState();
+		state.from = { coin: Coin.btc, network: Network.btcMainnet };
+		state.to = { coin: Coin.hive, network: Network.hiveMainnet };
+		const d = decideBroadcast(state, 'swap');
+		expect(d).toEqual({ action: 'send', intermediary: Network.magi });
+	});
+
+	it('Hive Mainnet deposit (hiveMainnet → magi) → send via magi', () => {
+		const state = new DepositTxState();
+		state.from = { coin: Coin.hive, network: Network.hiveMainnet };
+		state.to = { coin: Coin.hive, network: Network.magi };
+		expect(decideBroadcast(state, 'deposit')).toEqual({
+			action: 'send',
+			intermediary: Network.magi
+		});
+	});
+
+	it('Hive Mainnet withdraw (magi → hiveMainnet) → send via magi', () => {
+		const state = new WithdrawTxState();
+		state.from = { coin: Coin.hive, network: Network.magi };
+		state.to = { coin: Coin.hive, network: Network.hiveMainnet };
+		expect(decideBroadcast(state, 'withdraw')).toEqual({
+			action: 'send',
+			intermediary: Network.magi
+		});
+	});
+
+	it('BTC Mainnet withdraw (magi → btcMainnet) → send via magi', () => {
+		const state = new WithdrawTxState();
+		state.from = { coin: Coin.btc, network: Network.magi };
+		state.to = { coin: Coin.btc, network: Network.btcMainnet };
+		expect(decideBroadcast(state, 'withdraw')).toEqual({
+			action: 'send',
+			intermediary: Network.magi
+		});
+	});
+
+	it('Keepsats withdraw (magi → lightning) → send via lightning (withdraw bypasses v4v popup)', () => {
+		// Lightning withdraw is the one case where intermediary === lightning but
+		// the v4v popup is NOT opened — `send()` handles the lightning broadcast
+		// directly. The popup is only for deposits / swaps going IN to lightning.
+		const state = new WithdrawTxState();
+		state.from = { coin: Coin.btc, network: Network.magi };
+		state.to = { coin: Coin.btc, network: Network.lightning };
+		const d = decideBroadcast(state, 'withdraw');
+		expect(d).toEqual({ action: 'send', intermediary: Network.lightning });
+	});
+});
+
+// ─── V4V popup branch ────────────────────────────────────────────────────────
+
+describe('decideBroadcast — v4v popup branch', () => {
+	it('Lightning deposit (from.network = lightning) → v4v on deposit', () => {
+		const state = new DepositTxState();
+		state.from = { coin: Coin.btc, network: Network.lightning };
+		state.to = { coin: Coin.hive, network: Network.magi };
+		expect(decideBroadcast(state, 'deposit')).toEqual({ action: 'v4v' });
+	});
+
+	it('Lightning-routed swap (from.network = lightning) → v4v on swap', () => {
+		const state = new SwapTxState();
+		state.from = { coin: Coin.btc, network: Network.lightning };
+		state.to = { coin: Coin.hive, network: Network.magi };
+		expect(decideBroadcast(state, 'swap')).toEqual({ action: 'v4v' });
+	});
+
+	it('Lightning-routed transfer (to.network = lightning) → v4v on transfer', () => {
+		const state = new TransferTxState();
+		state.from = { coin: Coin.btc, network: Network.magi };
+		state.to = { coin: Coin.btc, network: Network.lightning };
+		expect(decideBroadcast(state, 'transfer')).toEqual({ action: 'v4v' });
+	});
+});
+
+// ─── railOverride is NOT read (contract pinning) ─────────────────────────────
+
+describe('decideBroadcast — railOverride is deliberately NOT read', () => {
+	// Pins the current contract: railOverride affects only `solveNetworkConstraints`
+	// (UI filtering), not the broadcast intermediary. If we ever decide to wire
+	// railOverride into broadcast routing, these tests invert in one line and
+	// document the behavior change.
+
+	it('railOverride = lightning on a BTC mainnet → HIVE swap is IGNORED — intermediary stays magi', () => {
+		const state = new SwapTxState();
+		state.from = { coin: Coin.btc, network: Network.btcMainnet };
+		state.to = { coin: Coin.hive, network: Network.hiveMainnet };
+		state.railOverride = Network.lightning;
+		const d = decideBroadcast(state, 'swap');
+		// Even with override = lightning, decideBroadcast picks magi from the
+		// from/to networks. Documents the rail-read decision deferred earlier.
+		expect(d).toEqual({ action: 'send', intermediary: Network.magi });
+	});
+
+	it('railOverride = magi on a Lightning deposit does NOT prevent the v4v popup', () => {
+		const state = new DepositTxState();
+		state.from = { coin: Coin.btc, network: Network.lightning };
+		state.to = { coin: Coin.hive, network: Network.magi };
+		state.railOverride = Network.magi;
+		expect(decideBroadcast(state, 'deposit')).toEqual({ action: 'v4v' });
+	});
+});

--- a/src/lib/sendswap/utils/broadcastDecision.ts
+++ b/src/lib/sendswap/utils/broadcastDecision.ts
@@ -1,0 +1,62 @@
+import { Network } from './sendOptions';
+import type { IntermediaryNetwork } from './sendOptions';
+import { getIntermediaryNetwork } from './getNetwork';
+import type { TxState } from './txState.svelte';
+
+export type TxType = 'swap' | 'transfer' | 'deposit' | 'withdraw';
+
+/**
+ * The three outcomes of deciding how to broadcast a transaction:
+ *  - `error`: required fields are missing — bail with the given message
+ *  - `v4v`: open the Lightning gateway popup and let it drive the broadcast
+ *  - `send`: call `send()` with the computed intermediary network
+ */
+export type BroadcastDecision =
+	| { action: 'error'; message: string }
+	| { action: 'v4v' }
+	| { action: 'send'; intermediary: IntermediaryNetwork };
+
+/**
+ * Pure decision logic extracted from `StepsMachine.initSend()`. Given a
+ * tx-state and the flow's `txType`, returns what action the caller should
+ * take. The function MUTATES `txState.to` when applying the default-to
+ * logic for deposit/withdraw (matches the in-place behavior the component
+ * had before extraction).
+ *
+ * Contract notes pinned by the test suite:
+ *  - The intermediary is computed via `getIntermediaryNetwork(from, to)` —
+ *    `txState.rail` / `txState.railOverride` are deliberately NOT read here.
+ *    The override is a UI-filtering hint (consumed by `solveNetworkConstraints`),
+ *    not a broadcast-routing override. Revisit if we ever want overrides to
+ *    affect broadcast.
+ *  - Lightning intermediary on a non-withdraw flow → opens the v4v popup
+ *    (the popup itself drives the broadcast); withdraw flows broadcast
+ *    directly even when the intermediary is Lightning (Keepsats).
+ */
+export function decideBroadcast(txState: TxState, txType: TxType): BroadcastDecision {
+	// For deposit/withdraw: when the user hasn't picked a destination, default
+	// `to` to the same coin as `from` on the txType's canonical network.
+	if (!txState.to && txState.from) {
+		const defaultToNetwork =
+			txType === 'deposit'
+				? Network.magi
+				: txType === 'withdraw'
+					? Network.hiveMainnet
+					: undefined;
+		if (defaultToNetwork) {
+			txState.to = { coin: txState.from.coin, network: defaultToNetwork };
+		}
+	}
+
+	if (!txState.from || !txState.to) {
+		return { action: 'error', message: 'Required field undefined.' };
+	}
+
+	const intermediary = getIntermediaryNetwork(txState.from, txState.to);
+
+	if (intermediary.value === Network.lightning.value && txType !== 'withdraw') {
+		return { action: 'v4v' };
+	}
+
+	return { action: 'send', intermediary };
+}

--- a/src/lib/sendswap/utils/getNetwork.test.ts
+++ b/src/lib/sendswap/utils/getNetwork.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for getIntermediaryNetwork and settlementLabel.
+ *
+ * getIntermediaryNetwork is about to become load-bearing: Milo's review on the
+ * txState refactor wants `rail` to derive from this function rather than be
+ * set explicitly. Locking in current behavior now means we can change how
+ * rail is wired without silently changing routing.
+ *
+ * settlementLabel feeds the user-visible ETA in ReviewSwap.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getIntermediaryNetwork, settlementLabel } from './getNetwork';
+import { Coin, Network, type CoinOnNetwork } from './sendOptions';
+
+const on = (coin: Coin, network: Network): CoinOnNetwork => ({ coin, network });
+
+// ─── getIntermediaryNetwork ──────────────────────────────────────────────────
+
+describe('getIntermediaryNetwork — routing rules', () => {
+	it('magi → magi (internal transfer) routes via magi', () => {
+		const result = getIntermediaryNetwork(on(Coin.hive, Network.magi), on(Coin.hive, Network.magi));
+		expect(result.value).toBe(Network.magi.value);
+	});
+
+	it('magi → hiveMainnet (HIVE withdraw) routes via magi', () => {
+		const result = getIntermediaryNetwork(
+			on(Coin.hive, Network.magi),
+			on(Coin.hive, Network.hiveMainnet)
+		);
+		expect(result.value).toBe(Network.magi.value);
+	});
+
+	it('hiveMainnet → magi (HIVE deposit) routes via magi', () => {
+		const result = getIntermediaryNetwork(
+			on(Coin.hive, Network.hiveMainnet),
+			on(Coin.hive, Network.magi)
+		);
+		expect(result.value).toBe(Network.magi.value);
+	});
+
+	it('magi → btcMainnet (BTC withdraw) routes via magi', () => {
+		const result = getIntermediaryNetwork(
+			on(Coin.btc, Network.magi),
+			on(Coin.btc, Network.btcMainnet)
+		);
+		expect(result.value).toBe(Network.magi.value);
+	});
+
+	it('btcMainnet → magi (BTC mainnet deposit) routes via magi', () => {
+		const result = getIntermediaryNetwork(
+			on(Coin.btc, Network.btcMainnet),
+			on(Coin.btc, Network.magi)
+		);
+		expect(result.value).toBe(Network.magi.value);
+	});
+
+	it('hiveMainnet → hiveMainnet routes via hiveMainnet (not magi)', () => {
+		// This is the only pair that bypasses magi.
+		const result = getIntermediaryNetwork(
+			on(Coin.hive, Network.hiveMainnet),
+			on(Coin.hbd, Network.hiveMainnet)
+		);
+		expect(result.value).toBe(Network.hiveMainnet.value);
+	});
+
+	it('lightning on from → routes via lightning (BTC mainnet deposit via LN)', () => {
+		const result = getIntermediaryNetwork(
+			on(Coin.btc, Network.lightning),
+			on(Coin.hive, Network.magi)
+		);
+		expect(result.value).toBe(Network.lightning.value);
+	});
+
+	it('lightning on to → routes via lightning (Keepsats-style withdraw)', () => {
+		const result = getIntermediaryNetwork(
+			on(Coin.btc, Network.magi),
+			on(Coin.btc, Network.lightning)
+		);
+		expect(result.value).toBe(Network.lightning.value);
+	});
+
+	it('lightning takes precedence over hive-direct routing', () => {
+		// Both endpoints touch lightning; should not fall through to hive.
+		const result = getIntermediaryNetwork(
+			on(Coin.btc, Network.lightning),
+			on(Coin.btc, Network.lightning)
+		);
+		expect(result.value).toBe(Network.lightning.value);
+	});
+
+	it('unknown network pair falls back to Network.unknown', () => {
+		const bogus: Network = {
+			value: 'totally_made_up',
+			label: 'Made Up',
+			icon: '/x.svg',
+			settlementSeconds: 0
+		};
+		const result = getIntermediaryNetwork(on(Coin.hive, bogus), on(Coin.hive, Network.magi));
+		expect(result.value).toBe(Network.unknown.value);
+	});
+
+	it('the returned IntermediaryNetwork exposes a feeCalculation function', () => {
+		// `IntermediaryNetwork = Network & { feeCalculation: ... }` — required
+		// non-null at the type level. Sanity-check the runtime contract.
+		const result = getIntermediaryNetwork(on(Coin.hive, Network.magi), on(Coin.hive, Network.magi));
+		expect(typeof result.feeCalculation).toBe('function');
+	});
+});
+
+// ─── settlementLabel ─────────────────────────────────────────────────────────
+
+describe('settlementLabel — user-visible ETA', () => {
+	it('empty list returns empty string', () => {
+		expect(settlementLabel([])).toBe('');
+	});
+
+	it('all-undefined returns empty string', () => {
+		expect(settlementLabel([undefined, undefined])).toBe('');
+	});
+
+	it('magi alone (0s) is Instant', () => {
+		expect(settlementLabel([Network.magi])).toBe('Instant');
+	});
+
+	it('hiveMainnet alone (~3s) is Instant', () => {
+		expect(settlementLabel([Network.hiveMainnet])).toBe('Instant');
+	});
+
+	it('lightning alone (~60s) is "About a minute"', () => {
+		expect(settlementLabel([Network.lightning])).toBe('About a minute');
+	});
+
+	it('btcMainnet alone (~600s) is "About 10 minutes"', () => {
+		expect(settlementLabel([Network.btcMainnet])).toBe('About 10 minutes');
+	});
+
+	it('picks the slowest network when several are passed', () => {
+		expect(
+			settlementLabel([Network.magi, Network.lightning, Network.btcMainnet, Network.hiveMainnet])
+		).toBe('About 10 minutes');
+	});
+
+	it('skips undefined entries (e.g. unset rail)', () => {
+		expect(settlementLabel([Network.lightning, undefined, Network.magi])).toBe('About a minute');
+	});
+});

--- a/src/lib/sendswap/utils/sendOptions.test.ts
+++ b/src/lib/sendswap/utils/sendOptions.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for the swapOptions catalog lookups.
+ *
+ * getFromOption / getToOption replaced ~20 ad-hoc `.find()` calls scattered
+ * across send/swap stages. The catalog has asymmetric coverage by design:
+ * SATS, USD and UNK are not in either list, and sHBD is in `.from` only.
+ * That asymmetry caused a real bug during the from/to migration: the
+ * Lightning deposit branch in DepositOptions had to add an explicit SATS
+ * fallback because `getToOption('sats')` returned undefined.
+ *
+ * These tests pin that asymmetry so future contributors don't silently
+ * introduce a regression that hides SATS in deposits.
+ */
+
+import { describe, it, expect } from 'vitest';
+import swapOptions, { Coin, Network, getFromOption, getToOption } from './sendOptions';
+
+// ─── getFromOption ───────────────────────────────────────────────────────────
+
+describe('getFromOption — source asset catalog', () => {
+	it('returns the AssetOption for HIVE', () => {
+		const opt = getFromOption(Coin.hive.value);
+		expect(opt?.coin.value).toBe(Coin.hive.value);
+		expect(opt?.networks.map((n) => n.value)).toEqual([
+			Network.magi.value,
+			Network.hiveMainnet.value
+		]);
+	});
+
+	it('returns the AssetOption for HBD', () => {
+		const opt = getFromOption(Coin.hbd.value);
+		expect(opt?.coin.value).toBe(Coin.hbd.value);
+		expect(opt?.networks.map((n) => n.value)).toContain(Network.hiveMainnet.value);
+	});
+
+	it('returns the AssetOption for sHBD (magi-only)', () => {
+		const opt = getFromOption(Coin.shbd.value);
+		expect(opt?.coin.value).toBe(Coin.shbd.value);
+		expect(opt?.networks.map((n) => n.value)).toEqual([Network.magi.value]);
+	});
+
+	it('returns the AssetOption for BTC', () => {
+		const opt = getFromOption(Coin.btc.value);
+		expect(opt?.coin.value).toBe(Coin.btc.value);
+		expect(opt?.networks.map((n) => n.value)).toEqual([
+			Network.magi.value,
+			Network.btcMainnet.value
+		]);
+	});
+
+	it('returns undefined for SATS (deliberately absent from the catalog)', () => {
+		// SATS is a display denomination of BTC, not a source asset on its own.
+		// Callers must fall back to an explicit { coin: sats, networks: [magi] }
+		// (see DepositOptions Lightning branch).
+		expect(getFromOption(Coin.sats.value)).toBeUndefined();
+	});
+
+	it('returns undefined for USD (display-only)', () => {
+		expect(getFromOption(Coin.usd.value)).toBeUndefined();
+	});
+
+	it('returns undefined for UNK (placeholder)', () => {
+		expect(getFromOption(Coin.unk.value)).toBeUndefined();
+	});
+
+	it('returns undefined for unknown coin values', () => {
+		expect(getFromOption('doge')).toBeUndefined();
+		expect(getFromOption('')).toBeUndefined();
+		expect(getFromOption(undefined)).toBeUndefined();
+	});
+});
+
+// ─── getToOption ─────────────────────────────────────────────────────────────
+
+describe('getToOption — destination asset catalog', () => {
+	it('returns the AssetOption for HIVE', () => {
+		const opt = getToOption(Coin.hive.value);
+		expect(opt?.coin.value).toBe(Coin.hive.value);
+		expect(opt?.networks.map((n) => n.value)).toContain(Network.magi.value);
+	});
+
+	it('returns the AssetOption for HBD', () => {
+		const opt = getToOption(Coin.hbd.value);
+		expect(opt?.coin.value).toBe(Coin.hbd.value);
+	});
+
+	it('returns the AssetOption for BTC (with btcMainnet first)', () => {
+		const opt = getToOption(Coin.btc.value);
+		expect(opt?.coin.value).toBe(Coin.btc.value);
+		// `to` lists btc with btcMainnet ahead of magi — the default toNetwork
+		// for a BTC withdraw is mainnet, not magi. Keep this ordering pinned.
+		expect(opt?.networks[0].value).toBe(Network.btcMainnet.value);
+	});
+
+	it('returns undefined for sHBD (deliberately not in destinations)', () => {
+		// sHBD cannot be a destination on its own — TransferOptions uses this
+		// asymmetry to block transfers TO sHBD.
+		expect(getToOption(Coin.shbd.value)).toBeUndefined();
+	});
+
+	it('returns undefined for SATS (not in catalog)', () => {
+		expect(getToOption(Coin.sats.value)).toBeUndefined();
+	});
+
+	it('returns undefined for USD / UNK / unknown', () => {
+		expect(getToOption(Coin.usd.value)).toBeUndefined();
+		expect(getToOption(Coin.unk.value)).toBeUndefined();
+		expect(getToOption('doge')).toBeUndefined();
+		expect(getToOption(undefined)).toBeUndefined();
+	});
+});
+
+// ─── swapOptions invariants ──────────────────────────────────────────────────
+
+describe('swapOptions catalog invariants', () => {
+	it('every from-AssetOption has at least one network', () => {
+		for (const opt of swapOptions.from) {
+			expect(opt.networks.length).toBeGreaterThan(0);
+		}
+	});
+
+	it('every to-AssetOption has at least one network', () => {
+		for (const opt of swapOptions.to) {
+			expect(opt.networks.length).toBeGreaterThan(0);
+		}
+	});
+
+	it('from-AssetOptions list magi as the first network where applicable', () => {
+		// txState shims default `network` to `v.networks[0]` when the AssetOption
+		// is assigned to fromCoin/toCoin while `from`/`to` is undefined. Many
+		// effects rely on this defaulting to magi — pin it.
+		for (const opt of swapOptions.from) {
+			expect(opt.networks[0].value).toBe(Network.magi.value);
+		}
+	});
+});

--- a/src/lib/sendswap/utils/sendUtils.ts
+++ b/src/lib/sendswap/utils/sendUtils.ts
@@ -35,6 +35,8 @@ import swapOptions, {
 	Coin,
 	Network,
 	networkMap,
+	getFromOption,
+	getToOption,
 	type CoinOnNetwork,
 	type AssetOption,
 	type IntermediaryNetwork
@@ -357,16 +359,14 @@ export async function getLastPaidNetwork(netVal?: string): Promise<moment.Moment
 
 export async function getFee(toAmount: string, state: TxStateBase) {
 	if (
-		state.fromCoin &&
-		state.fromNetwork &&
-		state.toCoin &&
-		state.toCoin.coin.value !== Coin.usd.value &&
-		state.toNetwork
+		state.from &&
+		state.to &&
+		state.to.coin.value !== Coin.usd.value
 	) {
-		const fee = await getIntermediaryNetwork(
-			{ coin: state.fromCoin.coin, network: state.fromNetwork },
-			{ coin: state.toCoin.coin, network: state.toNetwork }
-		).feeCalculation(new CoinAmount(Number(toAmount), state.toCoin.coin), state.fromCoin.coin);
+		const fee = await getIntermediaryNetwork(state.from, state.to).feeCalculation(
+			new CoinAmount(Number(toAmount), state.to.coin),
+			state.from.coin
+		);
 		return fee;
 	}
 }
@@ -553,8 +553,9 @@ export function solveToNetworks(state: TxStateBase): Network[] {
 	const recipientNetworks: Network[] | undefined = state.toUsername
 		? getRecipientNetworks(getDidFromUsername(state.toUsername)).filter((net) => !net.disabled)
 		: undefined;
-	const coinNetworks =
-		state.fromNetwork && state.fromCoin ? state.fromCoin.networks : undefined;
+	const coinNetworks = state.from
+		? getFromOption(state.from.coin.value)?.networks
+		: undefined;
 	const intersection =
 		recipientNetworks && coinNetworks
 			? coinNetworks.filter((net) =>
@@ -562,7 +563,7 @@ export function solveToNetworks(state: TxStateBase): Network[] {
 				)
 			: (recipientNetworks ?? coinNetworks ?? []);
 	if (getUsernameFromAuth(getAuth()()) === state.toUsername) {
-		return intersection.filter((net) => net.value !== state.fromNetwork?.value);
+		return intersection.filter((net) => net.value !== state.from?.network.value);
 	} else {
 		return intersection;
 	}
@@ -576,10 +577,13 @@ export async function send(
 	signal?: AbortSignal | undefined
 ): Promise<Error | { id: string }> {
 	// console.log('start of send() function, details:', details);
-	const fromCoin = details.fromCoin!;
-	const fromNetwork = details.fromNetwork!;
-	const toCoin = details.toCoin!;
-	const toNetwork = details.toNetwork!;
+	// `fromCoin`/`toCoin` are AssetOption (catalog entries with networks list)
+	// — needed downstream for `.networks` lookups. The coin and network
+	// themselves come from `details.from`/`details.to`.
+	const fromCoin = getFromOption(details.from!.coin.value)!;
+	const fromNetwork = details.from!.network;
+	const toCoin = getToOption(details.to!.coin.value)!;
+	const toNetwork = details.to!.network;
 	const toUsername = details.toUsername;
 	// Resolve send amount — toAmount may lag on deposit/withdraw due to effect timing,
 	// fall back to fromAmount which is always set by the stage components.

--- a/src/lib/sendswap/utils/txState.svelte.test.ts
+++ b/src/lib/sendswap/utils/txState.svelte.test.ts
@@ -16,7 +16,7 @@ import {
 	WithdrawTxState,
 	TxStateBase
 } from './txState.svelte'
-import { Coin, Network, getFromOption, getToOption } from './sendOptions'
+import { Coin, Network } from './sendOptions'
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /**
@@ -104,10 +104,8 @@ describe('default values — each class starts at zero-state', () => {
 		expect(state.toUsername).toBe('')
 		expect(state.fromAmount).toBe('0')
 		expect(state.toAmount).toBe('0')
-		expect(state.fromCoin).toBeUndefined()
-		expect(state.toCoin).toBeUndefined()
-		expect(state.fromNetwork).toBeUndefined()
-		expect(state.toNetwork).toBeUndefined()
+		expect(state.from).toBeUndefined()
+		expect(state.to).toBeUndefined()
 	})
 
 	it('SwapTxState-specific defaults', () => {
@@ -300,160 +298,3 @@ describe('from/to/rail source-of-truth fields', () => {
 	})
 })
 
-// ─── 6. Legacy shim contract (delete with the shims) ─────────────────────────
-//
-// These tests pin the exact behavior of the @deprecated fromCoin/fromNetwork/
-// toCoin/toNetwork getter-setters on TxStateBase. While shims exist, files
-// being migrated still use them; locking the contract here means we can
-// remove the shims at the end of #3 with confidence, and any per-file
-// migration that misreads the shim semantics will get caught.
-//
-// Delete this whole `describe` block when the shims are removed.
-
-describe('legacy shim: get fromCoin / get toCoin', () => {
-	it('returns undefined when `from` / `to` are unset', () => {
-		const state = new TransferTxState()
-		expect(state.fromCoin).toBeUndefined()
-		expect(state.toCoin).toBeUndefined()
-	})
-
-	it('returns the AssetOption matching from.coin for catalog hits', () => {
-		const state = new TransferTxState()
-		state.from = { coin: Coin.hive, network: Network.magi }
-		expect(state.fromCoin?.coin.value).toBe(Coin.hive.value)
-		expect(state.fromCoin).toBe(getFromOption(Coin.hive.value))
-	})
-
-	it('returns undefined for catalog misses even when `from` is set (SATS case)', () => {
-		// SATS isn't in swapOptions.from, so reading fromCoin yields undefined
-		// even though `from` itself holds a CoinOnNetwork. This is exactly why
-		// DepositOptions's Lightning branch needs an explicit SATS fallback.
-		const state = new TransferTxState()
-		state.from = { coin: Coin.sats, network: Network.magi }
-		expect(state.from).toBeDefined()
-		expect(state.fromCoin).toBeUndefined()
-	})
-
-	it('toCoin returns undefined for sHBD (sHBD is from-only)', () => {
-		const state = new TransferTxState()
-		state.to = { coin: Coin.shbd, network: Network.magi }
-		expect(state.toCoin).toBeUndefined()
-	})
-})
-
-describe('legacy shim: set fromCoin', () => {
-	it('clears `from` when assigned undefined', () => {
-		const state = new TransferTxState()
-		state.from = { coin: Coin.hive, network: Network.magi }
-		state.fromCoin = undefined
-		expect(state.from).toBeUndefined()
-	})
-
-	it('creates `from` with networks[0] when previously unset', () => {
-		const state = new TransferTxState()
-		const hiveOpt = getFromOption(Coin.hive.value)!
-		state.fromCoin = hiveOpt
-		expect(state.from?.coin.value).toBe(Coin.hive.value)
-		expect(state.from?.network.value).toBe(hiveOpt.networks[0].value)
-		// invariant: networks[0] is magi for every from-AssetOption
-		expect(state.from?.network.value).toBe(Network.magi.value)
-	})
-
-	it('preserves the existing network when `from` was already set', () => {
-		// Bug-class this prevents: a regression where reassigning fromCoin
-		// silently snaps the network back to magi.
-		const state = new TransferTxState()
-		state.from = { coin: Coin.hive, network: Network.hiveMainnet }
-		state.fromCoin = getFromOption(Coin.btc.value)!
-		expect(state.from?.coin.value).toBe(Coin.btc.value)
-		expect(state.from?.network.value).toBe(Network.hiveMainnet.value)
-	})
-
-	it('is a no-op when `from` is unset and the AssetOption has empty networks', () => {
-		// Pre-existing behavior: `set fromCoin({coin, networks: []})` with
-		// `from === undefined` resolves `net = v.networks[0] = undefined`, so
-		// the assignment falls through and `from` stays undefined. Pin this so
-		// nobody "improves" the shim by defaulting to magi here — the catalog
-		// itself enforces non-empty networks (see sendOptions.test.ts).
-		const state = new TransferTxState()
-		state.fromCoin = { coin: Coin.usd, networks: [] }
-		expect(state.from).toBeUndefined()
-	})
-})
-
-describe('legacy shim: set fromNetwork', () => {
-	it('clears `from` when assigned undefined', () => {
-		const state = new TransferTxState()
-		state.from = { coin: Coin.hive, network: Network.magi }
-		state.fromNetwork = undefined
-		expect(state.from).toBeUndefined()
-	})
-
-	it('swaps the network and preserves the coin when `from` is set', () => {
-		const state = new TransferTxState()
-		state.from = { coin: Coin.hive, network: Network.magi }
-		state.fromNetwork = Network.hiveMainnet
-		expect(state.from?.coin.value).toBe(Coin.hive.value)
-		expect(state.from?.network.value).toBe(Network.hiveMainnet.value)
-	})
-
-	it('is a no-op when `from` is undefined', () => {
-		// Pre-existing behavior: setting fromNetwork without a coin context
-		// has no effect. This was the silent regression that hid in SendSwap
-		// during the migration — the legacy `toNetwork = toNet` call was a
-		// no-op because `to.coin` hadn't been set yet. Pin it so the same
-		// trap is documented.
-		const state = new TransferTxState()
-		state.fromNetwork = Network.hiveMainnet
-		expect(state.from).toBeUndefined()
-	})
-})
-
-describe('legacy shim: set toCoin', () => {
-	it('clears `to` when assigned undefined', () => {
-		const state = new TransferTxState()
-		state.to = { coin: Coin.hive, network: Network.magi }
-		state.toCoin = undefined
-		expect(state.to).toBeUndefined()
-	})
-
-	it('creates `to` with networks[0] when previously unset', () => {
-		const state = new TransferTxState()
-		const btcTo = getToOption(Coin.btc.value)!
-		state.toCoin = btcTo
-		expect(state.to?.coin.value).toBe(Coin.btc.value)
-		// to-side BTC lists btcMainnet first.
-		expect(state.to?.network.value).toBe(Network.btcMainnet.value)
-	})
-
-	it('preserves the existing network when `to` was already set', () => {
-		const state = new TransferTxState()
-		state.to = { coin: Coin.hive, network: Network.hiveMainnet }
-		state.toCoin = getToOption(Coin.hbd.value)!
-		expect(state.to?.coin.value).toBe(Coin.hbd.value)
-		expect(state.to?.network.value).toBe(Network.hiveMainnet.value)
-	})
-})
-
-describe('legacy shim: set toNetwork', () => {
-	it('clears `to` when assigned undefined', () => {
-		const state = new TransferTxState()
-		state.to = { coin: Coin.hive, network: Network.magi }
-		state.toNetwork = undefined
-		expect(state.to).toBeUndefined()
-	})
-
-	it('swaps the network and preserves the coin when `to` is set', () => {
-		const state = new TransferTxState()
-		state.to = { coin: Coin.btc, network: Network.magi }
-		state.toNetwork = Network.btcMainnet
-		expect(state.to?.coin.value).toBe(Coin.btc.value)
-		expect(state.to?.network.value).toBe(Network.btcMainnet.value)
-	})
-
-	it('is a no-op when `to` is undefined', () => {
-		const state = new TransferTxState()
-		state.toNetwork = Network.btcMainnet
-		expect(state.to).toBeUndefined()
-	})
-})

--- a/src/lib/sendswap/utils/txState.svelte.test.ts
+++ b/src/lib/sendswap/utils/txState.svelte.test.ts
@@ -260,34 +260,25 @@ describe('original bug: QuickSwap writing toUsername must not reach QuickSend', 
 
 // ─── 5. New from/to source-of-truth ──────────────────────────────────────────
 
-describe('from/to/rail source-of-truth fields', () => {
+describe('from/to source-of-truth fields', () => {
 	it('start undefined', () => {
 		const state = new TransferTxState()
 		expect(state.from).toBeUndefined()
 		expect(state.to).toBeUndefined()
 		expect(state.rail).toBeUndefined()
+		expect(state.railOverride).toBeUndefined()
 	})
 
-	it('writing `from` does not touch `to` or `rail`', () => {
+	it('writing `from` does not touch `to`', () => {
 		const state = new TransferTxState()
 		state.from = { coin: Coin.hive, network: Network.magi }
 		expect(state.to).toBeUndefined()
-		expect(state.rail).toBeUndefined()
 	})
 
-	it('writing `to` does not touch `from` or `rail`', () => {
+	it('writing `to` does not touch `from`', () => {
 		const state = new TransferTxState()
 		state.to = { coin: Coin.hive, network: Network.hiveMainnet }
 		expect(state.from).toBeUndefined()
-		expect(state.rail).toBeUndefined()
-	})
-
-	it('writing `rail` does not touch `from` or `to`', () => {
-		const state = new TransferTxState()
-		state.rail = Network.lightning
-		expect(state.from).toBeUndefined()
-		expect(state.to).toBeUndefined()
-		expect(state.rail.value).toBe(Network.lightning.value)
 	})
 
 	it('round-trips a CoinOnNetwork literal', () => {
@@ -295,6 +286,67 @@ describe('from/to/rail source-of-truth fields', () => {
 		state.from = { coin: Coin.btc, network: Network.btcMainnet }
 		expect(state.from.coin.value).toBe(Coin.btc.value)
 		expect(state.from.network.value).toBe(Network.btcMainnet.value)
+	})
+})
+
+// ─── 6. rail derivation ──────────────────────────────────────────────────────
+
+describe('rail — derived from from/to via getIntermediaryNetwork', () => {
+	it('undefined when from or to is unset', () => {
+		const state = new TransferTxState()
+		expect(state.rail).toBeUndefined()
+		state.from = { coin: Coin.hive, network: Network.magi }
+		expect(state.rail).toBeUndefined()
+	})
+
+	it('derives to magi for { magi → hiveMainnet }', () => {
+		const state = new TransferTxState()
+		state.from = { coin: Coin.hive, network: Network.magi }
+		state.to = { coin: Coin.hive, network: Network.hiveMainnet }
+		expect(state.rail?.value).toBe(Network.magi.value)
+	})
+
+	it('derives to magi for { magi → btcMainnet }', () => {
+		const state = new TransferTxState()
+		state.from = { coin: Coin.btc, network: Network.magi }
+		state.to = { coin: Coin.btc, network: Network.btcMainnet }
+		expect(state.rail?.value).toBe(Network.magi.value)
+	})
+
+	it('derives to lightning when from.network is lightning', () => {
+		const state = new TransferTxState()
+		state.from = { coin: Coin.btc, network: Network.lightning }
+		state.to = { coin: Coin.hive, network: Network.magi }
+		expect(state.rail?.value).toBe(Network.lightning.value)
+	})
+
+	it('derives to lightning when to.network is lightning', () => {
+		const state = new TransferTxState()
+		state.from = { coin: Coin.btc, network: Network.magi }
+		state.to = { coin: Coin.btc, network: Network.lightning }
+		expect(state.rail?.value).toBe(Network.lightning.value)
+	})
+
+	it('railOverride forces the rail even when from/to would derive differently', () => {
+		// Mirrors the QuickSwap / /swap case: BTC mainnet → HIVE mainnet
+		// rails via Lightning, but neither endpoint network is Lightning.
+		// Without the override `getIntermediaryNetwork` would pick magi.
+		const state = new TransferTxState()
+		state.from = { coin: Coin.btc, network: Network.btcMainnet }
+		state.to = { coin: Coin.hive, network: Network.hiveMainnet }
+		expect(state.rail?.value).toBe(Network.magi.value)
+		state.railOverride = Network.lightning
+		expect(state.rail?.value).toBe(Network.lightning.value)
+	})
+
+	it('clearing railOverride restores the derived value', () => {
+		const state = new TransferTxState()
+		state.from = { coin: Coin.btc, network: Network.magi }
+		state.to = { coin: Coin.hive, network: Network.magi }
+		state.railOverride = Network.lightning
+		expect(state.rail?.value).toBe(Network.lightning.value)
+		state.railOverride = undefined
+		expect(state.rail?.value).toBe(Network.magi.value)
 	})
 })
 

--- a/src/lib/sendswap/utils/txState.svelte.test.ts
+++ b/src/lib/sendswap/utils/txState.svelte.test.ts
@@ -16,6 +16,7 @@ import {
 	WithdrawTxState,
 	TxStateBase
 } from './txState.svelte'
+import { Coin, Network, getFromOption, getToOption } from './sendOptions'
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /**
@@ -256,5 +257,203 @@ describe('original bug: QuickSwap writing toUsername must not reach QuickSend', 
 		sendState.toUsername = 'friend'
 
 		expect(swapState.toUsername).toBe('')
+	})
+})
+
+// ─── 5. New from/to source-of-truth ──────────────────────────────────────────
+
+describe('from/to/rail source-of-truth fields', () => {
+	it('start undefined', () => {
+		const state = new TransferTxState()
+		expect(state.from).toBeUndefined()
+		expect(state.to).toBeUndefined()
+		expect(state.rail).toBeUndefined()
+	})
+
+	it('writing `from` does not touch `to` or `rail`', () => {
+		const state = new TransferTxState()
+		state.from = { coin: Coin.hive, network: Network.magi }
+		expect(state.to).toBeUndefined()
+		expect(state.rail).toBeUndefined()
+	})
+
+	it('writing `to` does not touch `from` or `rail`', () => {
+		const state = new TransferTxState()
+		state.to = { coin: Coin.hive, network: Network.hiveMainnet }
+		expect(state.from).toBeUndefined()
+		expect(state.rail).toBeUndefined()
+	})
+
+	it('writing `rail` does not touch `from` or `to`', () => {
+		const state = new TransferTxState()
+		state.rail = Network.lightning
+		expect(state.from).toBeUndefined()
+		expect(state.to).toBeUndefined()
+		expect(state.rail.value).toBe(Network.lightning.value)
+	})
+
+	it('round-trips a CoinOnNetwork literal', () => {
+		const state = new TransferTxState()
+		state.from = { coin: Coin.btc, network: Network.btcMainnet }
+		expect(state.from.coin.value).toBe(Coin.btc.value)
+		expect(state.from.network.value).toBe(Network.btcMainnet.value)
+	})
+})
+
+// ─── 6. Legacy shim contract (delete with the shims) ─────────────────────────
+//
+// These tests pin the exact behavior of the @deprecated fromCoin/fromNetwork/
+// toCoin/toNetwork getter-setters on TxStateBase. While shims exist, files
+// being migrated still use them; locking the contract here means we can
+// remove the shims at the end of #3 with confidence, and any per-file
+// migration that misreads the shim semantics will get caught.
+//
+// Delete this whole `describe` block when the shims are removed.
+
+describe('legacy shim: get fromCoin / get toCoin', () => {
+	it('returns undefined when `from` / `to` are unset', () => {
+		const state = new TransferTxState()
+		expect(state.fromCoin).toBeUndefined()
+		expect(state.toCoin).toBeUndefined()
+	})
+
+	it('returns the AssetOption matching from.coin for catalog hits', () => {
+		const state = new TransferTxState()
+		state.from = { coin: Coin.hive, network: Network.magi }
+		expect(state.fromCoin?.coin.value).toBe(Coin.hive.value)
+		expect(state.fromCoin).toBe(getFromOption(Coin.hive.value))
+	})
+
+	it('returns undefined for catalog misses even when `from` is set (SATS case)', () => {
+		// SATS isn't in swapOptions.from, so reading fromCoin yields undefined
+		// even though `from` itself holds a CoinOnNetwork. This is exactly why
+		// DepositOptions's Lightning branch needs an explicit SATS fallback.
+		const state = new TransferTxState()
+		state.from = { coin: Coin.sats, network: Network.magi }
+		expect(state.from).toBeDefined()
+		expect(state.fromCoin).toBeUndefined()
+	})
+
+	it('toCoin returns undefined for sHBD (sHBD is from-only)', () => {
+		const state = new TransferTxState()
+		state.to = { coin: Coin.shbd, network: Network.magi }
+		expect(state.toCoin).toBeUndefined()
+	})
+})
+
+describe('legacy shim: set fromCoin', () => {
+	it('clears `from` when assigned undefined', () => {
+		const state = new TransferTxState()
+		state.from = { coin: Coin.hive, network: Network.magi }
+		state.fromCoin = undefined
+		expect(state.from).toBeUndefined()
+	})
+
+	it('creates `from` with networks[0] when previously unset', () => {
+		const state = new TransferTxState()
+		const hiveOpt = getFromOption(Coin.hive.value)!
+		state.fromCoin = hiveOpt
+		expect(state.from?.coin.value).toBe(Coin.hive.value)
+		expect(state.from?.network.value).toBe(hiveOpt.networks[0].value)
+		// invariant: networks[0] is magi for every from-AssetOption
+		expect(state.from?.network.value).toBe(Network.magi.value)
+	})
+
+	it('preserves the existing network when `from` was already set', () => {
+		// Bug-class this prevents: a regression where reassigning fromCoin
+		// silently snaps the network back to magi.
+		const state = new TransferTxState()
+		state.from = { coin: Coin.hive, network: Network.hiveMainnet }
+		state.fromCoin = getFromOption(Coin.btc.value)!
+		expect(state.from?.coin.value).toBe(Coin.btc.value)
+		expect(state.from?.network.value).toBe(Network.hiveMainnet.value)
+	})
+
+	it('is a no-op when `from` is unset and the AssetOption has empty networks', () => {
+		// Pre-existing behavior: `set fromCoin({coin, networks: []})` with
+		// `from === undefined` resolves `net = v.networks[0] = undefined`, so
+		// the assignment falls through and `from` stays undefined. Pin this so
+		// nobody "improves" the shim by defaulting to magi here — the catalog
+		// itself enforces non-empty networks (see sendOptions.test.ts).
+		const state = new TransferTxState()
+		state.fromCoin = { coin: Coin.usd, networks: [] }
+		expect(state.from).toBeUndefined()
+	})
+})
+
+describe('legacy shim: set fromNetwork', () => {
+	it('clears `from` when assigned undefined', () => {
+		const state = new TransferTxState()
+		state.from = { coin: Coin.hive, network: Network.magi }
+		state.fromNetwork = undefined
+		expect(state.from).toBeUndefined()
+	})
+
+	it('swaps the network and preserves the coin when `from` is set', () => {
+		const state = new TransferTxState()
+		state.from = { coin: Coin.hive, network: Network.magi }
+		state.fromNetwork = Network.hiveMainnet
+		expect(state.from?.coin.value).toBe(Coin.hive.value)
+		expect(state.from?.network.value).toBe(Network.hiveMainnet.value)
+	})
+
+	it('is a no-op when `from` is undefined', () => {
+		// Pre-existing behavior: setting fromNetwork without a coin context
+		// has no effect. This was the silent regression that hid in SendSwap
+		// during the migration — the legacy `toNetwork = toNet` call was a
+		// no-op because `to.coin` hadn't been set yet. Pin it so the same
+		// trap is documented.
+		const state = new TransferTxState()
+		state.fromNetwork = Network.hiveMainnet
+		expect(state.from).toBeUndefined()
+	})
+})
+
+describe('legacy shim: set toCoin', () => {
+	it('clears `to` when assigned undefined', () => {
+		const state = new TransferTxState()
+		state.to = { coin: Coin.hive, network: Network.magi }
+		state.toCoin = undefined
+		expect(state.to).toBeUndefined()
+	})
+
+	it('creates `to` with networks[0] when previously unset', () => {
+		const state = new TransferTxState()
+		const btcTo = getToOption(Coin.btc.value)!
+		state.toCoin = btcTo
+		expect(state.to?.coin.value).toBe(Coin.btc.value)
+		// to-side BTC lists btcMainnet first.
+		expect(state.to?.network.value).toBe(Network.btcMainnet.value)
+	})
+
+	it('preserves the existing network when `to` was already set', () => {
+		const state = new TransferTxState()
+		state.to = { coin: Coin.hive, network: Network.hiveMainnet }
+		state.toCoin = getToOption(Coin.hbd.value)!
+		expect(state.to?.coin.value).toBe(Coin.hbd.value)
+		expect(state.to?.network.value).toBe(Network.hiveMainnet.value)
+	})
+})
+
+describe('legacy shim: set toNetwork', () => {
+	it('clears `to` when assigned undefined', () => {
+		const state = new TransferTxState()
+		state.to = { coin: Coin.hive, network: Network.magi }
+		state.toNetwork = undefined
+		expect(state.to).toBeUndefined()
+	})
+
+	it('swaps the network and preserves the coin when `to` is set', () => {
+		const state = new TransferTxState()
+		state.to = { coin: Coin.btc, network: Network.magi }
+		state.toNetwork = Network.btcMainnet
+		expect(state.to?.coin.value).toBe(Coin.btc.value)
+		expect(state.to?.network.value).toBe(Network.btcMainnet.value)
+	})
+
+	it('is a no-op when `to` is undefined', () => {
+		const state = new TransferTxState()
+		state.toNetwork = Network.btcMainnet
+		expect(state.to).toBeUndefined()
 	})
 })

--- a/src/lib/sendswap/utils/txState.svelte.ts
+++ b/src/lib/sendswap/utils/txState.svelte.ts
@@ -1,6 +1,6 @@
 import { getContext, setContext } from 'svelte';
 import type { CoinAmount } from '$lib/currency/CoinAmount';
-import { getFromOption, getToOption, type AssetOption, type Coin, type CoinOnNetwork, type Network } from './sendOptions';
+import type { Coin, CoinOnNetwork, Network } from './sendOptions';
 
 // ─── Base (fields every flow shares) ─────────────────────────────────────────
 
@@ -25,60 +25,6 @@ export class TxStateBase {
 	fromAmount: string = $state('0');
 	toAmount: string = $state('0');
 	toUsername: string = $state('');
-
-	// ─── Legacy shims (migration-only) ──────────────────────────────────────────
-	// These bridge the paired (fromCoin/fromNetwork, toCoin/toNetwork) API to
-	// the collapsed `from`/`to: CoinOnNetwork` source of truth. They exist so
-	// existing consumers keep working while each file is migrated to read/write
-	// the new fields directly. **Do not introduce new usages** — read `.from` /
-	// `.to` instead. Will be removed once every consumer is migrated.
-
-	/** @deprecated read `txState.from?.coin` and look the AssetOption up via `getFromOption()` if you need the list of available networks. */
-	get fromCoin(): AssetOption | undefined {
-		return this.from ? getFromOption(this.from.coin.value) : undefined;
-	}
-	set fromCoin(v: AssetOption | undefined) {
-		if (!v) {
-			this.from = undefined;
-			return;
-		}
-		const net = this.from?.network ?? v.networks[0];
-		if (net) this.from = { coin: v.coin, network: net };
-	}
-	/** @deprecated read `txState.from?.network`. */
-	get fromNetwork(): Network | undefined {
-		return this.from?.network;
-	}
-	set fromNetwork(v: Network | undefined) {
-		if (!v) {
-			this.from = undefined;
-			return;
-		}
-		if (this.from?.coin) this.from = { coin: this.from.coin, network: v };
-	}
-	/** @deprecated read `txState.to?.coin` and look the AssetOption up via `getToOption()` if you need the list of available networks. */
-	get toCoin(): AssetOption | undefined {
-		return this.to ? getToOption(this.to.coin.value) : undefined;
-	}
-	set toCoin(v: AssetOption | undefined) {
-		if (!v) {
-			this.to = undefined;
-			return;
-		}
-		const net = this.to?.network ?? v.networks[0];
-		if (net) this.to = { coin: v.coin, network: net };
-	}
-	/** @deprecated read `txState.to?.network`. */
-	get toNetwork(): Network | undefined {
-		return this.to?.network;
-	}
-	set toNetwork(v: Network | undefined) {
-		if (!v) {
-			this.to = undefined;
-			return;
-		}
-		if (this.to?.coin) this.to = { coin: this.to.coin, network: v };
-	}
 }
 
 // ─── Swap (QuickSwap card, /swap page) ───────────────────────────────────────

--- a/src/lib/sendswap/utils/txState.svelte.ts
+++ b/src/lib/sendswap/utils/txState.svelte.ts
@@ -1,30 +1,84 @@
 import { getContext, setContext } from 'svelte';
 import type { CoinAmount } from '$lib/currency/CoinAmount';
-import type { Coin } from './sendOptions';
-import type { AssetOption, CoinOnNetwork, Network } from './sendOptions';
+import { getFromOption, getToOption, type AssetOption, type Coin, type CoinOnNetwork, type Network } from './sendOptions';
 
 // ─── Base (fields every flow shares) ─────────────────────────────────────────
 
 export class TxStateBase {
-	// ─── #3/#6 migration: new collapsed selection fields ───────────────────────
-	// `from`/`to` carry the user's chosen (coin, network) as a single value —
-	// matching what UI inputs produce (`CoinOnNetwork`). Eventually replaces the
-	// paired `fromCoin`+`fromNetwork` / `toCoin`+`toNetwork` below.
-	// `rail` is the explicit intermediary network — replaces the `method` field
-	// (#6). When set (e.g. Reown-BTC lightning swap), it overrides the
-	// `getIntermediaryNetwork(from, to)` derivation.
+	/**
+	 * Selected source — coin + chosen network as a single value, matching what
+	 * the asset/network picker produces (`CoinOnNetwork`). Use `getFromOption`
+	 * if you need the list of *available* networks for the coin.
+	 */
 	from: CoinOnNetwork | undefined = $state(undefined);
+	/** Selected destination, mirror of `from`. */
 	to: CoinOnNetwork | undefined = $state(undefined);
+	/**
+	 * Optional intermediary override. When `undefined`, callers derive the
+	 * intermediary via `getIntermediaryNetwork(from, to)`; set explicitly only
+	 * for flows whose rail can't be inferred from the from/to networks (e.g.
+	 * the Reown-BTC → HIVE swap that goes via Lightning while neither network
+	 * is Lightning).
+	 */
 	rail: Network | undefined = $state(undefined);
 
-	// ─── legacy fields (still authoritative; will be removed once consumers migrate)
-	fromCoin: AssetOption | undefined = $state(undefined);
-	fromNetwork: Network | undefined = $state(undefined);
 	fromAmount: string = $state('0');
-	toCoin: AssetOption | undefined = $state(undefined);
-	toNetwork: Network | undefined = $state(undefined);
 	toAmount: string = $state('0');
 	toUsername: string = $state('');
+
+	// ─── Legacy shims (migration-only) ──────────────────────────────────────────
+	// These bridge the paired (fromCoin/fromNetwork, toCoin/toNetwork) API to
+	// the collapsed `from`/`to: CoinOnNetwork` source of truth. They exist so
+	// existing consumers keep working while each file is migrated to read/write
+	// the new fields directly. **Do not introduce new usages** — read `.from` /
+	// `.to` instead. Will be removed once every consumer is migrated.
+
+	/** @deprecated read `txState.from?.coin` and look the AssetOption up via `getFromOption()` if you need the list of available networks. */
+	get fromCoin(): AssetOption | undefined {
+		return this.from ? getFromOption(this.from.coin.value) : undefined;
+	}
+	set fromCoin(v: AssetOption | undefined) {
+		if (!v) {
+			this.from = undefined;
+			return;
+		}
+		const net = this.from?.network ?? v.networks[0];
+		if (net) this.from = { coin: v.coin, network: net };
+	}
+	/** @deprecated read `txState.from?.network`. */
+	get fromNetwork(): Network | undefined {
+		return this.from?.network;
+	}
+	set fromNetwork(v: Network | undefined) {
+		if (!v) {
+			this.from = undefined;
+			return;
+		}
+		if (this.from?.coin) this.from = { coin: this.from.coin, network: v };
+	}
+	/** @deprecated read `txState.to?.coin` and look the AssetOption up via `getToOption()` if you need the list of available networks. */
+	get toCoin(): AssetOption | undefined {
+		return this.to ? getToOption(this.to.coin.value) : undefined;
+	}
+	set toCoin(v: AssetOption | undefined) {
+		if (!v) {
+			this.to = undefined;
+			return;
+		}
+		const net = this.to?.network ?? v.networks[0];
+		if (net) this.to = { coin: v.coin, network: net };
+	}
+	/** @deprecated read `txState.to?.network`. */
+	get toNetwork(): Network | undefined {
+		return this.to?.network;
+	}
+	set toNetwork(v: Network | undefined) {
+		if (!v) {
+			this.to = undefined;
+			return;
+		}
+		if (this.to?.coin) this.to = { coin: this.to.coin, network: v };
+	}
 }
 
 // ─── Swap (QuickSwap card, /swap page) ───────────────────────────────────────

--- a/src/lib/sendswap/utils/txState.svelte.ts
+++ b/src/lib/sendswap/utils/txState.svelte.ts
@@ -1,6 +1,7 @@
 import { getContext, setContext } from 'svelte';
 import type { CoinAmount } from '$lib/currency/CoinAmount';
 import type { Coin, CoinOnNetwork, Network } from './sendOptions';
+import { getIntermediaryNetwork } from './getNetwork';
 
 // ─── Base (fields every flow shares) ─────────────────────────────────────────
 
@@ -14,13 +15,25 @@ export class TxStateBase {
 	/** Selected destination, mirror of `from`. */
 	to: CoinOnNetwork | undefined = $state(undefined);
 	/**
-	 * Optional intermediary override. When `undefined`, callers derive the
-	 * intermediary via `getIntermediaryNetwork(from, to)`; set explicitly only
-	 * for flows whose rail can't be inferred from the from/to networks (e.g.
-	 * the Reown-BTC → HIVE swap that goes via Lightning while neither network
-	 * is Lightning).
+	 * Explicit intermediary override. Set ONLY for flows whose rail can't be
+	 * inferred from the from/to networks (e.g. the QuickSwap / /swap routes
+	 * that bridge external assets via Lightning while neither network is
+	 * Lightning). Read via the derived `rail` getter — never read this field
+	 * directly outside of the writer.
 	 */
-	rail: Network | undefined = $state(undefined);
+	railOverride: Network | undefined = $state(undefined);
+
+	/**
+	 * The intermediary network this TX rails through. Derived from `from` and
+	 * `to` via `getIntermediaryNetwork` by default; falls back to
+	 * `railOverride` when set (for cases where the from/to networks don't
+	 * indicate the rail — see `railOverride` doc).
+	 */
+	get rail(): Network | undefined {
+		if (this.railOverride) return this.railOverride;
+		if (!this.from || !this.to) return undefined;
+		return getIntermediaryNetwork(this.from, this.to);
+	}
 
 	fromAmount: string = $state('0');
 	toAmount: string = $state('0');

--- a/vitest-setup-client.ts
+++ b/vitest-setup-client.ts
@@ -1,6 +1,11 @@
 import '@testing-library/jest-dom/vitest';
 import { vi } from 'vitest';
 
+// SvelteKit's $env/dynamic/public is a virtual module not provided under
+// jsdom Vitest; stub it so files that transitively import it (e.g.
+// sendswap/v4v/config.ts) can load in client tests.
+vi.mock('$env/dynamic/public', () => ({ env: {} }));
+
 // required for svelte5 + jsdom as jsdom does not support matchMedia
 Object.defineProperty(window, 'matchMedia', {
 	writable: true,


### PR DESCRIPTION
## Summary

Completes the `txState` reshape started in 0.3.11. Per-side coin+network
collapse from four paired fields (`fromCoin` / `fromNetwork` /
`toCoin` / `toNetwork`) into two single fields (`from` / `to: CoinOnNetwork`)
across the entire send/swap/deposit/withdraw surface. Plus the cleanups
that became possible afterward:

- ~340 active legacy refs migrated across 13 components
- `@deprecated` shim getter/setters removed from `TxStateBase`
- `SelectAssetFlattened` collapsed to a single `bind:selected: CoinOnNetwork` prop
- `rail` is now a derived getter (computed via `getIntermediaryNetwork(from, to)`);
  the two flows that need an explicit override (QuickSwap + /swap Reown swap)
  use a new `railOverride` field
- `HiveMainnetDeposit` upgraded `useTxState()` → `useDepositState()` (matches
  every other deposit/withdraw picker)
- Fixed a pre-existing migration miss in StepsMachine's V4V popup
  (`toCoin!.coin` → `to.coin`) — would have thrown at runtime on a
  successful Lightning broadcast
- Decoupled `StepsMachine.initSend()` decision logic into a pure
  `decideBroadcast(txState, txType)` function for testability

## Testing

Test count: 74 → 212 (+138). Added:

- 67 safety-net tests run before the consumer migration started
  (`getIntermediaryNetwork`, swapOptions catalog lookups,
  `isValidAmountString`, txState shim contract)
- 42 Tier-A flow integration tests (one file per tx flow) — pin
  state-shape, rail derivation, and per-flow defaults
- 18 Tier-C `decideBroadcast` contract tests — pin every broadcast
  decision incl. the "railOverride is NOT read for broadcast routing"
  contract
- Plus an env-stub fix in vitest-setup-client so client tests can
  import sendswap modules

Type-check baseline: 194 → 146 errors (-48). No new errors introduced.

## Notes for reviewers

Two follow-ups intentionally deferred:
- StepsMachine reads `getIntermediaryNetwork(from, to)` directly; the
  new `railOverride` field affects `solveNetworkConstraints` (UI
  filtering) but not broadcast routing. This is the current contract
  per docs.magi.eco (BTC↔HIVE swaps route through Magi DEX, not
  Lightning). The `decideBroadcast` test suite explicitly pins this
  contract — if we want to flip the behavior later, the tests flip in
  one line.
- SATS catalog-miss in LightningDeposit picker (clicking SATS in the
  destination picker silently clears the selection). Pre-existing; not
  caused by the refactor. Separate fix.