### PR TITLE
fix(api): proxy v4v.app cryptoprices to bypass CORS (production hotfix)

### DIFF
--- a/src/lib/sendswap/v4v/api-types/cryptoprices.ts
+++ b/src/lib/sendswap/v4v/api-types/cryptoprices.ts
@@ -1,4 +1,3 @@
-import { V4VAPP_API_BASE } from '../config'
 import { getQuerier } from './query'
 
 export type Cryptoprices = {
@@ -63,5 +62,11 @@ export type Cryptoprices = {
 	};
 };
 
-const url = `${V4VAPP_API_BASE}/v1/cryptoprices/`;
+// Routes through a same-origin server proxy (`/api/cryptoprices`) because
+// v4v.app stopped sending CORS headers on this endpoint — the browser
+// fetch fails with `No 'Access-Control-Allow-Origin' header`. The proxy
+// forwards server-to-server, where CORS doesn't apply. Same pattern as
+// `/api/gql` (CHANGELOG 0.3.7). Dev-vs-prod v4v selection lives in the
+// proxy now (reads PUBLIC_V4VAPP_API_MODE server-side).
+const url = '/api/cryptoprices';
 export const getCryptoPrices = getQuerier<Cryptoprices>(url);

--- a/src/routes/api/cryptoprices/+server.ts
+++ b/src/routes/api/cryptoprices/+server.ts
@@ -1,0 +1,60 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+
+/**
+ * Same-origin proxy for v4v.app's `/v1/cryptoprices/` endpoint.
+ *
+ * Mirrors the `/api/gql` pattern (CHANGELOG 0.3.7). v4v.app stopped sending
+ * `Access-Control-Allow-Origin` on this endpoint, so the browser fetch fails
+ * with a CORS error — cascading into market prices, pool USD volumes, and
+ * balance USD conversions. This proxy forwards the request server-to-server,
+ * where CORS doesn't apply.
+ *
+ * APP-09: same-origin only — reject cross-origin callers so this proxy
+ * isn't a free relay for anyone else.
+ */
+
+const UPSTREAM_DEFAULT = 'https://api.v4v.app/v1/cryptoprices/';
+const UPSTREAM_DEV = 'https://devapi.v4v.app/v1/cryptoprices/';
+
+// Match the V4V dev-mode toggle used in src/lib/sendswap/v4v/config.ts.
+function getUpstream(): string {
+	const mode =
+		env.PUBLIC_V4VAPP_API_MODE ?? env.VITE_V4VAPP_API_MODE ?? '';
+	return mode === 'dev' ? UPSTREAM_DEV : UPSTREAM_DEFAULT;
+}
+
+export const GET: RequestHandler = async ({ url, request, fetch }) => {
+	// APP-09: only same-origin browsers (the app itself) may call this proxy.
+	// Browsers don't send `Origin` on same-origin GETs, so we also accept
+	// `Sec-Fetch-Site: same-origin` — sent by all modern browsers (Chromium,
+	// Firefox, Safari 16.4+) for same-origin requests. Direct URL navigations
+	// have `Sec-Fetch-Site: none` and are rejected (this endpoint should only
+	// be called programmatically by the app).
+	const allowedOrigin = (env.ALTERA_ORIGIN || url.origin).toLowerCase();
+	const reqOrigin = request.headers.get('origin');
+	const fetchSite = request.headers.get('sec-fetch-site');
+	const isSameOrigin =
+		fetchSite === 'same-origin' ||
+		(reqOrigin !== null && reqOrigin.toLowerCase() === allowedOrigin);
+	if (!isSameOrigin) {
+		return json({ error: 'forbidden' }, { status: 403 });
+	}
+
+	try {
+		const upstream = getUpstream();
+		const res = await fetch(upstream);
+		if (!res.ok) {
+			return json(
+				{ error: `Upstream returned ${res.status}` },
+				{ status: res.status === 404 ? 404 : 502 }
+			);
+		}
+		const data = await res.json();
+		return json(data);
+	} catch (err) {
+		console.error('cryptoprices proxy error:', err);
+		return json({ error: 'Failed to fetch upstream cryptoprices' }, { status: 502 });
+	}
+};


### PR DESCRIPTION
## Production incident

`api.v4v.app` stopped sending `Access-Control-Allow-Origin` on the
`/v1/cryptoprices/` endpoint. Browser direct-fetch is now blocked,
cascading into:

- **`/pools`** — nothing renders (`fetchPools()` awaits
  `getCryptoPrices()` before doing anything else)
- **MarketPrices** dashboard card — empty
- **Balance USD conversions** — every `convertTo(Coin.usd, …)` throws
- **Swap fee / review screens** — USD figures blank or stale

Same class of incident as the GraphQL CORS tightening fixed in 0.3.7.
Same playbook.

## Fix

New same-origin server proxy at `/api/cryptoprices` (`src/routes/api/cryptoprices/+server.ts`)
forwards the request server-to-server, where CORS doesn't apply. The
client (`src/lib/sendswap/v4v/api-types/cryptoprices.ts`) now points
at the proxy URL instead of `https://api.v4v.app/v1/cryptoprices/`
directly.

### Origin check

APP-09 same-origin gate, but accepts **both**:

- `Sec-Fetch-Site: same-origin` (sent by all modern browsers for
  same-origin requests, including GETs where `Origin` is omitted)
- `Origin === allowedOrigin` (POST/CORS path used by other proxies)

Direct URL navigation (`Sec-Fetch-Site: none`) is rejected — the
endpoint is meant to be called programmatically by the app only.

### Dev/prod selection

`PUBLIC_V4VAPP_API_MODE` is now read server-side in the proxy
(was `V4VAPP_API_BASE` consumed in the client). Same behavior, just
the right side of the network boundary.

## What I checked

- Type-check baseline unchanged at 146 errors / 32 warnings
- 220/220 tests pass
- Live indexer / pool query path unaffected (separate endpoint)