### PR TITLE
fix(transfer): remove unused getFee import and update accountBalance …

### DIFF
--- a/src/lib/sendswap/stages/TransferOptions.svelte
+++ b/src/lib/sendswap/stages/TransferOptions.svelte
@@ -8,7 +8,6 @@
 		getLastPaidContact,
 		getLastPaidNetwork,
 		getRecipientNetworks,
-		getFee,
 		solveToNetworks,
 		type NetworkOptionParam
 	} from '../utils/sendUtils';
@@ -41,7 +40,7 @@
 	import Divider from '$lib/components/Divider.svelte';
 	import BalanceInfo from '../components/info/BalanceInfo.svelte';
 	import PillButton from '$lib/PillButton.svelte';
-	import { accountBalance, type AccountBalance } from '$lib/stores/currentBalance';
+	import { accountBalance, getBalanceAmount, type AccountBalance } from '$lib/stores/currentBalance';
 	import {
 		estimateBtcUnmapFee,
 		type BtcFeeEstimate


### PR DESCRIPTION
This pull request makes minor updates to the `TransferOptions.svelte` component, primarily involving import statements. The changes include removing an unused utility function and adding a new import from the balance store.

- **Code cleanup:**
  * Removed the unused `getFee` import from `sendUtils` to keep the codebase clean.

- **Balance store update:**
  * Added the `getBalanceAmount` import from `$lib/stores/currentBalance`, as this was throwing an error after a transfer from a non hive account