### PR TITLE
chore: align package.json version with CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Altera are documented here.
 
+> **Release process**: bump `package.json` version to match the new entry's
+> heading (e.g. `0.3.14`). The version was historically stuck at `0.0.1`
+> because the app is `"private": true` and never published — kept here for
+> CI / build-banner / release-script use, and so a glance at `package.json`
+> matches reality.
+
 ## [0.3.14] — 2026-06-03
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.0.1",
+	"version": "0.3.14",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {


### PR DESCRIPTION
## Summary
The `package.json` version was stuck at `0.0.1` since project inception while
the CHANGELOG ran from 0.3.7 through 0.3.14. No automation reads the field
today (the in-app version banner uses git SHA via vite.config), but having
it match reality makes a glance at `package.json` informative and primes
the file for any future CI / release tooling.

Adds a one-paragraph release-process note at the top of CHANGELOG.md so
the convention is documented going forward.