### PR TITLE
fix(swap): worst-case stabilizer quote — unblocks BTC swaps (0.3.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ All notable changes to Altera are documented here.
 > CI / build-banner / release-script use, and so a glance at `package.json`
 > matches reality.
 
+## [0.3.15] — 2026-06-06
+
+### Fixes
+
+- **BTC swaps were silently reverting with `slippage tolerance exceeded` on mainnet — fixed by changing the quote, not the slippage.** The on-chain consensus pendulum multiplies both fee legs by a stabilizer multiplier `m ∈ [1, 2]` (`incentive-pendulum/wasm/applier.go:200-221`, cap from `fees_int.go:DefaultStabilizerParamsBps`). `swapCalc.ts` was modeling `m = 1`, so on shallow pools (the 0.023-BTC BTC/HBD pool especially) the quote overstated the user's output and the contract reverted the swap. The right fix isn't to widen slippage — that's still optimistic and a swap at the cap still fails — it's to make the quote itself a **guaranteed floor**. We now compute fees with the worst-case `m = 2.0` cap baked in:
+  ```
+  expectedOutput = grossOut − 2 × (baseProtocolFee + baseClpFee)
+  ```
+  Properties this gives us:
+    - For any real on-chain `m ∈ [1, 2]`, `actualOutput ≥ expectedOutput` — users never receive less than quoted, sometimes more
+    - The on-chain slippage gate (`actualOutput ≥ min_amount_out`) always passes for the stabilizer portion; slippage is now back to its original job of absorbing reserve drift between sign and execute. Default stays at 1%
+    - No fetch of pendulum V/E geometry needed (which would re-implement consensus math — exactly the drift class this bug was an instance of). The bound is a constant, no drift possible
+    - Fixes the issue for **every** route touching the shallow pool (BTC↔HBD, BTC↔HIVE, HIVE↔BTC, HBD↔BTC) and the HBD↔HIVE edge-case failures the incident report also flagged
+  - **Trade-off (intentional):** the quote line is now pessimistic. On HIVE↔HBD the difference is ~0.06% (invisible). On BTC routes it's ~6.6% lower than a naive m=1 quote — but it matches the on-chain worst-case execution exactly. Users get **at least** what they see, never less. Truth over favorable comparison
+  - **Maintenance tripwire:** the fix encodes `STABILIZER_CAP_BPS = 20000n` (m = 2.0) at the top of `swapCalc.ts`. If `fees_int.go:DefaultStabilizerParamsBps.Cap` is ever raised in a protocol upgrade, this constant must move in the same PR — otherwise we silently regress. Tracked by two new tests in `swapCalc.test.ts` that pin the worst-case behavior against the worked figures from the incident report (76,132 mHBD floor for the 150,000-sat BTC→HBD case)
+  - UI is unchanged: original 4 slippage presets (`0.5 / 1 / 2 / 3%`), default 1%, custom cap back to ~100%. No banners, no info icons, no auto-raise. The math is just correct now
+- The long-term fix remains a backend `simulateSwap` that runs the actual `ApplySwapFees` and returns `userOutput` — that would let the quote be the EXACT delivery (m=1 to 2 as appropriate) instead of the worst-case floor. Until then this floor is the safe answer. Tracking via the incident report "Altera Swap Quote ↔ On-Chain Pendulum Divergence (Stabilizer Omission)" dated 2026-06-06
+- Both `/swap` (`SwapOptions.svelte`) and the dashboard QuickSwap card consume the same `swapCalc.ts`, so this fix flows into both UIs with no separate change
+
 ## [0.3.14] — 2026-06-03
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.3.14",
+	"version": "0.3.15",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {

--- a/src/lib/pools/swapCalc.test.ts
+++ b/src/lib/pools/swapCalc.test.ts
@@ -81,8 +81,12 @@ describe('calculateSwap', () => {
 		// 10 HIVE (10,000 units) into a 2,221 HIVE pool → ~0.45% of reserve
 		const r = calculateSwap(10_000n, 2_221_000n, 2_221_000n, 100);
 		expect(r.expectedOutput).toBeGreaterThan(0n);
-		// grossOut ≈ 9,955 mHBD; after fees should be >9,900 mHBD
-		expect(r.expectedOutput).toBeGreaterThan(9_900n);
+		// grossOut ≈ 9,955 mHBD. After the worst-case stabilizer (m=2.0)
+		// applied to both fee legs, expectedOutput is the FLOOR users will
+		// receive — ≈ 9,854 mHBD here (~1.5% below grossOut), still very
+		// close. Actual on-chain delivery is ≥ this floor for any real m.
+		expect(r.expectedOutput).toBeGreaterThan(9_800n);
+		expect(r.expectedOutput).toBeLessThan(9_955n); // strictly below grossOut
 	});
 
 	it('large trade near 50% cap has very high CLP fee', () => {
@@ -106,6 +110,47 @@ describe('calculateSwap', () => {
 	it('minAmountOut ≤ expectedOutput always', () => {
 		const r = calculateSwap(10_000n, 2_221_000n, 2_221_000n, 200);
 		expect(r.minAmountOut).toBeLessThanOrEqual(r.expectedOutput);
+	});
+
+	// ─── Stabilizer worst-case guarantees ─────────────────────────────────
+	// These pin the contract our quote makes with users: "you will receive
+	// AT LEAST `expectedOutput`". If anyone ever weakens the stabilizer
+	// floor (e.g. drops the ×2 multiplier without a matching backend
+	// guarantee), these tests turn red — and BTC swaps start reverting in
+	// production the same way they did before this fix.
+
+	it('expectedOutput equals the on-chain floor at the m=2.0 stabilizer cap', () => {
+		// Worked figures from the 2026-06-06 incident report (§5):
+		//   hop-1 BTC→HBD, 150,000 sats into 2,313,898 : 1,426,458
+		//   grossOut    ≈ 86,842
+		//   baseCLP     ≈ 5,286
+		//   baseProtocol ≈ 69
+		//   userOutput at m=2.0  ≈ 76,132
+		// Our worst-case quote MUST equal that floor (within BigInt floor
+		// rounding) — otherwise the 110%-reliable property is broken.
+		const r = calculateSwap(150_000n, 2_313_898n, 1_426_458n, 100);
+		// Allow ±5 units for floor-rounding differences across the
+		// independent base-fee calculations.
+		const ON_CHAIN_FLOOR = 76_132n;
+		const diff = r.expectedOutput - ON_CHAIN_FLOOR;
+		const absDiff = diff < 0n ? -diff : diff;
+		expect(absDiff).toBeLessThanOrEqual(5n);
+	});
+
+	it('expectedOutput is strictly less than grossOut (stabilizer is applied)', () => {
+		// If someone accidentally drops the ×2 multiplier this becomes
+		// equal to the m=1 quote which on-chain reality exceeds — and
+		// BTC swaps start reverting again.
+		const r = calculateSwap(150_000n, 2_313_898n, 1_426_458n, 100);
+		const newX = 2_313_898n + 150_000n;
+		const grossOut = 1_426_458n - (2_313_898n * 1_426_458n) / newX;
+		const m1Quote = grossOut - (grossOut * 8n) / 10000n - (150_000n * 150_000n * 1_426_458n) / (newX * newX);
+		// Worst-case must be strictly LESS than the m=1 quote — by roughly
+		// the size of one fee leg (the surplus). Sanity-check the gap is at
+		// least 5% of the m=1 quote on this very shallow pool.
+		expect(r.expectedOutput).toBeLessThan(m1Quote);
+		const gap = m1Quote - r.expectedOutput;
+		expect(Number(gap) / Number(m1Quote)).toBeGreaterThan(0.05);
 	});
 });
 

--- a/src/lib/pools/swapCalc.ts
+++ b/src/lib/pools/swapCalc.ts
@@ -8,14 +8,59 @@
  * pool, the constant-product invariant produces a gross output, and
  * fees are carved off that.
  *
- * Formulas (mirror the on-chain Go contract):
- *   grossOut  = Y - (X * Y) / (X + x)
- *   base fee  = grossOut * feeBps / 10000        (output units, floor 1)
- *   CLP fee   = (x^2 * Y) / (x + X)^2            (output units, floor 1)
- *   total fee = base fee + CLP fee
- *   amountOut = grossOut - base fee - CLP fee
- *   min_amount_out = amountOut * (10000 - slippageBps) / 10000
+ * Formulas:
+ *   grossOut          = Y - (X * Y) / (X + x)
+ *   base protocol fee = grossOut * feeBps / 10000        (output units, floor 1)
+ *   base CLP fee      = (x^2 * Y) / (x + X)^2            (output units, floor 1)
+ *
+ *   ─── STABILIZER WORST-CASE (m = 2.0 cap) ───
+ *
+ *   The on-chain consensus code applies a pendulum stabilizer
+ *   multiplier `m` to BOTH fee legs at execution
+ *   (`incentive-pendulum/wasm/applier.go:200-221`,
+ *   `incentive-pendulum/fees_int.go:68-124`). `m` is bounded:
+ *   `m ∈ [1.0, 2.0]` where 2.0 is the hard cap set by
+ *   `DefaultStabilizerParamsBps.Cap` (`fees_int.go:59-66`).
+ *
+ *   We don't know the live `m` from the frontend — fetching pendulum
+ *   V/E geometry would re-implement consensus math, exactly the drift
+ *   class this codebase was bitten by. Instead we use the bound:
+ *   compute `expectedOutput` as if `m = 2.0` (the worst case).
+ *
+ *     expectedOutput = grossOut - 2 × (baseProtocol + baseCLP)
+ *     min_amount_out = expectedOutput * (10000 - slippageBps) / 10000
+ *
+ *   Guarantees this gives us:
+ *     • For any real on-chain m ∈ [1, 2], actualOutput ≥ expectedOutput
+ *     • The slippage gate on-chain (`actualOutput ≥ min_amount_out`)
+ *       always passes for the stabilizer portion — slippage only
+ *       needs to absorb normal reserve drift between sign and execute
+ *     • User receives at least what they were quoted; sometimes more
+ *
+ *   Trade-off: the quote is pessimistic. On deep HIVE/HBD pools the
+ *   surplus is ~0.06% so the difference is invisible. On the shallow
+ *   BTC/HBD pool it can be 6.6% — users see a lower number than a
+ *   naive `m = 1` quote, but they will never be under-delivered.
+ *
+ *   ⚠️ MAINTENANCE TRIPWIRE: this depends on the on-chain cap staying
+ *   at 2.0. If `fees_int.go:DefaultStabilizerParamsBps.Cap` is ever
+ *   raised, update `STABILIZER_CAP_BPS` below in lockstep — otherwise
+ *   we silently regress to the same class of bug.
+ *
+ *   The proper long-term fix is still a backend `simulateSwap` that
+ *   returns the actual `userOutput` from the live `ApplySwapFees`.
+ *   Tracking: incident report "Altera Swap Quote ↔ On-Chain Pendulum
+ *   Divergence (Stabilizer Omission)" dated 2026-06-06.
  */
+
+/**
+ * Hard cap on the pendulum stabilizer multiplier `m` in basis points.
+ * 20000 bps = m = 2.0. Mirrors `DefaultStabilizerParamsBps.Cap` in
+ * `go-vsc-node/modules/incentive-pendulum/fees_int.go:59-66`. If that
+ * file's `Cap` ever changes, change this constant in the same PR.
+ */
+const STABILIZER_CAP_BPS = 20000n;
+const BPS_SCALE = 10000n;
 
 import { GetStateByKeysStore } from '$houdini';
 import { fetchPoolRegistry, fetchPoolLiquiditySnapshot } from './poolsData';
@@ -133,12 +178,19 @@ export async function findPoolByPair(
 }
 
 /**
- * Calculate swap fees and expected output using pure integer arithmetic.
+ * Calculate swap fees and worst-case expected output.
+ *
+ * The returned `baseFee` / `clpFee` / `totalFee` are the **charged**
+ * fees at the stabilizer cap (i.e. base × 2). UI components that want
+ * the unmultiplied base fees can recover them as `totalFee / 2`.
  *
  * @param x         Input amount (smallest units)
  * @param X         Reserve of input asset (smallest units)
  * @param Y         Reserve of output asset (smallest units)
- * @param slippageBps  Slippage tolerance in basis points (e.g. 100 = 1%)
+ * @param slippageBps  Slippage tolerance in basis points (e.g. 100 = 1%).
+ *                     Now only needs to absorb normal AMM reserve drift
+ *                     between sign and execute — the stabilizer surplus
+ *                     is already baked into `expectedOutput`.
  */
 export function calculateSwap(
 	x: bigint,
@@ -161,18 +213,30 @@ export function calculateSwap(
 	const newX = X + x;
 	const grossOut = Y - (X * Y) / newX;
 
-	// base fee = grossOut * 8 / 10000  (output units, floor 1 to match contract)
-	let baseFee = (grossOut * 8n) / 10000n;
-	if (baseFee === 0n) baseFee = 1n;
+	// Base fees, before stabilizer multiplier (mirror on-chain at m=1):
+	//   protocol fee = grossOut * 8 / 10000   (output units, floor 1)
+	//   CLP fee      = (x^2 * Y) / (x + X)^2  (output units, floor 1)
+	let baseProtocolFee = (grossOut * 8n) / 10000n;
+	if (baseProtocolFee === 0n) baseProtocolFee = 1n;
 
-	// CLP fee = (x^2 * Y) / (x + X)^2  (output units, floor 1)
-	let clpFee = (x * x * Y) / (newX * newX);
-	if (clpFee === 0n) clpFee = 1n;
+	let baseClpFee = (x * x * Y) / (newX * newX);
+	if (baseClpFee === 0n) baseClpFee = 1n;
 
-	const totalFee = baseFee + clpFee;
+	// Apply the worst-case stabilizer multiplier (m = 2.0 at the cap).
+	// On-chain the multiplier is `charged = floor(base * m_bps / BpsScale)`
+	// — matches `incentive-pendulum/fees_int.go:128-133 ApplyMultiplierBps`.
+	// We use m_bps = STABILIZER_CAP_BPS so the resulting `expectedOutput`
+	// is a guaranteed FLOOR over any real on-chain m ∈ [1, 2].
+	const chargedProtocolFee = (baseProtocolFee * STABILIZER_CAP_BPS) / BPS_SCALE;
+	const chargedClpFee = (baseClpFee * STABILIZER_CAP_BPS) / BPS_SCALE;
+	const totalFee = chargedProtocolFee + chargedClpFee;
 
-	// amountOut = grossOut - baseFee - clpFee
-	let expectedOutput = grossOut - baseFee - clpFee;
+	// expectedOutput is the worst-case net delivery (m = 2.0).
+	// Actual on-chain delivery for any real m ∈ [1, 2] is ≥ this number,
+	// so the contract's `actualOutput ≥ min_amount_out` gate always passes
+	// for the stabilizer portion when slippage ≥ 0 (slippage just covers
+	// normal reserve drift now).
+	let expectedOutput = grossOut - totalFee;
 	if (expectedOutput < 0n) {
 		expectedOutput = 0n;
 	}
@@ -182,8 +246,8 @@ export function calculateSwap(
 	const minAmountOut = (expectedOutput * (10000n - slipBps)) / 10000n;
 
 	return {
-		baseFee,
-		clpFee,
+		baseFee: chargedProtocolFee,
+		clpFee: chargedClpFee,
 		totalFee,
 		expectedOutput,
 		minAmountOut,

--- a/src/lib/pools/swapCalcConsumers.test.ts
+++ b/src/lib/pools/swapCalcConsumers.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Drift guard for the swap-math single source of truth.
+ *
+ * The pendulum stabilizer fix (2026-06-06) bakes a worst-case m=2.0
+ * multiplier into `calculateSwap` / `calculateTwoHopSwap` in
+ * `src/lib/pools/swapCalc.ts`. Every UI that quotes a swap to users
+ * MUST route through that file — otherwise the floor guarantee
+ * (user receives ≥ quoted) silently breaks for that UI.
+ *
+ * This test asserts the known consumers (today: the /swap page and
+ * the dashboard QuickSwap card) still:
+ *   1. import from `$lib/pools/swapCalc`
+ *   2. actually call `calculateSwap` (or `calculateTwoHopSwap`) at least once
+ *   3. do NOT redefine `calculateSwap` locally
+ *
+ * If a new file starts computing swap fees, add it to KNOWN_CONSUMERS
+ * — the act of editing this list is itself the review prompt.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const KNOWN_CONSUMERS = [
+	'src/lib/cards/QuickSwap.svelte',
+	'src/lib/sendswap/stages/SwapOptions.svelte'
+];
+
+describe('swap math drift guard — consumers must route through swapCalc.ts', () => {
+	for (const rel of KNOWN_CONSUMERS) {
+		describe(rel, () => {
+			const abs = resolve(process.cwd(), rel);
+			const src = readFileSync(abs, 'utf-8');
+
+			it('imports from $lib/pools/swapCalc', () => {
+				expect(src).toMatch(/from\s+['"]\$lib\/pools\/swapCalc['"]/);
+			});
+
+			it('imports calculateSwap or calculateTwoHopSwap by name', () => {
+				// Loose: either symbol satisfies. SwapOptions uses both; QuickSwap uses both.
+				expect(src).toMatch(/\bcalculateSwap\b|\bcalculateTwoHopSwap\b/);
+			});
+
+			it('actually calls one of the math functions (not just imports it)', () => {
+				// A call-site, distinguished from a bare reference / import line.
+				expect(src).toMatch(/\b(calculateSwap|calculateTwoHopSwap)\s*\(/);
+			});
+
+			it('does NOT redefine calculateSwap locally', () => {
+				// Catches the copy-paste regression: someone inlines the math here
+				// and forgets the worst-case stabilizer multiplier.
+				expect(src).not.toMatch(/function\s+calculateSwap\s*\(/);
+				expect(src).not.toMatch(/const\s+calculateSwap\s*=\s*\(/);
+			});
+
+			it('does NOT redefine calculateTwoHopSwap locally', () => {
+				expect(src).not.toMatch(/function\s+calculateTwoHopSwap\s*\(/);
+				expect(src).not.toMatch(/const\s+calculateTwoHopSwap\s*=\s*\(/);
+			});
+		});
+	}
+});


### PR DESCRIPTION
## Summary

Fixes the production incident where BTC swaps reverted on mainnet with
`slippage tolerance exceeded`. Root cause: `swapCalc.ts` ignored the
on-chain pendulum stabilizer multiplier (`m ∈ [1, 2]` per
`go-vsc-node/incentive-pendulum/fees_int.go:DefaultStabilizerParamsBps`),
so the quoted output exceeded what the contract delivered. On the
shallow BTC/HBD pool the gap (~2–7%) blew past the 1% default slippage
deterministically.

The fix doesn't widen slippage and doesn't port the consensus math —
both of those carry the same drift risk this bug was an instance of.
Instead it uses the **bound**: compute the quote as if `m = 2.0` (the
cap). For any real on-chain `m ≤ 2`, `actualOutput ≥ expectedOutput`,
so the contract's slippage gate always passes for the stabilizer
portion. Slippage is back to its original job (reserve drift only).

## What changes for users

| Surface | Before | After |
|---|---|---|
| Quote shown | Optimistic — user gets less | Guaranteed floor — user gets ≥ quoted, sometimes more |
| BTC swaps at default 1% slippage | Reverted deterministically | Complete |
| HBD↔HIVE edge-case reverts | Possible | Fixed (same mechanism) |
| UI / slippage presets | — | Unchanged. 0.5 / 1 / 2 / 3%, default 1% |

Quote becomes pessimistic on BTC routes (~6.6% lower than a naive m=1
quote) — matches the on-chain worst case exactly. On HIVE↔HBD it's
~0.06% lower — invisible.

## Both UIs covered

`/swap` (`SwapOptions.svelte`) and the dashboard QuickSwap card both
consume the same `swapCalc.ts`. One change, both surfaces.

## Tests

- **`swapCalc.test.ts`** — pins the worst-case floor against the
  incident report's worked figures (76,132 mHBD floor for the
  150,000-sat BTC→HBD case from the failing tx `6891b6bc…`). Also
  asserts the multiplier is actually applied — catches accidental
  removal.
- **`swapCalcConsumers.test.ts`** (new) — static drift guard:
  `QuickSwap.svelte` and `SwapOptions.svelte` must (a) import from
  `$lib/pools/swapCalc`, (b) actually call it, and (c) not redefine
  the math locally. Catches the copy-paste regression where someone
  inlines stale fee math into a consumer.

Full suite: 232 passing, 2 skipped, 0 failed. Type-check baseline
holds at 60/32.

## ⚠ Maintenance tripwire (please read)

`STABILIZER_CAP_BPS = 20000n` in `swapCalc.ts` mirrors
`DefaultStabilizerParamsBps.Cap = 2.0` in
`go-vsc-node/modules/incentive-pendulum/fees_int.go:59-66`.

**If a future protocol PR raises that cap, this constant must move in
lockstep**, or the worst-case ceases to be the worst case and we
silently regress. The drift-guard tests can't catch this because they
check our code, not the backend — needs backend-team awareness.

A nice-to-have long-term: expose the cap via GraphQL (or any read-only
endpoint) so Altera fetches it at runtime instead of hardcoding.

## Long-term direction

The proper fix is still a backend `simulateSwap` that returns the
actual `userOutput` from the live `ApplySwapFees`. That would let the
quote show the exact m=1.4 typical delivery instead of the m=2.0
floor — slightly better UX, same reliability. Tracking via the
2026-06-06 incident report.