### PR TITLE
fix(swap): show explicit "exceeds pool" hint next to blank receive field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to Altera are documented here.
 > CI / build-banner / release-script use, and so a glance at `package.json`
 > matches reality.
 
+## [0.3.16] — 2026-06-06
+
+### Fixes
+
+- **Receive field went blank with no explanation when the swap input was too large for the pool** (e.g. 1 BTC into the ~0.023 BTC pool, or 10,000 HBD into a 1,426 HBD pool). The calc correctly clamps `expectedOutput` to `0n` in these cases and the submit button is correctly disabled, but the existing "Amount exceeds pool depth" hint was a small inline span on the FROM side sitting next to the USD line, so users staring at the blank RECEIVE field read it as "the page froze". The post-0.3.15 worst-case stabilizer slightly widens the range where the m=2 fee overflows `grossOut` → clamps to 0, which made this UX flaw more obvious. Two small changes on `/swap` (`SwapOptions.svelte`): mirror the pool-depth hint on the RECEIVE side ("Pool can't absorb this amount") so the blank field has a reason right next to it; reword the FROM-side message from the jargony "Amount exceeds pool depth" to "Insufficient pool liquidity — try a smaller amount". QuickSwap already renders this as a prominent banner and was left untouched
+
 ## [0.3.15] — 2026-06-06
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.3.15",
+	"version": "0.3.16",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {

--- a/src/lib/sendswap/stages/SwapOptions.svelte
+++ b/src/lib/sendswap/stages/SwapOptions.svelte
@@ -1029,7 +1029,7 @@ let expectedOutputUsd = $derived.by(() => {
 							>Insufficient {coinDisplayLabel(txState.from.coin)} balance</span
 						>
 					{:else if exceedsPoolDepth}
-						<span class="section-error-inline">Amount exceeds pool depth</span>
+						<span class="section-error-inline">Insufficient pool liquidity — try a smaller amount</span>
 					{/if}
 				</div>
 			</div>
@@ -1096,6 +1096,16 @@ let expectedOutputUsd = $derived.by(() => {
 							<span class="price-unavailable">Price unavailable</span>
 						{/if}
 					</span>
+					<!-- Mirror the "exceeds pool depth" hint on the receive side too:
+					     when the input overflows the pool the calc clamps expectedOutput
+					     to 0 and AmountInput renders empty, which reads as "nothing
+					     happened". This makes the cause obvious right next to the
+					     blank field. Other section-error-inline cases (sameCoin,
+					     insufficientBalance) already render on the FROM side, so we
+					     only echo the pool-depth one here. -->
+					{#if exceedsPoolDepth}
+						<span class="section-error-inline">Pool can't absorb this amount</span>
+					{/if}
 				</div>
 			</div>
 


### PR DESCRIPTION
## Summary

Post-0.3.15, when a swap input exceeds the pool's input-side reserve
(1 BTC into the ~0.023 BTC pool, 10,000 HBD into a 1,426 HBD pool, etc.),
the receive field went blank with no nearby explanation. The math is
correct (swap is impossible, submit is disabled) and there *was* an
"Amount exceeds pool depth" hint on the FROM side — but it was a small
inline span sitting next to the USD line, so the blank RECEIVE field
read as "the page froze".

This PR adds two surgical changes on `/swap` (`SwapOptions.svelte`):
- Mirror the pool-depth hint on the RECEIVE side ("Pool can't absorb this amount")
- Reword the FROM-side message from "Amount exceeds pool depth" to "Insufficient pool liquidity — try a smaller amount"

QuickSwap already renders this loudly and was left untouched.