### PR TITLE
feat(transactions): filters, sorting, and per-tx protocol fees (0.3.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ All notable changes to Altera are documented here.
 > CI / build-banner / release-script use, and so a glance at `package.json`
 > matches reality.
 
+## [0.3.17] — 2026-06-10
+
+### Features
+
+- **Transactions page: filters.** Quick chips for tokens (HIVE/HBD/BTC) and time range (all/24h/7d/30d) inline above the table, plus a right-edge drawer (portaled to `document.body`, slides in/out, backdrop/ESC/Done all close it) holding all five filter groups: tokens, time range, amount min–max, operation type, and address/user. Hybrid design: client-side filtering over the merged list is the display source of truth (the merged list contains localStorage pending txs and BTC-deposit indexer events the server never filtered); the server-expressible subset (`byType`, `byLedgerToFrom`) is threaded into the GraphQL fetches so paginated pages stay relevant. Active panel filters surface as per-value summary chips with individual clear buttons, grouped by category with pipe separators. Text inputs apply live with a 300ms debounce; every close path commits pending text. Auto-top-up keeps extending fetches while client filters leave fewer than 8 visible rows
+- **Transactions page: sorting.** Date and Amount column headers are click-to-sort (desc → asc toggle with a chevron on the active column), mirroring the pools-table pattern. Amount sorts on USD value across assets; the per-item value is the largest ledger/op entry — not the sum — because a swap's ledger repeats the same value across hops and summing would double-count. Default stays Date desc (the feed's natural order, sort pass skipped entirely). Status/Type/To-From deliberately not sortable: they're categories, and the filter drawer serves those better
+- **Transaction detail popup: protocol-fee section.** Swaps pay the protocol (magi) fee as an explicit ledger transfer to `pendulum:nodes` — those legs now show in the popup, summed per asset. Deliberately not a table column: the LP fee and stabilizer surcharge stay in the pool (implicit in the exchange rate), so a per-row fee column would under-report the real cost; the popup carries the honest note "LP fee is included in the exchange rate"
+
+### Fixes
+
+- Transactions card capped at `calc(100vh - 12rem)` — the empty-state's blurred skeleton rows no longer stretch the card past the screen, and the empty state is no longer scrollable (it only contained decorative rows). The small dashboard embed opts out and keeps sizing to its container
+
+### Testing
+
+- 36 tests in `filters.test.ts` pin the filter matrix (per-group matching, asset normalization, amount-unit handling for both smallest-unit ints and Hive L1 decimal strings, combined AND semantics, identity fast-path, server-vars mapping) and the sort semantics (date asc/desc, USD-normalized cross-asset ordering, max-not-sum for swap ledgers, input immutability)
+
 ## [0.3.16] — 2026-06-06
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.3.16",
+	"version": "0.3.17",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {

--- a/src/lib/stores/txStores.ts
+++ b/src/lib/stores/txStores.ts
@@ -225,6 +225,17 @@ export function clearAllStores() {
 	btcDepositStore.set([]);
 }
 
+/**
+ * Optional server-side filter variables threaded into GetTransactions.
+ * Used by the transactions page's filter bar so paginated fetches return
+ * mostly-matching rows; display filtering is still client-side (see
+ * routes/(authed)/transactions/filters.ts for the rationale).
+ */
+export type TxServerFilters = {
+	byType?: string[];
+	byLedgerToFrom?: string;
+};
+
 // load txs from store
 // set: sets the store to the txs loaded
 // update: loads new txs, adds any that aren't in local store to the front
@@ -233,7 +244,8 @@ export async function fetchTxs(
 	did: string,
 	type: 'set' | 'update' | 'extend',
 	setLoading?: (val: boolean) => void,
-	limit = 12
+	limit = 12,
+	serverFilters?: TxServerFilters
 ) {
 	if (type !== 'update') {
 		if (setLoading) setLoading(true);
@@ -243,7 +255,9 @@ export async function fetchTxs(
 			variables: {
 				limit: limit,
 				did,
-				offset: type === 'extend' ? get(magiTxsStore).length : undefined
+				offset: type === 'extend' ? get(magiTxsStore).length : undefined,
+				byType: serverFilters?.byType,
+				byLedgerToFrom: serverFilters?.byLedgerToFrom
 			},
 			policy: 'NetworkOnly'
 		})
@@ -298,7 +312,11 @@ export async function fetchTxs(
 	return success;
 }
 
-export async function waitForExtend(did: string, limit = 12): Promise<boolean> {
-	await fetchTxs(did, 'extend', undefined, limit);
+export async function waitForExtend(
+	did: string,
+	limit = 12,
+	serverFilters?: TxServerFilters
+): Promise<boolean> {
+	await fetchTxs(did, 'extend', undefined, limit, serverFilters);
 	return true;
 }

--- a/src/routes/(authed)/transactions/+page.svelte
+++ b/src/routes/(authed)/transactions/+page.svelte
@@ -2,10 +2,13 @@
 	import { getAccountNameFromDid } from '$lib/getAccountName';
 	import { page } from '$app/state';
 	import Table from './Table/Table.svelte';
+	import FilterBar from './FilterBar.svelte';
+	import { EMPTY_FILTERS, type TxFilters } from './filters';
 	import { getAuth } from '$lib/auth/store';
 	import { goto } from '$app/navigation';
 	let auth = $derived(getAuth()());
 	let did = $derived(auth.value?.did);
+	let filters = $state<TxFilters>({ ...EMPTY_FILTERS });
 	const autoOpenOp: [string, number] | undefined = $derived.by(() => {
 		const autoOpenTxId = page.url.searchParams.get('tx');
 		const autoOpenIndex = Number(page.url.searchParams.get('index'));
@@ -28,7 +31,10 @@
 <div class="flex">
 	<h1>Transactions involving {did ? getAccountNameFromDid(did) : '0xd072...AdAA'}</h1>
 	{#if did}
-		<Table {did} initialOpen={autoOpenOp}></Table>
+		<!-- Chips row with the Filters trigger at its right end, below the
+		     title and directly above the table. -->
+		<FilterBar bind:filters />
+		<Table {did} initialOpen={autoOpenOp} {filters}></Table>
 	{/if}
 </div>
 
@@ -39,7 +45,7 @@
 		font-family: 'Nunito Sans', sans-serif;
 		font-size: 1.25rem;
 		font-weight: 600;
-		margin: 0 0 1rem 0;
+		margin: 0 0 0.75rem 0;
 	}
 	.flex {
 		display: flex;

--- a/src/routes/(authed)/transactions/FilterBar.svelte
+++ b/src/routes/(authed)/transactions/FilterBar.svelte
@@ -1,0 +1,617 @@
+<!--
+	Filter controls for the transactions table — two surfaces:
+
+	1. QUICK FILTERS: token + time-range chips rendered inline (hidden on
+	   narrow screens via media query) so the most common filters are one
+	   click away without opening anything.
+	2. FULL PANEL: a "Filters" button (rendered top-right by the parent's
+	   header row) opening the project's SidePopup — the same right-slide
+	   panel used for transaction details — holding all five filter
+	   groups with room to breathe.
+
+	State is owned by the parent (+page.svelte) via the bindable `filters`
+	prop. Filtering itself happens elsewhere (filters.ts / Table.svelte).
+-->
+<script lang="ts">
+	import { fade, fly } from 'svelte/transition';
+	import { portal } from '@zag-js/svelte';
+	import { ListFilter, X } from '@lucide/svelte';
+	import {
+		EMPTY_FILTERS,
+		TIME_RANGE_OPTIONS,
+		TOKEN_OPTIONS,
+		TYPE_OPTIONS,
+		activeFilterCount,
+		type TxFilters
+	} from './filters';
+
+	let { filters = $bindable() }: { filters: TxFilters } = $props();
+
+	const activeCount = $derived(activeFilterCount(filters));
+
+	let panelOpen = $state(false);
+	function togglePanel() {
+		// Commit any half-typed text before the panel goes away — closing
+		// the drawer must never silently drop input.
+		if (panelOpen) commitTexts();
+		panelOpen = !panelOpen;
+	}
+
+	// Local text state for the free-text inputs. Applied LIVE with a
+	// 300ms debounce — the client filter is a pure function over the
+	// loaded rows (sub-ms), and the only expensive path (server refetch
+	// for full account ids) fires once after typing stops, not per
+	// keystroke. Enter applies immediately.
+	let amountMinText = $state('');
+	let amountMaxText = $state('');
+	let addressText = $state('');
+
+	let debounceHandle: ReturnType<typeof setTimeout> | undefined;
+	function debounceCommit() {
+		clearTimeout(debounceHandle);
+		debounceHandle = setTimeout(commitTexts, 300);
+	}
+
+	function commitTexts() {
+		clearTimeout(debounceHandle);
+		const min = parseFloat(amountMinText.replace(',', '.'));
+		const max = parseFloat(amountMaxText.replace(',', '.'));
+		filters.amountMin = Number.isFinite(min) && min > 0 ? min : null;
+		filters.amountMax = Number.isFinite(max) && max > 0 ? max : null;
+		filters.address = addressText.trim();
+	}
+
+	function toggleToken(value: string) {
+		filters.tokens = filters.tokens.includes(value)
+			? filters.tokens.filter((t) => t !== value)
+			: [...filters.tokens, value];
+	}
+
+	function toggleType(value: string) {
+		filters.types = filters.types.includes(value)
+			? filters.types.filter((t) => t !== value)
+			: [...filters.types, value];
+	}
+
+	function clearAll() {
+		filters = { ...EMPTY_FILTERS };
+		amountMinText = '';
+		amountMaxText = '';
+		addressText = '';
+	}
+
+	const amountChipLabel = $derived.by(() => {
+		const { amountMin: min, amountMax: max } = filters;
+		if (min != null && max != null) return `${min} – ${max}`;
+		if (min != null) return `≥ ${min}`;
+		if (max != null) return `≤ ${max}`;
+		return '';
+	});
+
+	/** Any filter set from the PANEL (not the quick chips) is active —
+	 *  drives the pipe divider before the dynamic summary chips. */
+	const hasPanelChips = $derived(
+		amountChipLabel !== '' || filters.types.length > 0 || filters.address.trim() !== ''
+	);
+</script>
+
+<!-- One row: permanent quick chips │ dynamic summary chips … [Filters].
+     The trigger sits at the right END of the chips row (margin-left auto),
+     not up on the title line. -->
+<div class="quick-filters">
+	<div class="quick-group">
+		{#each TOKEN_OPTIONS as opt (opt.value)}
+			<button
+				class="chip"
+				class:on={filters.tokens.includes(opt.value)}
+				onclick={() => toggleToken(opt.value)}
+			>
+				{opt.label}
+			</button>
+		{/each}
+	</div>
+	<div class="quick-sep"></div>
+	<div class="quick-group">
+		{#each TIME_RANGE_OPTIONS as opt (opt.value)}
+			<button
+				class="chip"
+				class:on={filters.timeRange === opt.value}
+				onclick={() => (filters.timeRange = opt.value)}
+			>
+				{opt.label}
+			</button>
+		{/each}
+	</div>
+
+	<!-- Pipe divider: separates the ALWAYS-PRESENT quick chips from the
+	     dynamic summary chips that appear/disappear as panel filters
+	     toggle. Rendered only when at least one panel filter is active. -->
+	{#if hasPanelChips}
+		<div class="quick-sep"></div>
+	{/if}
+
+	<!-- Summary chips, grouped by category with a pipe BETWEEN categories
+	     (amount │ types │ address) — chips of the same category sit
+	     together; the pipes mark the category boundaries. -->
+	{#if amountChipLabel}
+		<span class="summary-chip">
+			{amountChipLabel}
+			<button
+				aria-label="Clear amount filter"
+				onclick={() => {
+					filters.amountMin = null;
+					filters.amountMax = null;
+					amountMinText = '';
+					amountMaxText = '';
+				}}><X size={12} /></button
+			>
+		</span>
+	{/if}
+	{#if amountChipLabel && filters.types.length > 0}
+		<div class="quick-sep"></div>
+	{/if}
+	<!-- One chip per selected type, each individually clearable — removing
+	     "transfer" shouldn't also clear "deposit". -->
+	{#each filters.types as t (t)}
+		<span class="summary-chip">
+			{TYPE_OPTIONS.find((o) => o.value === t)?.label ?? t}
+			<button aria-label="Remove {t} filter" onclick={() => toggleType(t)}
+				><X size={12} /></button
+			>
+		</span>
+	{/each}
+	{#if filters.address.trim() !== '' && (amountChipLabel !== '' || filters.types.length > 0)}
+		<div class="quick-sep"></div>
+	{/if}
+	{#if filters.address.trim() !== ''}
+		<span class="summary-chip">
+			{filters.address}
+			<button
+				aria-label="Clear address filter"
+				onclick={() => {
+					filters.address = '';
+					addressText = '';
+				}}><X size={12} /></button
+			>
+		</span>
+	{/if}
+
+	<button class="filter-trigger" class:active={activeCount > 0} onclick={togglePanel}>
+		<ListFilter size={15} />
+		<span>Filters{activeCount > 0 ? ` (${activeCount})` : ''}</span>
+	</button>
+</div>
+
+<!-- ── Right-edge drawer ──
+     A fixed full-height panel sliding in from the right edge of the
+     screen (~26rem wide, capped at 90vw on phones). Backdrop click and
+     ESC both slide it back out. Local to this component on purpose —
+     the shared SidePopup is a centered modal used by tx details and
+     restyling it would change that surface too. -->
+<svelte:window
+	onkeydown={(e) => {
+		if (e.key === 'Escape' && panelOpen) togglePanel();
+	}}
+/>
+
+{#if panelOpen}
+	<!-- use:portal teleports both nodes to document.body — same trick
+	     SidePopup uses. Without it, any ancestor with a transform /
+	     backdrop-filter becomes the containing block for position:fixed
+	     and the drawer renders trapped inside the page card instead of
+	     spanning the full viewport. -->
+	<div
+		use:portal
+		class="drawer-backdrop"
+		transition:fade={{ duration: 180 }}
+		onclick={togglePanel}
+		role="presentation"
+	></div>
+	<div
+		use:portal
+		class="drawer"
+		transition:fly={{ x: 420, duration: 260, opacity: 1 }}
+		role="dialog"
+		aria-modal="true"
+		aria-label="Filter transactions"
+	>
+		<div class="drawer-header">
+			<h3>Filters</h3>
+			<button class="drawer-close" aria-label="Close filters" onclick={togglePanel}>
+				<X size={20} />
+			</button>
+		</div>
+		{@render panelContent()}
+	</div>
+{/if}
+
+{#snippet panelContent()}
+	<div class="filter-panel">
+		<section>
+			<h4>Tokens</h4>
+			<div class="chip-group">
+				{#each TOKEN_OPTIONS as opt (opt.value)}
+					<button
+						class="chip large"
+						class:on={filters.tokens.includes(opt.value)}
+						onclick={() => toggleToken(opt.value)}
+					>
+						{opt.label}
+					</button>
+				{/each}
+			</div>
+		</section>
+
+		<section>
+			<h4>Time range</h4>
+			<div class="chip-group">
+				{#each TIME_RANGE_OPTIONS as opt (opt.value)}
+					<button
+						class="chip large"
+						class:on={filters.timeRange === opt.value}
+						onclick={() => (filters.timeRange = opt.value)}
+					>
+						{opt.label}
+					</button>
+				{/each}
+			</div>
+		</section>
+
+		<section>
+			<h4>Amount</h4>
+			<div class="amount-row">
+				<input
+					type="text"
+					inputmode="decimal"
+					placeholder="Min"
+					bind:value={amountMinText}
+					oninput={debounceCommit}
+				/>
+				<span class="amount-sep">–</span>
+				<input
+					type="text"
+					inputmode="decimal"
+					placeholder="Max"
+					bind:value={amountMaxText}
+					oninput={debounceCommit}
+				/>
+			</div>
+			<p class="hint">In the asset&rsquo;s own units — e.g. 10 matches 10 HIVE or 10 BTC</p>
+		</section>
+
+		<section>
+			<h4>Type</h4>
+			<div class="chip-group">
+				{#each TYPE_OPTIONS as opt (opt.value)}
+					<button
+						class="chip large"
+						class:on={filters.types.includes(opt.value)}
+						onclick={() => toggleType(opt.value)}
+					>
+						{opt.label}
+					</button>
+				{/each}
+			</div>
+		</section>
+
+		<section>
+			<h4>Address / user</h4>
+			<input
+				class="address-input"
+				type="text"
+				placeholder="hive:username, 0x…, bc1…"
+				bind:value={addressText}
+				oninput={debounceCommit}
+				onkeydown={(e) => {
+					if (e.key === 'Enter') commitTexts();
+				}}
+			/>
+			<p class="hint">Matches either side of a transfer, partial text is fine</p>
+		</section>
+
+		<div class="panel-footer">
+			<button class="clear-all" onclick={clearAll} disabled={activeCount === 0}>
+				Clear all
+			</button>
+			<button class="apply" onclick={togglePanel}>Done</button>
+		</div>
+	</div>
+{/snippet}
+
+<style lang="scss">
+	/* ── Trigger ── */
+	.filter-trigger {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		padding: 0.45rem 1rem;
+		border-radius: 999px;
+		border: 1px solid var(--dash-card-border);
+		background: rgba(255, 255, 255, 0.04);
+		color: var(--dash-text-primary);
+		font: inherit;
+		font-size: 0.85rem;
+		font-weight: 500;
+		cursor: pointer;
+		white-space: nowrap;
+		transition:
+			background-color 150ms ease,
+			border-color 150ms ease;
+	}
+	.filter-trigger:hover {
+		background: rgba(255, 255, 255, 0.08);
+	}
+	.filter-trigger.active {
+		border-color: var(--dash-accent-purple, #6f6af8);
+		color: var(--dash-accent-purple, #6f6af8);
+		background: rgba(111, 106, 248, 0.08);
+	}
+
+	/* ── Quick filters row ── */
+	.quick-filters {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		flex-wrap: wrap;
+		margin: 0.25rem 0 1rem;
+	}
+	/* Trigger sits at the right end of the chips row. */
+	.quick-filters > .filter-trigger {
+		margin-left: auto;
+	}
+	.quick-sep {
+		width: 1px;
+		height: 1.25rem;
+		background: var(--dash-card-border);
+		margin: 0 0.35rem;
+	}
+	.quick-group {
+		display: flex;
+		gap: 0.4rem;
+		flex-wrap: wrap;
+	}
+	/* On narrow screens the quick chips take too much vertical space —
+	   the side panel covers everything, so hide them and keep just the
+	   summary chips (which only render when something is active). */
+	@media (max-width: 900px) {
+		.quick-group,
+		.quick-sep {
+			display: none;
+		}
+	}
+
+	/* ── Chips (shared) ── */
+	.chip {
+		padding: 0.3rem 0.8rem;
+		border-radius: 999px;
+		border: 1px solid var(--dash-card-border);
+		background: rgba(255, 255, 255, 0.03);
+		color: var(--dash-text-secondary);
+		font: inherit;
+		font-size: 0.78rem;
+		font-weight: 500;
+		cursor: pointer;
+		white-space: nowrap;
+		transition: all 130ms ease;
+	}
+	.chip:hover {
+		border-color: rgba(255, 255, 255, 0.28);
+		color: var(--dash-text-primary);
+	}
+	.chip.on {
+		border-color: var(--dash-accent-purple, #6f6af8);
+		background: rgba(111, 106, 248, 0.18);
+		color: var(--dash-text-primary);
+	}
+	.chip.large {
+		padding: 0.45rem 1rem;
+		font-size: 0.85rem;
+	}
+
+	/* ── Summary chips (active filters set from the panel) ── */
+	.summary-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3rem;
+		padding: 0.25rem 0.4rem 0.25rem 0.7rem;
+		border-radius: 999px;
+		border: 1px solid var(--dash-accent-purple, #6f6af8);
+		background: rgba(111, 106, 248, 0.12);
+		color: var(--dash-text-primary);
+		font-size: 0.75rem;
+		max-width: 14rem;
+		overflow: hidden;
+	}
+	.summary-chip button {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		background: none;
+		border: none;
+		padding: 0.1rem;
+		color: var(--dash-text-secondary);
+		cursor: pointer;
+		border-radius: 50%;
+	}
+	.summary-chip button:hover {
+		color: var(--dash-text-primary);
+		background: rgba(255, 255, 255, 0.1);
+	}
+
+	/* ── Drawer shell ── */
+	.drawer-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.55);
+		z-index: 40;
+	}
+	.drawer {
+		position: fixed;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		width: min(26rem, 90vw);
+		box-sizing: border-box;
+		z-index: 41;
+		display: flex;
+		flex-direction: column;
+		background: linear-gradient(135deg, #20202a 0%, #13131a 100%);
+		border-left: 1px solid var(--dash-card-border);
+		box-shadow: -12px 0 40px rgba(0, 0, 0, 0.45);
+		padding: 1.25rem 1.5rem;
+		overflow-y: auto;
+	}
+	.drawer-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 1.25rem;
+	}
+	.drawer-header h3 {
+		margin: 0;
+		font-size: 1.15rem;
+		font-weight: 600;
+		color: var(--dash-text-primary);
+		font-family: 'Nunito Sans', sans-serif;
+	}
+	.drawer-close {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		background: none;
+		border: none;
+		padding: 0.35rem;
+		border-radius: 8px;
+		color: var(--dash-text-secondary);
+		cursor: pointer;
+		transition: background-color 130ms ease, color 130ms ease;
+	}
+	.drawer-close:hover {
+		background: rgba(255, 255, 255, 0.08);
+		color: var(--dash-text-primary);
+	}
+
+	/* ── Drawer content ── */
+	.filter-panel {
+		display: flex;
+		flex-direction: column;
+		/* Generous breathing room between filter groups — they read as
+		   distinct sections rather than one stacked blob. */
+		gap: 2.5rem;
+		padding-top: 0.5rem;
+	}
+	.filter-panel section {
+		display: flex;
+		flex-direction: column;
+		gap: 0.6rem;
+	}
+	.filter-panel h4 {
+		margin: 0;
+		font-size: 0.72rem;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--dash-text-secondary);
+		font-weight: 600;
+	}
+	.chip-group {
+		display: flex;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+	}
+
+	.amount-row {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+	}
+	/* Compact: fixed narrow width instead of flex-filling half the drawer
+	   each. Explicit height (not padding-derived) so the boxes are
+	   pixel-identical to the address input regardless of UA defaults. */
+	.amount-row input {
+		width: 6.5rem;
+		height: 2.25rem;
+		box-sizing: border-box;
+		flex: none;
+		font: inherit;
+		font-size: 0.85rem;
+		background: rgba(255, 255, 255, 0.04);
+		border: 1px solid var(--dash-card-border);
+		color: var(--dash-text-primary);
+		border-radius: 10px;
+		padding: 0 0.65rem;
+		transition: border-color 150ms ease;
+	}
+	.amount-row input:focus {
+		outline: none;
+		border-color: var(--dash-accent-purple, #6f6af8);
+	}
+	.amount-sep {
+		color: var(--dash-text-muted);
+		flex-shrink: 0;
+	}
+	.hint {
+		margin: 0;
+		font-size: 0.72rem;
+		color: var(--dash-text-muted);
+	}
+
+	.address-input {
+		width: 100%;
+		height: 2.25rem;
+		box-sizing: border-box;
+		font: inherit;
+		font-size: 0.85rem;
+		background: rgba(255, 255, 255, 0.04);
+		border: 1px solid var(--dash-card-border);
+		color: var(--dash-text-primary);
+		border-radius: 10px;
+		padding: 0 0.65rem;
+		transition: border-color 150ms ease;
+	}
+	.address-input:focus {
+		outline: none;
+		border-color: var(--dash-accent-purple, #6f6af8);
+	}
+
+	/* ── Panel footer ── */
+	.panel-footer {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 1rem;
+		padding-top: 0.75rem;
+		border-top: 1px solid var(--dash-card-border);
+	}
+	.clear-all {
+		background: none;
+		border: none;
+		padding: 0.4rem 0;
+		font: inherit;
+		font-size: 0.85rem;
+		color: var(--dash-text-secondary);
+		text-decoration: underline;
+		cursor: pointer;
+	}
+	.clear-all:hover:not(:disabled) {
+		color: var(--dash-text-primary);
+	}
+	.clear-all:disabled {
+		opacity: 0.4;
+		cursor: default;
+	}
+	.apply {
+		background: var(--dash-accent-purple, #6f6af8);
+		border: none;
+		color: #fff;
+		font: inherit;
+		font-size: 0.85rem;
+		font-weight: 600;
+		padding: 0.55rem 1.5rem;
+		border-radius: 999px;
+		cursor: pointer;
+		transition: background-color 150ms ease;
+	}
+	.apply:hover {
+		background: #807cff;
+	}
+</style>

--- a/src/routes/(authed)/transactions/FilterBar.svelte
+++ b/src/routes/(authed)/transactions/FilterBar.svelte
@@ -51,6 +51,9 @@
 		clearTimeout(debounceHandle);
 		debounceHandle = setTimeout(commitTexts, 300);
 	}
+	// Unmount cleanup — a pending debounce would otherwise fire commitTexts
+	// against destroyed state if the user navigates away mid-typing.
+	$effect(() => () => clearTimeout(debounceHandle));
 
 	function commitTexts() {
 		clearTimeout(debounceHandle);
@@ -155,9 +158,7 @@
 	{#each filters.types as t (t)}
 		<span class="summary-chip">
 			{TYPE_OPTIONS.find((o) => o.value === t)?.label ?? t}
-			<button aria-label="Remove {t} filter" onclick={() => toggleType(t)}
-				><X size={12} /></button
-			>
+			<button aria-label="Remove {t} filter" onclick={() => toggleType(t)}><X size={12} /></button>
 		</span>
 	{/each}
 	{#if filters.address.trim() !== '' && (amountChipLabel !== '' || filters.types.length > 0)}
@@ -310,9 +311,7 @@
 		</section>
 
 		<div class="panel-footer">
-			<button class="clear-all" onclick={clearAll} disabled={activeCount === 0}>
-				Clear all
-			</button>
+			<button class="clear-all" onclick={clearAll} disabled={activeCount === 0}> Clear all </button>
 			<button class="apply" onclick={togglePanel}>Done</button>
 		</div>
 	</div>
@@ -484,7 +483,9 @@
 		border-radius: 8px;
 		color: var(--dash-text-secondary);
 		cursor: pointer;
-		transition: background-color 130ms ease, color 130ms ease;
+		transition:
+			background-color 130ms ease,
+			color 130ms ease;
 	}
 	.drawer-close:hover {
 		background: rgba(255, 255, 255, 0.08);

--- a/src/routes/(authed)/transactions/GetTransactions.gql
+++ b/src/routes/(authed)/transactions/GetTransactions.gql
@@ -1,5 +1,19 @@
-query GetTransactions($did: String, $limit: Int, $offset: Int) {
-	findTransaction(filterOptions: { limit: $limit, offset: $offset, byAccount: $did }) @paginate {
+query GetTransactions(
+	$did: String
+	$limit: Int
+	$offset: Int
+	$byType: [String!]
+	$byLedgerToFrom: String
+) {
+	findTransaction(
+		filterOptions: {
+			limit: $limit
+			offset: $offset
+			byAccount: $did
+			byType: $byType
+			byLedgerToFrom: $byLedgerToFrom
+		}
+	) @paginate {
 		anchr_height
 		anchr_ts
 		first_seen

--- a/src/routes/(authed)/transactions/Table/Table.svelte
+++ b/src/routes/(authed)/transactions/Table/Table.svelte
@@ -15,30 +15,81 @@
 	import ContractTr from './tr/ContractTr.svelte';
 	import BtcMappingTr from './tr/BtcMappingTr.svelte';
 	import BtcDepositTr from './tr/BtcDepositTr.svelte';
+	import {
+		EMPTY_FILTERS,
+		applyClientFilters,
+		isFiltering,
+		toServerFilterVars,
+		type TxFilters
+	} from '../filters';
 
 	let {
 		did,
 		allowPopup = true,
 		initialOpen,
 		limit: limitProp,
-		size = 'full'
+		size = 'full',
+		filters = EMPTY_FILTERS
 	}: {
 		did: string;
 		allowPopup?: boolean;
 		initialOpen?: [string, number];
 		limit?: number;
 		size?: 'small' | 'full';
+		/** Optional filter state from the transactions page's FilterBar.
+		 *  Client-side filters apply to the displayed list; the byType /
+		 *  byLedgerToFrom subset also goes into the GraphQL fetches so
+		 *  pagination returns mostly-matching rows. */
+		filters?: TxFilters;
 	} = $props();
 	let loading = $state(true);
 	let lastLength = $state(0);
 	let currStoreLen = $derived($allTransactionsStore.length);
 	let hitBottom = $derived(lastLength === currStoreLen);
 
-	const displayTxs = $derived(
-		limitProp != null
-			? ($allTransactionsStore ?? []).slice(0, limitProp)
-			: ($allTransactionsStore ?? [])
-	) as TxListItem[];
+	// Server-expressible subset of the active filters, threaded into every
+	// fetchTxs call so paginated pages stay relevant under filtering.
+	const serverVars = $derived(toServerFilterVars(filters));
+
+	const displayTxs = $derived.by(() => {
+		const filtered = applyClientFilters($allTransactionsStore ?? [], filters);
+		return (limitProp != null ? filtered.slice(0, limitProp) : filtered) as TxListItem[];
+	});
+
+	// When the server-side filter subset changes, the loaded store contains
+	// rows fetched under DIFFERENT query filters — reset and refetch so
+	// offset-based pagination math stays coherent. Client-only filter
+	// changes (token/amount/time) don't need this; they just re-filter the
+	// already-loaded rows. Initialized lazily on the first effect run (no
+	// fetch) so mount-time loading stays owned by onMount.
+	let lastServerVarsKey: string | null = null;
+	$effect(() => {
+		const key = JSON.stringify(serverVars);
+		if (lastServerVarsKey === null) {
+			lastServerVarsKey = key;
+			return;
+		}
+		if (key === lastServerVarsKey) return;
+		lastServerVarsKey = key;
+		lastLength = 0;
+		fetchTxs(did, 'set', (val) => (loading = val), limitProp ?? 20, serverVars);
+	});
+
+	// Thin-results top-up: when client-side filters hide most of the loaded
+	// rows, auto-extend until the visible list has enough to fill the
+	// screen or the server runs out (hitBottom). The `loading` guard keeps
+	// fetches sequential; hitBottom stops the loop when a fetch adds
+	// nothing new.
+	const FILTER_TOPUP_TARGET = 8;
+	$effect(() => {
+		if (limitProp != null) return; // only the full page auto-extends
+		if (!isFiltering(filters)) return;
+		if (loading || hitBottom) return;
+		if (displayTxs.length >= FILTER_TOPUP_TARGET) return;
+		if (($allTransactionsStore ?? []).length === 0) return; // initial load owns this
+		lastLength = currStoreLen;
+		fetchTxs(did, 'extend', (val) => (loading = val), 12, serverVars);
+	});
 
 	// Routing: determine which TR component to render for a VSC op.
 	type OpTrType = 'regular' | 'btc-vsc' | 'contract';
@@ -59,7 +110,7 @@
 	}
 
 	function updateAll() {
-		fetchTxs(did, 'update', (val) => (loading = val));
+		fetchTxs(did, 'update', (val) => (loading = val), 12, serverVars);
 		fetchBtcDeposits(did, 'update');
 	}
 
@@ -67,7 +118,7 @@
 	onMount(() => {
 		const fetchLimit = limitProp ?? 20;
 		if (!initialOpen && $allTransactionsStore.length < fetchLimit) {
-			fetchTxs(did, 'set', (val) => (loading = val), fetchLimit);
+			fetchTxs(did, 'set', (val) => (loading = val), fetchLimit, serverVars);
 			fetchBtcDeposits(did, 'set', fetchLimit);
 		}
 		const rootStyle = getComputedStyle(document.documentElement);
@@ -180,12 +231,13 @@
 	</div>
 	<div
 		class="body-scroll"
+		class:no-scroll={!displayTxs?.length && !loading}
 		onscroll={(e) => {
 			if (limitProp != null) return;
 			const me = e.currentTarget;
 			if (me.scrollHeight - me.scrollTop - me.clientHeight <= 1 && !hitBottom && !loading) {
 				lastLength = currStoreLen;
-				fetchTxs(did, 'extend', (val) => (loading = val), 12);
+				fetchTxs(did, 'extend', (val) => (loading = val), 12, serverVars);
 				fetchBtcDeposits(did, 'extend', 12);
 			}
 		}}
@@ -299,6 +351,12 @@
 		width: 100%;
 		flex-grow: 1;
 		min-height: 0;
+		/* Never grow past the viewport: with zero (or few) transactions the
+		   blurred skeleton rows used to stretch the card well beyond the
+		   screen. 12rem ≈ topbar + page title + filter chips row; rows
+		   beyond the cap scroll inside .body-scroll as before. The small
+		   dashboard variant opts out below. */
+		max-height: calc(100vh - 12rem);
 		position: relative;
 		background: var(--dash-card-bg);
 		border: 1px solid var(--dash-card-border);
@@ -395,6 +453,14 @@
 		position: relative;
 	}
 
+	/* Empty state: the blurred skeleton rows are decoration, not content —
+	   scrolling them makes no sense (you'd be scrolling "no transactions").
+	   The class is toggled off again as soon as real rows or the loading
+	   skeleton render. */
+	.body-scroll.no-scroll {
+		overflow: hidden;
+	}
+
 	.no-transactions-overlay {
 		position: absolute;
 		top: 0;
@@ -423,6 +489,7 @@
 	/* Small variant for dashboard embed */
 	.card.small {
 		padding: 0;
+		max-height: none; /* embeds size to their container, not the viewport */
 		border: none;
 		border-radius: 0;
 		box-shadow: none;

--- a/src/routes/(authed)/transactions/Table/Table.svelte
+++ b/src/routes/(authed)/transactions/Table/Table.svelte
@@ -19,9 +19,14 @@
 		EMPTY_FILTERS,
 		applyClientFilters,
 		isFiltering,
+		sortTxItems,
 		toServerFilterVars,
-		type TxFilters
+		type TxFilters,
+		type TxSortColumn,
+		type TxSortDirection
 	} from '../filters';
+	import { getCryptoPrices } from '$lib/sendswap/v4v/api-types/cryptoprices';
+	import { ChevronDown, ChevronUp } from '@lucide/svelte';
 
 	let {
 		did,
@@ -51,9 +56,42 @@
 	// fetchTxs call so paginated pages stay relevant under filtering.
 	const serverVars = $derived(toServerFilterVars(filters));
 
+	// ── Sorting (full page only — the dashboard embed keeps feed order) ──
+	// Client-side over the loaded rows, mirroring the pools table's
+	// header-click pattern. Date desc is the feed's natural order, so that
+	// default applies zero re-ordering.
+	let sortCol = $state<TxSortColumn>('date');
+	let sortDir = $state<TxSortDirection>('desc');
+	let usdPrices = $state({ hive: 0, hbd: 0, btc: 0 });
+	$effect(() => {
+		// One-shot price fetch for amount sorting (same source the rows use).
+		getCryptoPrices()
+			.then((p) => {
+				usdPrices = {
+					hive: p.hive?.usd ?? 0,
+					hbd: p.hive_dollar?.usd ?? 0,
+					btc: p.bitcoin?.usd ?? 0
+				};
+			})
+			.catch(() => {/* amount sort degrades to 0s; date sort unaffected */});
+	});
+	function toggleSort(col: TxSortColumn) {
+		if (sortCol === col) {
+			sortDir = sortDir === 'desc' ? 'asc' : 'desc';
+		} else {
+			sortCol = col;
+			sortDir = 'desc';
+		}
+	}
+
 	const displayTxs = $derived.by(() => {
 		const filtered = applyClientFilters($allTransactionsStore ?? [], filters);
-		return (limitProp != null ? filtered.slice(0, limitProp) : filtered) as TxListItem[];
+		// Skip the sort pass entirely in the default feed order.
+		const sorted =
+			sortCol === 'date' && sortDir === 'desc'
+				? filtered
+				: sortTxItems(filtered, sortCol, sortDir, usdPrices);
+		return (limitProp != null ? sorted.slice(0, limitProp) : sorted) as TxListItem[];
 	});
 
 	// When the server-side filter subset changes, the loaded store contains
@@ -223,10 +261,20 @@
 <div class={['card', { small: size === 'small' }]}>
 	<div class="table-scroll">
 	<div class="header-row">
-		<div class="h h-date">Date</div>
+		<button class="h h-date sortable" class:sorted={sortCol === 'date'} onclick={() => toggleSort('date')}>
+			Date
+			{#if sortCol === 'date'}
+				{#if sortDir === 'desc'}<ChevronDown size={13} />{:else}<ChevronUp size={13} />{/if}
+			{/if}
+		</button>
 		<div class="h h-to-from">To/From</div>
 		<div class="h h-status">Status</div>
-		<div class="h h-amount">Amount</div>
+		<button class="h h-amount sortable" class:sorted={sortCol === 'amount'} onclick={() => toggleSort('amount')}>
+			Amount
+			{#if sortCol === 'amount'}
+				{#if sortDir === 'desc'}<ChevronDown size={13} />{:else}<ChevronUp size={13} />{/if}
+			{/if}
+		</button>
 		<div class="h h-type">Type</div>
 	</div>
 	<div
@@ -393,6 +441,35 @@
 		font-size: 0.8rem;
 		text-align: left;
 		border-bottom: 1px solid var(--dash-divider);
+	}
+	/* Sortable headers are <button>s — reset native styles so they render
+	   identically to the plain div headers, plus a light hover + the
+	   chevron when active. */
+	button.h.sortable {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		background: none;
+		border: none;
+		border-bottom: 1px solid var(--dash-divider);
+		font-family: inherit;
+		cursor: pointer;
+		transition: color 130ms ease;
+	}
+	button.h.sortable:hover {
+		color: var(--dash-text-primary);
+	}
+	/* The plain .h-amount header was text-align: center; the button is
+	   inline-flex so text-align no longer applies — center via
+	   justify-content instead. Date stays left-aligned like before. */
+	button.h-amount.sortable {
+		justify-content: center;
+	}
+	button.h.sortable.sorted {
+		color: var(--dash-text-primary);
+	}
+	button.h.sortable :global(svg) {
+		flex-shrink: 0;
 	}
 	.h-to-from {
 		text-align: left;

--- a/src/routes/(authed)/transactions/Table/Table.svelte
+++ b/src/routes/(authed)/transactions/Table/Table.svelte
@@ -73,7 +73,9 @@
 					btc: p.bitcoin?.usd ?? 0
 				};
 			})
-			.catch(() => {/* amount sort degrades to 0s; date sort unaffected */});
+			.catch(() => {
+				/* amount sort degrades to 0s; date sort unaffected */
+			});
 	});
 	function toggleSort(col: TxSortColumn) {
 		if (sortCol === col) {
@@ -260,43 +262,51 @@
 
 <div class={['card', { small: size === 'small' }]}>
 	<div class="table-scroll">
-	<div class="header-row">
-		<button class="h h-date sortable" class:sorted={sortCol === 'date'} onclick={() => toggleSort('date')}>
-			Date
-			{#if sortCol === 'date'}
-				{#if sortDir === 'desc'}<ChevronDown size={13} />{:else}<ChevronUp size={13} />{/if}
-			{/if}
-		</button>
-		<div class="h h-to-from">To/From</div>
-		<div class="h h-status">Status</div>
-		<button class="h h-amount sortable" class:sorted={sortCol === 'amount'} onclick={() => toggleSort('amount')}>
-			Amount
-			{#if sortCol === 'amount'}
-				{#if sortDir === 'desc'}<ChevronDown size={13} />{:else}<ChevronUp size={13} />{/if}
-			{/if}
-		</button>
-		<div class="h h-type">Type</div>
-	</div>
-	<div
-		class="body-scroll"
-		class:no-scroll={!displayTxs?.length && !loading}
-		onscroll={(e) => {
-			if (limitProp != null) return;
-			const me = e.currentTarget;
-			if (me.scrollHeight - me.scrollTop - me.clientHeight <= 1 && !hitBottom && !loading) {
-				lastLength = currStoreLen;
-				fetchTxs(did, 'extend', (val) => (loading = val), 12, serverVars);
-				fetchBtcDeposits(did, 'extend', 12);
-			}
-		}}
-	>
-		<table>
-			<tbody
-				id="transactions-tbody"
-				class={!displayTxs?.length && !loading ? 'no-transactions-container' : ''}
+		<div class="header-row">
+			<button
+				class="h h-date sortable"
+				class:sorted={sortCol === 'date'}
+				onclick={() => toggleSort('date')}
 			>
-				{#if displayTxs && displayTxs.length > 0}
-					<!-- {#each $allTransactionsStore as tx (tx.id)}
+				Date
+				{#if sortCol === 'date'}
+					{#if sortDir === 'desc'}<ChevronDown size={13} />{:else}<ChevronUp size={13} />{/if}
+				{/if}
+			</button>
+			<div class="h h-to-from">To/From</div>
+			<div class="h h-status">Status</div>
+			<button
+				class="h h-amount sortable"
+				class:sorted={sortCol === 'amount'}
+				onclick={() => toggleSort('amount')}
+			>
+				Amount
+				{#if sortCol === 'amount'}
+					{#if sortDir === 'desc'}<ChevronDown size={13} />{:else}<ChevronUp size={13} />{/if}
+				{/if}
+			</button>
+			<div class="h h-type">Type</div>
+		</div>
+		<div
+			class="body-scroll"
+			class:no-scroll={!displayTxs?.length && !loading}
+			onscroll={(e) => {
+				if (limitProp != null) return;
+				const me = e.currentTarget;
+				if (me.scrollHeight - me.scrollTop - me.clientHeight <= 1 && !hitBottom && !loading) {
+					lastLength = currStoreLen;
+					fetchTxs(did, 'extend', (val) => (loading = val), 12, serverVars);
+					fetchBtcDeposits(did, 'extend', 12);
+				}
+			}}
+		>
+			<table>
+				<tbody
+					id="transactions-tbody"
+					class={!displayTxs?.length && !loading ? 'no-transactions-container' : ''}
+				>
+					{#if displayTxs && displayTxs.length > 0}
+						<!-- {#each $allTransactionsStore as tx (tx.id)}
 					{@const { ops, id } = tx}
 					{#each ops!.sort((a, b) => {
 						// put deposits below other ops in their transaction
@@ -310,13 +320,13 @@
 						{/if}
 					{/each}
 				{/each} -->
-					{#each displayTxs as item (item.kind === 'vsc' ? item.tx.id : item.event.indexer_tx_hash)}
-						{#if item.kind === 'btc-deposit'}
-							<BtcDepositTr event={item.event} onRowClick={toggleDetails} />
-						{:else}
-							{@const tx = item.tx}
-							{@const { ops } = tx}
-							<!--
+						{#each displayTxs as item (item.kind === 'vsc' ? item.tx.id : item.event.indexer_tx_hash)}
+							{#if item.kind === 'btc-deposit'}
+								<BtcDepositTr event={item.event} onRowClick={toggleDetails} />
+							{:else}
+								{@const tx = item.tx}
+								{@const { ops } = tx}
+								<!--
 								Always iterate the full `ops` array so every
 								operation in a transaction renders as its own
 								row. Previously contract transactions collapsed
@@ -329,54 +339,54 @@
 								with a deposit-last override retained inside
 								each op-index group.
 							-->
-							{#each [...(ops ?? [])].sort((a, b) => {
-								const depDiff = (a?.type === 'deposit' ? 1 : 0) - (b?.type === 'deposit' ? 1 : 0);
-								if (depDiff !== 0) return depDiff;
-								return (b?.index ?? 0) - (a?.index ?? 0);
-							}) as op, i (`${tx.id}-${op?.index ?? i}`)}
-								{#if op}
-									{@const trType = getOpTrType(op)}
-									{#if trType === 'regular'}
-										<Tr {tx} {op} onRowClick={toggleDetails} />
-									{:else if trType === 'btc-vsc'}
-										<BtcMappingTr {tx} {op} onRowClick={toggleDetails} />
-									{:else if trType === 'contract'}
-										<ContractTr {tx} {op} onRowClick={toggleDetails} />
+								{#each [...(ops ?? [])].sort((a, b) => {
+									const depDiff = (a?.type === 'deposit' ? 1 : 0) - (b?.type === 'deposit' ? 1 : 0);
+									if (depDiff !== 0) return depDiff;
+									return (b?.index ?? 0) - (a?.index ?? 0);
+								}) as op, i (`${tx.id}-${op?.index ?? i}`)}
+									{#if op}
+										{@const trType = getOpTrType(op)}
+										{#if trType === 'regular'}
+											<Tr {tx} {op} onRowClick={toggleDetails} />
+										{:else if trType === 'btc-vsc'}
+											<BtcMappingTr {tx} {op} onRowClick={toggleDetails} />
+										{:else if trType === 'contract'}
+											<ContractTr {tx} {op} onRowClick={toggleDetails} />
+										{/if}
 									{/if}
-								{/if}
-							{/each}
-						{/if}
-					{/each}
-				{:else if !loading}
-					{#each Array(skeletonRowCount - 1) as _, i}
-						<tr class="skeleton-row blurred-skeleton">
-							<td><div class="skeleton-cell date"></div></td>
-							<td><div class="skeleton-cell to-from"></div></td>
-							<td><div class="skeleton-cell status"></div></td>
-							<td><div class="skeleton-cell amount"></div></td>
-							<td><div class="skeleton-cell type"></div></td>
-						</tr>
-					{/each}
-				{/if}
-				{#if loading}
-					{#each Array(skeletonRowCount) as _, i}
-						<tr class="skeleton-row">
-							<td><div class="skeleton-cell date"></div></td>
-							<td><div class="skeleton-cell to-from"></div></td>
-							<td><div class="skeleton-cell status"></div></td>
-							<td><div class="skeleton-cell amount"></div></td>
-							<td><div class="skeleton-cell type"></div></td>
-						</tr>
-					{/each}
-				{/if}
-			</tbody>
-		</table>
-		{#if !displayTxs?.length && !loading}
-			<div class={['no-transactions-overlay', { short: skeletonRowCount <= 5 }]}>
-				<div class="no-transactions-message">No transactions found</div>
-			</div>
-		{/if}
-	</div>
+								{/each}
+							{/if}
+						{/each}
+					{:else if !loading}
+						{#each Array(skeletonRowCount - 1) as _, i}
+							<tr class="skeleton-row blurred-skeleton">
+								<td><div class="skeleton-cell date"></div></td>
+								<td><div class="skeleton-cell to-from"></div></td>
+								<td><div class="skeleton-cell status"></div></td>
+								<td><div class="skeleton-cell amount"></div></td>
+								<td><div class="skeleton-cell type"></div></td>
+							</tr>
+						{/each}
+					{/if}
+					{#if loading}
+						{#each Array(skeletonRowCount) as _, i}
+							<tr class="skeleton-row">
+								<td><div class="skeleton-cell date"></div></td>
+								<td><div class="skeleton-cell to-from"></div></td>
+								<td><div class="skeleton-cell status"></div></td>
+								<td><div class="skeleton-cell amount"></div></td>
+								<td><div class="skeleton-cell type"></div></td>
+							</tr>
+						{/each}
+					{/if}
+				</tbody>
+			</table>
+			{#if !displayTxs?.length && !loading}
+				<div class={['no-transactions-overlay', { short: skeletonRowCount <= 5 }]}>
+					<div class="no-transactions-message">No transactions found</div>
+				</div>
+			{/if}
+		</div>
 	</div>
 </div>
 
@@ -612,5 +622,4 @@
 			display: none;
 		}
 	}
-
 </style>

--- a/src/routes/(authed)/transactions/Table/tr/Tr.svelte
+++ b/src/routes/(authed)/transactions/Table/tr/Tr.svelte
@@ -148,6 +148,27 @@
 		});
 	});
 
+	/**
+	 * Protocol (magi) fee legs of this transaction: ledger transfers whose
+	 * destination is `pendulum:nodes` — the pool sends the protocol fee
+	 * there on every swap. Summed per asset (a two-hop swap can pay fees
+	 * in two assets). The LP fee never appears in the ledger — it stays in
+	 * the pool and is implicit in the exchange rate — so the popup labels
+	 * that explicitly rather than under-reporting the total cost.
+	 */
+	const protocolFees: UnkCoinAmount[] = $derived.by(() => {
+		const sums = new Map<string, number>();
+		for (const entry of tx.ledger ?? []) {
+			if (!entry || entry.to !== 'pendulum:nodes') continue;
+			const assetKey = String(entry.asset ?? '').split('_')[0];
+			sums.set(assetKey, (sums.get(assetKey) ?? 0) + Number(entry.amount ?? 0));
+		}
+		return [...sums.entries()].map(
+			([assetKey, total]) =>
+				new CoinAmount(total, Coin[assetKey as keyof typeof Coin] || Coin.unk, true)
+		);
+	});
+
 	function handleTrigger() {
 		onRowClick([tx.id, op.index], thisRowContent);
 	}
@@ -243,6 +264,20 @@
 				<p>{memo.get('msg')}</p>
 			</div>
 		{/if}
+		{#if protocolFees.length > 0}
+			<div class="fees section">
+				<h3>Fees</h3>
+				<div class="fee-rows">
+					{#each protocolFees as fee (fee.coin.value)}
+						<div class="fee-row">
+							<span class="fee-row-label">Protocol fee</span>
+							<span>{prettyWithDisplayUnit(fee)}</span>
+						</div>
+					{/each}
+					<p class="fee-note">LP fee is included in the exchange rate.</p>
+				</div>
+			</div>
+		{/if}
 		<div class="tx-id section">
 			<h3>Transaction Id</h3>
 			<Clipboard value={tx.id} label="" disabled={tx.isPending && tx.id == 'UNK'} />
@@ -320,6 +355,27 @@
 		display: flex;
 		flex-wrap: wrap;
 		gap: 1rem;
+	}
+	.fee-rows {
+		display: flex;
+		flex-direction: column;
+		gap: 0.3rem;
+		padding-top: 0.25rem;
+	}
+	.fee-row {
+		display: flex;
+		justify-content: space-between;
+		gap: 1rem;
+		font-size: var(--text-sm);
+	}
+	.fee-row-label {
+		color: var(--dash-text-secondary);
+	}
+	.fee-note {
+		margin: 0.15rem 0 0;
+		font-size: var(--text-sm);
+		color: var(--dash-text-muted);
+		font-style: italic;
 	}
 	.section {
 		padding: 0.5rem;

--- a/src/routes/(authed)/transactions/Table/tr/Tr.svelte
+++ b/src/routes/(authed)/transactions/Table/tr/Tr.svelte
@@ -157,13 +157,15 @@
 	 * that explicitly rather than under-reporting the total cost.
 	 */
 	const protocolFees: UnkCoinAmount[] = $derived.by(() => {
-		const sums = new Map<string, number>();
+		// Plain object, not Map — this is ephemeral local accumulation inside
+		// a $derived, not reactive state (svelte/prefer-svelte-reactivity).
+		const sums: Record<string, number> = {};
 		for (const entry of tx.ledger ?? []) {
 			if (!entry || entry.to !== 'pendulum:nodes') continue;
 			const assetKey = String(entry.asset ?? '').split('_')[0];
-			sums.set(assetKey, (sums.get(assetKey) ?? 0) + Number(entry.amount ?? 0));
+			sums[assetKey] = (sums[assetKey] ?? 0) + Number(entry.amount ?? 0);
 		}
-		return [...sums.entries()].map(
+		return Object.entries(sums).map(
 			([assetKey, total]) =>
 				new CoinAmount(total, Coin[assetKey as keyof typeof Coin] || Coin.unk, true)
 		);
@@ -289,11 +291,7 @@
 					VSC Block Explorer<ExternalLink /></a
 				>
 				{#if to.slice(0, 5) === 'hive:' && from.slice(0, 5) === 'hive:'}
-					<a
-						href={'https://hivehub.dev/tx/' + tx.id}
-						target="_blank"
-						rel="noreferrer"
-					>
+					<a href={'https://hivehub.dev/tx/' + tx.id} target="_blank" rel="noreferrer">
 						Hive Block Explorer<ExternalLink /></a
 					>
 				{/if}

--- a/src/routes/(authed)/transactions/filters.test.ts
+++ b/src/routes/(authed)/transactions/filters.test.ts
@@ -31,7 +31,6 @@ function iso(msAgo: number): string {
 }
 
 /** Minimal vsc TxListItem with one ledger entry. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function vscTx(opts: {
 	id: string;
 	msAgo?: number;
@@ -63,9 +62,7 @@ function vscTx(opts: {
 						type: opts.type ?? 'transfer'
 					}
 				],
-		ops: opts.opType
-			? [{ type: opts.opType, index: 0, data: opts.opData ?? {} }]
-			: []
+		ops: opts.opType ? [{ type: opts.opType, index: 0, data: opts.opData ?? {} }] : []
 	};
 	return { kind: 'vsc', tx };
 }

--- a/src/routes/(authed)/transactions/filters.test.ts
+++ b/src/routes/(authed)/transactions/filters.test.ts
@@ -14,6 +14,8 @@ import {
 	activeFilterCount,
 	applyClientFilters,
 	isFiltering,
+	itemAmountUsd,
+	sortTxItems,
 	toServerFilterVars,
 	type TxFilters
 } from './filters';
@@ -314,5 +316,84 @@ describe('toServerFilterVars', () => {
 
 	it('does NOT pass partial text to byLedgerToFrom (exact-match would starve results)', () => {
 		expect(toServerFilterVars(f({ address: 'alice' })).byLedgerToFrom).toBeUndefined();
+	});
+});
+
+// ─── sorting ─────────────────────────────────────────────────────────────────
+
+const PRICES = { hive: 0.25, hbd: 1, btc: 100_000 };
+
+describe('itemAmountUsd', () => {
+	it('uses the LARGEST entry, not the sum (swap ledgers repeat value across hops)', () => {
+		// Swap-shaped tx: in-leg 5 HBD, fee 0.02 HBD, out-leg 20 HIVE ($5).
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const tx: any = {
+			id: 'swap',
+			anchr_ts: iso(0),
+			first_seen: iso(0),
+			status: 'CONFIRMED',
+			isPending: false,
+			ledger: [
+				{ asset: 'hbd', amount: 5000, from: 'hive:a', to: 'contract:pool', type: 'transfer' },
+				{ asset: 'hbd', amount: 20, from: 'contract:pool', to: 'pendulum:nodes', type: 'transfer' },
+				{ asset: 'hive', amount: 20_000, from: 'contract:pool', to: 'hive:a', type: 'transfer' }
+			],
+			ops: []
+		};
+		// max(5*1, 0.02*1, 20*0.25) = 5 — NOT 10.02
+		expect(itemAmountUsd({ kind: 'vsc', tx }, PRICES)).toBeCloseTo(5);
+	});
+
+	it('prices btc-deposit events in BTC', () => {
+		// 150,000 sats = 0.0015 BTC × $100k = $150
+		expect(itemAmountUsd(btcDeposit({ id: 'b', sats: '150000' }), PRICES)).toBeCloseTo(150);
+	});
+});
+
+describe('sortTxItems', () => {
+	const items = [
+		vscTx({ id: 'old-small', msAgo: 3 * DAY, asset: 'hive', amount: 4_000 }), // $1
+		vscTx({ id: 'new-big', msAgo: 1 * HOUR, asset: 'hbd', amount: 50_000 }), // $50
+		btcDeposit({ id: 'mid-btc', msAgo: 1 * DAY, sats: '10000' }) // $10
+	];
+	const ids = (out: ReturnType<typeof sortTxItems>) =>
+		out.map((i) => (i.kind === 'vsc' ? i.tx.id : i.event.indexer_tx_hash));
+
+	it('date desc = newest first', () => {
+		expect(ids(sortTxItems(items, 'date', 'desc', PRICES))).toEqual([
+			'new-big',
+			'mid-btc',
+			'old-small'
+		]);
+	});
+
+	it('date asc = oldest first', () => {
+		expect(ids(sortTxItems(items, 'date', 'asc', PRICES))).toEqual([
+			'old-small',
+			'mid-btc',
+			'new-big'
+		]);
+	});
+
+	it('amount desc = biggest USD first, across assets', () => {
+		expect(ids(sortTxItems(items, 'amount', 'desc', PRICES))).toEqual([
+			'new-big',
+			'mid-btc',
+			'old-small'
+		]);
+	});
+
+	it('amount asc = smallest USD first', () => {
+		expect(ids(sortTxItems(items, 'amount', 'asc', PRICES))).toEqual([
+			'old-small',
+			'mid-btc',
+			'new-big'
+		]);
+	});
+
+	it('does not mutate the input array', () => {
+		const before = [...items];
+		sortTxItems(items, 'amount', 'asc', PRICES);
+		expect(items).toEqual(before);
 	});
 });

--- a/src/routes/(authed)/transactions/filters.test.ts
+++ b/src/routes/(authed)/transactions/filters.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Tests for the transactions-page client-side filter logic.
+ *
+ * All fixtures are hand-built TxListItems matching the real shapes:
+ *   - vsc items carry ledger[] entries (smallest-unit integer amounts)
+ *     and/or ops[] payloads (Hive L1 ops use human-unit decimal strings)
+ *   - btc-deposit items carry indexer events (satoshi string amounts)
+ *
+ * The clock is injected so time-range assertions are deterministic.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+	EMPTY_FILTERS,
+	activeFilterCount,
+	applyClientFilters,
+	isFiltering,
+	toServerFilterVars,
+	type TxFilters
+} from './filters';
+import type { TxListItem } from '$lib/stores/txStores';
+
+const NOW = Date.parse('2026-06-10T12:00:00Z');
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+function iso(msAgo: number): string {
+	// Backend emits bare ISO without Z; getTimestamp appends it.
+	return new Date(NOW - msAgo).toISOString().replace(/\.\d{3}Z$/, '');
+}
+
+/** Minimal vsc TxListItem with one ledger entry. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function vscTx(opts: {
+	id: string;
+	msAgo?: number;
+	asset?: string;
+	amount?: number; // smallest units
+	from?: string;
+	to?: string;
+	type?: string;
+	noLedger?: boolean;
+	opType?: string;
+	opData?: Record<string, unknown>;
+}): TxListItem {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const tx: any = {
+		id: opts.id,
+		anchr_ts: iso(opts.msAgo ?? 0),
+		first_seen: iso(opts.msAgo ?? 0),
+		anchr_height: 1,
+		status: 'CONFIRMED',
+		isPending: false,
+		ledger: opts.noLedger
+			? []
+			: [
+					{
+						asset: opts.asset ?? 'hive',
+						amount: opts.amount ?? 1000,
+						from: opts.from ?? 'hive:alice',
+						to: opts.to ?? 'hive:bob',
+						type: opts.type ?? 'transfer'
+					}
+				],
+		ops: opts.opType
+			? [{ type: opts.opType, index: 0, data: opts.opData ?? {} }]
+			: []
+	};
+	return { kind: 'vsc', tx };
+}
+
+function btcDeposit(opts: { id: string; msAgo?: number; sats?: string }): TxListItem {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const event: any = {
+		indexer_tx_hash: opts.id,
+		indexer_ts: iso(opts.msAgo ?? 0),
+		indexer_block_height: 1,
+		amount: opts.sats ?? '150000',
+		recipient: 'hive:carol',
+		sender: 'bc1qsomebtcaddress'
+	};
+	return { kind: 'btc-deposit', event };
+}
+
+function f(partial: Partial<TxFilters>): TxFilters {
+	return { ...EMPTY_FILTERS, ...partial };
+}
+
+// ─── isFiltering / activeFilterCount ─────────────────────────────────────────
+
+describe('isFiltering & activeFilterCount', () => {
+	it('EMPTY_FILTERS is not filtering', () => {
+		expect(isFiltering(EMPTY_FILTERS)).toBe(false);
+		expect(activeFilterCount(EMPTY_FILTERS)).toBe(0);
+	});
+
+	it('each filter group counts once', () => {
+		expect(activeFilterCount(f({ tokens: ['hive'] }))).toBe(1);
+		expect(activeFilterCount(f({ amountMin: 1, amountMax: 5 }))).toBe(1); // min+max = one group
+		expect(
+			activeFilterCount(
+				f({ tokens: ['hive'], timeRange: '7d', types: ['transfer'], address: 'bob' })
+			)
+		).toBe(4);
+	});
+
+	it('whitespace-only address is not filtering', () => {
+		expect(isFiltering(f({ address: '   ' }))).toBe(false);
+	});
+});
+
+// ─── token filter ────────────────────────────────────────────────────────────
+
+describe('token filter', () => {
+	const items = [
+		vscTx({ id: 'a', asset: 'hive' }),
+		vscTx({ id: 'b', asset: 'hbd' }),
+		vscTx({ id: 'c', asset: 'hbd_savings' }),
+		btcDeposit({ id: 'd' })
+	];
+
+	it('keeps only matching assets', () => {
+		const out = applyClientFilters(items, f({ tokens: ['hive'] }), NOW);
+		expect(out.map((i) => (i.kind === 'vsc' ? i.tx.id : i.event.indexer_tx_hash))).toEqual(['a']);
+	});
+
+	it('normalizes suffixed assets (hbd_savings matches hbd)', () => {
+		const out = applyClientFilters(items, f({ tokens: ['hbd'] }), NOW);
+		expect(out).toHaveLength(2); // b + c
+	});
+
+	it('btc filter catches indexer btc-deposit items', () => {
+		const out = applyClientFilters(items, f({ tokens: ['btc'] }), NOW);
+		expect(out).toHaveLength(1);
+		expect(out[0].kind).toBe('btc-deposit');
+	});
+
+	it('multi-token keeps the union', () => {
+		const out = applyClientFilters(items, f({ tokens: ['hive', 'btc'] }), NOW);
+		expect(out).toHaveLength(2);
+	});
+});
+
+// ─── time range ──────────────────────────────────────────────────────────────
+
+describe('time range filter', () => {
+	const items = [
+		vscTx({ id: 'fresh', msAgo: 1 * HOUR }),
+		vscTx({ id: 'days', msAgo: 3 * DAY }),
+		vscTx({ id: 'weeks', msAgo: 20 * DAY }),
+		vscTx({ id: 'old', msAgo: 90 * DAY })
+	];
+
+	it('24h keeps only the fresh tx', () => {
+		const out = applyClientFilters(items, f({ timeRange: '24h' }), NOW);
+		expect(out.map((i) => (i.kind === 'vsc' ? i.tx.id : ''))).toEqual(['fresh']);
+	});
+
+	it('7d keeps fresh + days', () => {
+		const out = applyClientFilters(items, f({ timeRange: '7d' }), NOW);
+		expect(out).toHaveLength(2);
+	});
+
+	it('30d keeps everything but old', () => {
+		const out = applyClientFilters(items, f({ timeRange: '30d' }), NOW);
+		expect(out).toHaveLength(3);
+	});
+
+	it('all keeps everything', () => {
+		const out = applyClientFilters(items, f({ timeRange: 'all' }), NOW);
+		expect(out).toHaveLength(4);
+	});
+});
+
+// ─── amount range ────────────────────────────────────────────────────────────
+
+describe('amount filter (human units per entry asset)', () => {
+	const items = [
+		vscTx({ id: 'small', asset: 'hive', amount: 500 }), // 0.5 HIVE
+		vscTx({ id: 'mid', asset: 'hive', amount: 25_000 }), // 25 HIVE
+		vscTx({ id: 'big', asset: 'hive', amount: 1_000_000 }), // 1000 HIVE
+		btcDeposit({ id: 'btc', sats: '150000' }) // 0.0015 BTC
+	];
+
+	it('min only', () => {
+		const out = applyClientFilters(items, f({ amountMin: 10 }), NOW);
+		expect(out).toHaveLength(2); // mid + big
+	});
+
+	it('max only', () => {
+		const out = applyClientFilters(items, f({ amountMax: 1 }), NOW);
+		expect(out).toHaveLength(2); // small (0.5) + btc (0.0015)
+	});
+
+	it('min+max window', () => {
+		const out = applyClientFilters(items, f({ amountMin: 1, amountMax: 100 }), NOW);
+		expect(out).toHaveLength(1); // mid
+	});
+
+	it('decimal-string op amounts are treated as human units', () => {
+		// Hive L1 withdraw op: amount "5.453" (human units, not smallest)
+		const item = vscTx({
+			id: 'l1',
+			noLedger: true,
+			opType: 'withdraw',
+			opData: { from: 'hive:x', to: 'hive:x', asset: 'hbd', amount: '5.453' }
+		});
+		expect(applyClientFilters([item], f({ amountMin: 5, amountMax: 6 }), NOW)).toHaveLength(1);
+		expect(applyClientFilters([item], f({ amountMin: 100 }), NOW)).toHaveLength(0);
+	});
+});
+
+// ─── type filter ─────────────────────────────────────────────────────────────
+
+describe('type filter', () => {
+	const items = [
+		vscTx({ id: 't1', type: 'transfer' }),
+		vscTx({ id: 't2', type: 'deposit' }),
+		vscTx({ id: 't3', noLedger: true, opType: 'call_contract', opData: { action: 'swap' } }),
+		vscTx({ id: 't4', type: 'stake' })
+	];
+
+	it('single type', () => {
+		const out = applyClientFilters(items, f({ types: ['deposit'] }), NOW);
+		expect(out).toHaveLength(1);
+	});
+
+	it("'call' matches call_contract ops too", () => {
+		const out = applyClientFilters(items, f({ types: ['call'] }), NOW);
+		expect(out).toHaveLength(1);
+		expect(out[0].kind === 'vsc' && out[0].tx.id).toBe('t3');
+	});
+
+	it('multiple types = union', () => {
+		const out = applyClientFilters(items, f({ types: ['transfer', 'stake'] }), NOW);
+		expect(out).toHaveLength(2);
+	});
+
+	it('btc deposits count as type=deposit', () => {
+		const out = applyClientFilters([btcDeposit({ id: 'b1' })], f({ types: ['deposit'] }), NOW);
+		expect(out).toHaveLength(1);
+	});
+});
+
+// ─── address filter ──────────────────────────────────────────────────────────
+
+describe('address filter', () => {
+	const items = [
+		vscTx({ id: 'a1', from: 'hive:alice', to: 'hive:bob' }),
+		vscTx({ id: 'a2', from: 'hive:carol', to: 'did:pkh:eip155:1:0xAbC123' }),
+		btcDeposit({ id: 'a3' }) // sender bc1qsomebtcaddress, recipient hive:carol
+	];
+
+	it('matches partial account names case-insensitively', () => {
+		expect(applyClientFilters(items, f({ address: 'ALICE' }), NOW)).toHaveLength(1);
+	});
+
+	it('matches either side (from or to)', () => {
+		const out = applyClientFilters(items, f({ address: 'carol' }), NOW);
+		expect(out).toHaveLength(2); // a2 (from) + a3 (recipient)
+	});
+
+	it('matches EVM-style addresses', () => {
+		expect(applyClientFilters(items, f({ address: '0xabc' }), NOW)).toHaveLength(1);
+	});
+
+	it('matches BTC sender addresses on deposit events', () => {
+		expect(applyClientFilters(items, f({ address: 'bc1q' }), NOW)).toHaveLength(1);
+	});
+});
+
+// ─── combined filters ────────────────────────────────────────────────────────
+
+describe('combined filters (AND across groups)', () => {
+	const items = [
+		vscTx({ id: 'x1', asset: 'hive', amount: 50_000, type: 'transfer', msAgo: HOUR }),
+		vscTx({ id: 'x2', asset: 'hive', amount: 50_000, type: 'transfer', msAgo: 40 * DAY }),
+		vscTx({ id: 'x3', asset: 'hbd', amount: 50_000, type: 'transfer', msAgo: HOUR }),
+		vscTx({ id: 'x4', asset: 'hive', amount: 100, type: 'transfer', msAgo: HOUR })
+	];
+
+	it('token AND time AND amount all must pass', () => {
+		const out = applyClientFilters(
+			items,
+			f({ tokens: ['hive'], timeRange: '7d', amountMin: 10 }),
+			NOW
+		);
+		expect(out).toHaveLength(1);
+		expect(out[0].kind === 'vsc' && out[0].tx.id).toBe('x1');
+	});
+
+	it('no filters → identity (same reference)', () => {
+		expect(applyClientFilters(items, EMPTY_FILTERS, NOW)).toBe(items);
+	});
+});
+
+// ─── server-side variable mapping ────────────────────────────────────────────
+
+describe('toServerFilterVars', () => {
+	it('empty filters → no vars', () => {
+		expect(toServerFilterVars(EMPTY_FILTERS)).toEqual({});
+	});
+
+	it("expands 'call' to wire-level op names", () => {
+		expect(toServerFilterVars(f({ types: ['call', 'transfer'] })).byType).toEqual([
+			'call',
+			'call_contract',
+			'transfer'
+		]);
+	});
+
+	it('passes full account ids through byLedgerToFrom', () => {
+		expect(toServerFilterVars(f({ address: 'hive:alice' })).byLedgerToFrom).toBe('hive:alice');
+	});
+
+	it('does NOT pass partial text to byLedgerToFrom (exact-match would starve results)', () => {
+		expect(toServerFilterVars(f({ address: 'alice' })).byLedgerToFrom).toBeUndefined();
+	});
+});

--- a/src/routes/(authed)/transactions/filters.ts
+++ b/src/routes/(authed)/transactions/filters.ts
@@ -208,8 +208,7 @@ export function applyClientFilters(
 	if (!isFiltering(filters)) return items;
 
 	const address = filters.address.trim().toLowerCase();
-	const cutoffMs =
-		filters.timeRange === 'all' ? null : nowMs - TIME_RANGE_MS[filters.timeRange];
+	const cutoffMs = filters.timeRange === 'all' ? null : nowMs - TIME_RANGE_MS[filters.timeRange];
 
 	return items.filter((item) => {
 		if (cutoffMs != null && itemTimestampMs(item) < cutoffMs) return false;
@@ -248,8 +247,7 @@ export function applyClientFilters(
 		}
 		if (address !== '') {
 			const matchesAddress = entries.some(
-				(e) =>
-					e.from.toLowerCase().includes(address) || e.to.toLowerCase().includes(address)
+				(e) => e.from.toLowerCase().includes(address) || e.to.toLowerCase().includes(address)
 			);
 			if (!matchesAddress) return false;
 		}

--- a/src/routes/(authed)/transactions/filters.ts
+++ b/src/routes/(authed)/transactions/filters.ts
@@ -1,0 +1,286 @@
+/**
+ * Transactions-page filter model + pure client-side filter function.
+ *
+ * Design (hybrid filtering):
+ *   - CLIENT-SIDE filtering over the merged `allTransactionsStore` list is
+ *     the SOURCE OF TRUTH for what's displayed. It must be, because the
+ *     merged list contains items the server never filtered: localStorage
+ *     pending txs and BTC-deposit indexer events.
+ *   - SERVER-SIDE filter options (TransactionFilter.byType /
+ *     byLedgerToFrom) are threaded into the GraphQL fetch as a PAGINATION
+ *     OPTIMIZATION: when a type/address filter is active, pages fetched
+ *     from the server contain mostly-matching rows so infinite scroll
+ *     stays useful. The client filter then re-verifies everything.
+ *
+ * Pure functions only — no stores, no DOM — so the whole matrix is
+ * unit-testable (see filters.test.ts).
+ */
+import type { TxListItem } from '$lib/stores/txStores';
+import { getTimestamp } from '$lib/stores/txStores';
+
+// ─── Filter state ────────────────────────────────────────────────────────────
+
+export type TimeRangePreset = 'all' | '24h' | '7d' | '30d';
+
+export type TxFilters = {
+	/** Lowercase asset values to keep (e.g. ['hive', 'hbd']). Empty = all. */
+	tokens: string[];
+	/** Time window preset. 'all' = no time filtering. */
+	timeRange: TimeRangePreset;
+	/** Minimum amount in HUMAN units of the entry's own asset. null = no floor. */
+	amountMin: number | null;
+	/** Maximum amount in HUMAN units of the entry's own asset. null = no cap. */
+	amountMax: number | null;
+	/** Op/ledger types to keep (e.g. ['transfer', 'deposit']). Empty = all. */
+	types: string[];
+	/** Case-insensitive substring matched against from/to accounts. '' = all. */
+	address: string;
+};
+
+export const EMPTY_FILTERS: TxFilters = {
+	tokens: [],
+	timeRange: 'all',
+	amountMin: null,
+	amountMax: null,
+	types: [],
+	address: ''
+};
+
+export function isFiltering(f: TxFilters): boolean {
+	return (
+		f.tokens.length > 0 ||
+		f.timeRange !== 'all' ||
+		f.amountMin != null ||
+		f.amountMax != null ||
+		f.types.length > 0 ||
+		f.address.trim() !== ''
+	);
+}
+
+/** Count of active filter groups — drives the "Filters (2)" chip label. */
+export function activeFilterCount(f: TxFilters): number {
+	let n = 0;
+	if (f.tokens.length > 0) n++;
+	if (f.timeRange !== 'all') n++;
+	if (f.amountMin != null || f.amountMax != null) n++;
+	if (f.types.length > 0) n++;
+	if (f.address.trim() !== '') n++;
+	return n;
+}
+
+// ─── Options the UI offers ───────────────────────────────────────────────────
+
+/** Assets the filter chips offer. Lowercase values matching ledger `asset`
+ *  fields (which sometimes carry suffixes like "hbd_savings" — matching is
+ *  done on the prefix before '_'). */
+export const TOKEN_OPTIONS = [
+	{ value: 'hive', label: 'HIVE' },
+	{ value: 'hbd', label: 'HBD' },
+	{ value: 'btc', label: 'BTC' }
+] as const;
+
+/** Operation/ledger types the filter offers. Values match both
+ *  `ledger[].type` and `ops[].type` (the client filter checks both). */
+export const TYPE_OPTIONS = [
+	{ value: 'transfer', label: 'Transfer' },
+	{ value: 'deposit', label: 'Deposit' },
+	{ value: 'withdraw', label: 'Withdraw' },
+	{ value: 'stake', label: 'Stake' },
+	{ value: 'unstake', label: 'Unstake' },
+	{ value: 'call', label: 'Contract call' }
+] as const;
+
+export const TIME_RANGE_OPTIONS: { value: TimeRangePreset; label: string }[] = [
+	{ value: 'all', label: 'All time' },
+	{ value: '24h', label: 'Last 24 hours' },
+	{ value: '7d', label: 'Last 7 days' },
+	{ value: '30d', label: 'Last 30 days' }
+];
+
+// ─── Internals ───────────────────────────────────────────────────────────────
+
+const TIME_RANGE_MS: Record<Exclude<TimeRangePreset, 'all'>, number> = {
+	'24h': 24 * 60 * 60 * 1000,
+	'7d': 7 * 24 * 60 * 60 * 1000,
+	'30d': 30 * 24 * 60 * 60 * 1000
+};
+
+/** Decimal places per asset for converting smallest units → human units. */
+const ASSET_DECIMALS: Record<string, number> = {
+	hive: 3,
+	hbd: 3,
+	btc: 8,
+	sats: 0
+};
+
+/** "hbd_savings" → "hbd"; "HIVE" → "hive". */
+function normalizeAsset(raw: unknown): string {
+	return String(raw ?? '')
+		.toLowerCase()
+		.split('_')[0];
+}
+
+function toHumanAmount(raw: unknown, asset: string): number | null {
+	const dp = ASSET_DECIMALS[asset];
+	if (dp === undefined) return null;
+	if (typeof raw === 'number') return raw / 10 ** dp;
+	if (typeof raw === 'string') {
+		const n = Number(raw);
+		if (!Number.isFinite(n)) return null;
+		// Strings with a decimal point are already human units (Hive L1 ops
+		// e.g. "5.453"); integer strings are smallest units.
+		return raw.includes('.') ? n : n / 10 ** dp;
+	}
+	return null;
+}
+
+/** Every (asset, amount, from, to, type) tuple found on a tx — from both
+ *  ledger entries and op payloads. A tx matches a filter if ANY entry does. */
+type TxEntry = {
+	asset: string;
+	amountHuman: number | null;
+	from: string;
+	to: string;
+	type: string;
+};
+
+function entriesOf(item: TxListItem): TxEntry[] {
+	if (item.kind === 'btc-deposit') {
+		return [
+			{
+				asset: 'btc',
+				amountHuman: toHumanAmount(item.event.amount, 'btc'),
+				from: item.event.sender ?? '',
+				to: item.event.recipient ?? '',
+				type: 'deposit'
+			}
+		];
+	}
+	const out: TxEntry[] = [];
+	for (const entry of item.tx.ledger ?? []) {
+		if (!entry) continue;
+		const asset = normalizeAsset(entry.asset);
+		out.push({
+			asset,
+			amountHuman: toHumanAmount(entry.amount, asset),
+			from: entry.from ?? '',
+			to: entry.to ?? '',
+			type: String(entry.type ?? '')
+		});
+	}
+	for (const op of item.tx.ops ?? []) {
+		if (!op) continue;
+		const data = op.data ?? {};
+		const asset = normalizeAsset(data.asset);
+		out.push({
+			asset,
+			amountHuman: toHumanAmount(data.amount, asset),
+			from: String(data.from ?? ''),
+			to: String(data.to ?? ''),
+			type: String(op.type ?? '')
+		});
+	}
+	return out;
+}
+
+function itemTimestampMs(item: TxListItem): number {
+	if (item.kind === 'btc-deposit') {
+		const ts = item.event.indexer_ts;
+		return new Date(ts.endsWith('Z') ? ts : ts + 'Z').getTime();
+	}
+	return new Date(getTimestamp(item.tx)).getTime();
+}
+
+// ─── The filter ──────────────────────────────────────────────────────────────
+
+/**
+ * Apply all active filters to the merged tx list. An item passes when EVERY
+ * active filter group matches at least one of its entries (token, amount,
+ * type, address) and its timestamp falls inside the window.
+ *
+ * @param nowMs  Injected clock for testability (defaults to Date.now()).
+ */
+export function applyClientFilters(
+	items: TxListItem[],
+	filters: TxFilters,
+	nowMs: number = Date.now()
+): TxListItem[] {
+	if (!isFiltering(filters)) return items;
+
+	const address = filters.address.trim().toLowerCase();
+	const cutoffMs =
+		filters.timeRange === 'all' ? null : nowMs - TIME_RANGE_MS[filters.timeRange];
+
+	return items.filter((item) => {
+		if (cutoffMs != null && itemTimestampMs(item) < cutoffMs) return false;
+
+		const entries = entriesOf(item);
+		if (entries.length === 0) {
+			// No parseable entries (rare malformed tx): only show when no
+			// entry-based filter is active.
+			return (
+				filters.tokens.length === 0 &&
+				filters.types.length === 0 &&
+				filters.amountMin == null &&
+				filters.amountMax == null &&
+				address === ''
+			);
+		}
+
+		if (filters.tokens.length > 0 && !entries.some((e) => filters.tokens.includes(e.asset))) {
+			return false;
+		}
+		if (filters.types.length > 0) {
+			// 'call' should also match 'call_contract'.
+			const matchesType = entries.some((e) =>
+				filters.types.some((t) => e.type === t || e.type.startsWith(t + '_'))
+			);
+			if (!matchesType) return false;
+		}
+		if (filters.amountMin != null || filters.amountMax != null) {
+			const inRange = entries.some((e) => {
+				if (e.amountHuman == null) return false;
+				if (filters.amountMin != null && e.amountHuman < filters.amountMin) return false;
+				if (filters.amountMax != null && e.amountHuman > filters.amountMax) return false;
+				return true;
+			});
+			if (!inRange) return false;
+		}
+		if (address !== '') {
+			const matchesAddress = entries.some(
+				(e) =>
+					e.from.toLowerCase().includes(address) || e.to.toLowerCase().includes(address)
+			);
+			if (!matchesAddress) return false;
+		}
+		return true;
+	});
+}
+
+// ─── Server-side mapping ─────────────────────────────────────────────────────
+
+/**
+ * The subset of filters expressible as GraphQL TransactionFilter options.
+ * Used to make paginated fetches return mostly-matching rows; the client
+ * filter above remains the display source of truth.
+ *
+ * byLedgerToFrom is exact-match on the server, so we only pass the address
+ * through when it looks like a full account (contains ':' as in
+ * 'hive:user' / 'did:pkh:…') — for partial text the server filter would
+ * wrongly return nothing and starve the client filter of candidates.
+ */
+export function toServerFilterVars(filters: TxFilters): {
+	byType?: string[];
+	byLedgerToFrom?: string;
+} {
+	const out: { byType?: string[]; byLedgerToFrom?: string } = {};
+	if (filters.types.length > 0) {
+		// Expand 'call' to the wire-level op names.
+		out.byType = filters.types.flatMap((t) => (t === 'call' ? ['call', 'call_contract'] : [t]));
+	}
+	const addr = filters.address.trim();
+	if (addr.includes(':')) {
+		out.byLedgerToFrom = addr;
+	}
+	return out;
+}

--- a/src/routes/(authed)/transactions/filters.ts
+++ b/src/routes/(authed)/transactions/filters.ts
@@ -183,7 +183,7 @@ function entriesOf(item: TxListItem): TxEntry[] {
 	return out;
 }
 
-function itemTimestampMs(item: TxListItem): number {
+export function itemTimestampMs(item: TxListItem): number {
 	if (item.kind === 'btc-deposit') {
 		const ts = item.event.indexer_ts;
 		return new Date(ts.endsWith('Z') ? ts : ts + 'Z').getTime();
@@ -283,4 +283,49 @@ export function toServerFilterVars(filters: TxFilters): {
 		out.byLedgerToFrom = addr;
 	}
 	return out;
+}
+
+// ─── Sorting ─────────────────────────────────────────────────────────────────
+
+export type TxSortColumn = 'date' | 'amount';
+export type TxSortDirection = 'asc' | 'desc';
+
+/**
+ * Representative USD value of a tx item for amount sorting: the LARGEST
+ * entry (ledger or op leg) valued at current prices. Max — not sum —
+ * because a swap's ledger repeats the same value across hops (in→pool,
+ * pool→out, fee) and summing would double-count. Entries in assets we
+ * can't price contribute 0.
+ */
+export function itemAmountUsd(
+	item: TxListItem,
+	usdPrices: { hive: number; hbd: number; btc: number }
+): number {
+	let max = 0;
+	for (const e of entriesOf(item)) {
+		if (e.amountHuman == null) continue;
+		const price = usdPrices[e.asset as keyof typeof usdPrices] ?? 0;
+		const usd = Math.abs(e.amountHuman) * price;
+		if (usd > max) max = usd;
+	}
+	return max;
+}
+
+/**
+ * Sort the (already filtered) tx list client-side. Date desc is the feed's
+ * natural order — sorting is stable (Array.prototype.sort is stable per
+ * spec) so equal keys keep their incoming order.
+ */
+export function sortTxItems(
+	items: TxListItem[],
+	col: TxSortColumn,
+	dir: TxSortDirection,
+	usdPrices: { hive: number; hbd: number; btc: number }
+): TxListItem[] {
+	const sign = dir === 'asc' ? 1 : -1;
+	const key =
+		col === 'date'
+			? (i: TxListItem) => itemTimestampMs(i)
+			: (i: TxListItem) => itemAmountUsd(i, usdPrices);
+	return [...items].sort((a, b) => sign * (key(a) - key(b)));
 }


### PR DESCRIPTION
## Summary

Implements the "[TRANSACTIONS page] add filters" and "add sorting" Notion
tasks, plus a protocol-fee section in the transaction detail popup.

## Filters

- **Quick chips** above the table for the two most common filters — tokens
  (HIVE/HBD/BTC) and time range (all/24h/7d/30d). Hidden below 900px.
- **Right-edge drawer** (Filters button at the end of the chips row) with all
  five groups: tokens, time range, amount min–max, type, address/user.
  Portaled to document.body so ancestor backdrop-filters can't trap it;
  backdrop click / ESC / Done all close it.
- **Hybrid architecture**: client-side filtering over the merged tx list is
  the display source of truth — it has to be, since the list contains
  localStorage pending txs and BTC-deposit indexer events the server never
  saw. The server-expressible subset (`byType`, `byLedgerToFrom`) goes into
  the GraphQL fetches so paginated pages stay relevant; an auto-top-up
  extends fetches while filters leave <8 visible rows.
- Active panel filters render as per-value summary chips (one per selected
  type) with individual clears, grouped by category with pipe separators.
- Text inputs apply live (300ms debounce, Enter = instant); every close
  path commits pending text so input is never silently dropped.

## Sorting

- **Date and Amount headers are click-to-sort** (desc → asc, chevron on the
  active column), mirroring the pools-table pattern.
- Amount sorts on **USD value across assets**; per-item value is the largest
  ledger/op entry — not the sum — because swap ledgers repeat the same value
  across hops (in→pool, pool→out, fee).
- Default stays Date desc (feed order; sort pass skipped). Status/Type/
  To-From deliberately not sortable — they're categories, the drawer serves
  them better.

## Protocol fees in the detail popup

Swaps pay the protocol fee as a ledger transfer to `pendulum:nodes`; those
legs now show in the popup, summed per asset. Deliberately NOT a table
column: LP fee + stabilizer stay in the pool (implicit in the rate), so a
per-row column would under-report the true cost. The popup carries the
honest note "LP fee is included in the exchange rate".

## Fixes

- Transactions card capped at `calc(100vh - 12rem)`; the empty state no
  longer stretches past the screen and is no longer scrollable.
- Debounce timer cleaned up on FilterBar unmount (review finding).

## Verification

- 235 tests passing (36 new in `filters.test.ts` pinning the filter matrix
  and sort semantics)
- svelte-check at the pre-existing 60/32 baseline
- Changed files prettier-formatted; new eslint findings fixed (remaining
  errors in the area predate this branch)

## Notes for reviewers

- Backend exposes no `orderBy`, so sorting is client-side over loaded rows
  (same caveat as filtering — documented in `filters.ts`).
- The deep-link tx hunt (`?tx=…`) deliberately stays unfiltered.
- The dashboard's small Table embed is unaffected (defaults: no filters,
  feed order, no height cap).