### PR TITLE
feat(witness): contract-updates section on the witness page (0.3.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ All notable changes to Altera are documented here.
 > CI / build-banner / release-script use, and so a glance at `package.json`
 > matches reality.
 
+## [0.3.18] — 2026-06-12
+
+### Features
+
+- **Witness page: contract updates.** New section surfacing pending, time-locked system-contract upgrades from go-vsc-node PR #210's `findPendingContractUpdates`: which contract, the new WASM CID, who proposed it, owner, queued/activation block heights, and a live countdown to activation. Each pending row links to the proposer account, the new code on IPFS, and the contract on the VSC explorer; a detail page per update lives at `/witness-assistant/contract-update/[id]`. Every pending update is shown (not just known contracts) — curated pools/router/bridge get a friendly name + category badge, unknown contracts resolve their on-chain name via `findContract` (e.g. "DEX Router") or fall back to a short id, so nothing is hidden from a witness. Data fetches through the same-origin `/api/gql` proxy following the app's configured node; 30s polling
+- **Witness page: dormant "awaiting backend" state.** Ships safely to mainnet before the backend is deployed there (PR #210 is testnet-only as of this release; verified absent on `api.vsc.eco` + `vsc.techcoderx.com`). When the configured node doesn't serve the field, the section renders a grayed, desaturated card with an "AWAITING BACKEND" badge instead of fake data or an error. The poll auto-activates it the instant the field goes live — the gray fades out and real data renders with zero redeploy. Dev builds get labeled mock fixtures (`?mock=1`) for visual review, compiled out of production
+
+### Fixes
+
+- **`activation_ts` parsed as UTC.** Live testnet verification (2026-06-12) surfaced that the node emits the timestamp without a timezone designator (`2026-06-12T14:08:45`), which naive `Date.parse` treats as local time — shifting activation by the user's UTC offset and making the countdown read "unlocked" for a still-pending update. `tsToUnixSec` now appends `Z` when no designator is present (same as `txStores.getTimestamp`); the detail page's local-time display routes through the same path. Pinned by a timezone-independent test
+- **Hardened module-scope localStorage access** in `client.ts`, `nodeSelection/select.ts`, and `magiTransactions/dhive.ts`. These read localStorage at module-evaluation time; the jsdom Vitest client project exposes a `localStorage` global without a callable `getItem`, so every client test importing this module graph crashed at collection (2 suites, 33 tests). Safe accessors (optional chaining + try/catch, plus a callable-`getItem` check in `select.ts`) keep behavior identical in real browsers and make the modules import-safe everywhere
+
+### Testing
+
+- 28 tests pin the witness contract-updates feature: wire-shape contract against PR #210, render states (loading / live / mock / empty / dormant), fallback paths (GraphQL error, HTTP 4xx/5xx, non-JSON), on-chain name resolution, and UTC timestamp parsing. The localStorage hardening un-broke 33 pre-existing client tests (full suite 296 → 297 passing)
+
 ## [0.3.17] — 2026-06-10
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.3.17",
+	"version": "0.3.18",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,6 +12,20 @@ export const keyTbd = 'prefs-tbd';
 
 const DEFAULT_VSC_NET_ID = 'vsc-mainnet';
 
+/**
+ * localStorage access that never throws at module-evaluation time.
+ * client.ts runs `localStorage.getItem` at module scope; in the jsdom
+ * Vitest environment (and any context where Storage isn't fully
+ * implemented) that crashed every test importing this module's graph.
+ */
+function lsGet(key: string): string | null {
+	try {
+		return globalThis.localStorage?.getItem?.(key) ?? null;
+	} catch {
+		return null;
+	}
+}
+
 /** Default Magi indexer (Hasura) base URL — same as okinoko/prod.
  *  The `/v1/graphql` path is appended by the GraphQL proxy route. */
 export const DEFAULT_MAGI_INDEXER_URL = 'https://indexer.magi.milohpr.com';
@@ -19,7 +33,7 @@ export const DEFAULT_MAGI_INDEXER_URL = 'https://indexer.magi.milohpr.com';
 /** DEX Router contract — routes swaps and BTC/HBD liquidity deposits.
  *  Network-switched between mainnet and testnet. */
 export const DEX_ROUTER_CONTRACT_ID = (() => {
-	const isTestnet = (browser && localStorage.getItem(keyVscNetworkId)) === 'vsc-testnet';
+	const isTestnet = (browser && lsGet(keyVscNetworkId)) === 'vsc-testnet';
 	return isTestnet
 		? 'vsc1Bens5nrhnbbHEUftCWaLPYegDx9LGLXEUP'
 		: 'vsc1Brvi4YZHLkocYNAFd7Gf1JpsPjzNnv4i45';
@@ -37,7 +51,7 @@ const TESTNET_DEPRECATED_POOL_IDS = [
 ];
 
 const deprecatedPoolIds: ReadonlySet<string> = new Set(
-	(browser && localStorage.getItem(keyVscNetworkId)) === 'vsc-testnet'
+	(browser && lsGet(keyVscNetworkId)) === 'vsc-testnet'
 		? TESTNET_DEPRECATED_POOL_IDS
 		: []
 );
@@ -50,7 +64,7 @@ export function isDeprecatedPool(contractId: string): boolean {
 export const currentGqlUrl = browser ? resolveNodeUrl('vsc') : DEFAULT_GQL_URL;
 
 export const vscNetworkId =
-	(browser && localStorage.getItem(keyVscNetworkId)) || DEFAULT_VSC_NET_ID;
+	(browser && lsGet(keyVscNetworkId)) || DEFAULT_VSC_NET_ID;
 
 /** True when the configured VSC network is the testnet. */
 export const isVscTestnet = (): boolean => vscNetworkId === 'vsc-testnet';
@@ -61,9 +75,9 @@ export const getMagiIndexerBaseUrl = (): string =>
 	browser ? resolveNodeUrl('indexer') : DEFAULT_MAGI_INDEXER_URL;
 
 /** Display unit for Hive (e.g. TESTS on testnet). Use for UI only. */
-export const getHiveAssetName = (): string => (browser && localStorage.getItem(keyTests)) || 'HIVE';
+export const getHiveAssetName = (): string => (browser && lsGet(keyTests)) || 'HIVE';
 /** Display unit for HBD (e.g. TBD on testnet). Use for UI only. */
-export const getHbdAssetName = (): string => (browser && localStorage.getItem(keyTbd)) || 'HBD';
+export const getHbdAssetName = (): string => (browser && lsGet(keyTbd)) || 'HBD';
 
 /**
  * Same-origin GraphQL proxy endpoint. The browser POSTs here instead of

--- a/src/lib/magiTransactions/dhive.ts
+++ b/src/lib/magiTransactions/dhive.ts
@@ -7,6 +7,17 @@ export const keyHiveApiList = 'hive-api';
 export const keyHiveApiAllowBackups = 'hive-api-allow-backup';
 export const keyHiveNetworkId = 'hive-network-id';
 
+// localStorage access that never throws at module-evaluation time — some
+// environments (jsdom Vitest client project) expose a localStorage global
+// without a callable getItem. Mirrors client.ts's lsGet.
+function lsGet(key: string): string | null {
+	try {
+		return globalThis.localStorage?.getItem?.(key) ?? null;
+	} catch {
+		return null;
+	}
+}
+
 // export const DEFAULT_HIVE_APIS = [
 // 	'https://api.hive.blog',
 // 	'https://api.hivekings.com',
@@ -15,19 +26,19 @@ export const keyHiveNetworkId = 'hive-network-id';
 // ];
 
 export const DEFAULT_HIVE_APIS = [
-	(browser && localStorage.getItem(keyHiveApiList)) || 'https://api.hive.blog'
+	(browser && lsGet(keyHiveApiList)) || 'https://api.hive.blog'
 ];
 
 const urls: string[] = (() => {
 	const primary = browser ? resolveNodeUrl('hive') : 'https://api.hive.blog';
-	const allowBackupStr = browser && localStorage.getItem(keyHiveApiAllowBackups);
+	const allowBackupStr = browser && lsGet(keyHiveApiAllowBackups);
 	const allowBackups = allowBackupStr ? allowBackupStr === 'true' : true;
 	if (!allowBackups) return [primary];
 	return Array.from(new Set([primary, ...hiveRpcNodes]));
 })();
 
 const opts: ClientOptions = {
-	chainId: (browser && localStorage.getItem(keyHiveNetworkId)) || undefined
+	chainId: (browser && lsGet(keyHiveNetworkId)) || undefined
 };
 
 export const DHive = new Client(urls, opts);

--- a/src/lib/nodeSelection/select.ts
+++ b/src/lib/nodeSelection/select.ts
@@ -39,7 +39,11 @@ const NODES: Record<Category, string[]> = {
 
 function ls(): Storage | null {
 	try {
+		// Some environments (jsdom Vitest client project) expose a
+		// `localStorage` global that isn't a full Storage implementation —
+		// validate getItem is callable, not just that the global exists.
 		if (!browser || typeof localStorage === 'undefined') return null;
+		if (typeof localStorage.getItem !== 'function') return null;
 		return localStorage;
 	} catch {
 		return null;

--- a/src/lib/witness/contractUpdates/ContractUpdatesSection.svelte
+++ b/src/lib/witness/contractUpdates/ContractUpdatesSection.svelte
@@ -1,0 +1,426 @@
+<!--
+	Contract Updates panel — surfaces pending governance updates on the
+	witness page so witnesses can audit code that's about to ship.
+
+	Aligned with the `findPendingContractUpdates` GraphQL shape from
+	go-vsc-node PR #210. While that PR is unmerged we read from
+	`mockData.ts`; swap to the Houdini store once the field is live.
+
+	The chain has no concept of contract name / category / human title —
+	those come from a curated client-side registry (`CONTRACT_REGISTRY`
+	in mockData.ts). Updates against unknown contracts still render
+	(showing a truncated id) but with no friendly label.
+-->
+<script lang="ts">
+	import Card from '$lib/cards/Card.svelte';
+	import Countdown from './Countdown.svelte';
+	import { loadPendingUpdates, type LoadResult } from './loader';
+	import { tsToUnixSec, type ContractUpdateView } from './types';
+	import { proposerTxUrl, codeIpfsUrl, contractExplorerUrl } from './auditLinks';
+	import { ExternalLink, FileCode2, Loader2, ShieldAlert, User } from '@lucide/svelte';
+
+	type SectionState = { source: 'loading' } | LoadResult;
+	let state = $state<SectionState>({ source: 'loading' });
+
+	$effect(() => {
+		// Initial fetch + a light 10s poll. The poll matters for live
+		// observation: on testnet the contract-update timelock is ~90
+		// seconds, so a queued update must appear without a manual refresh
+		// or the window is missed. Sequential guard: skip a tick if the
+		// previous request is still in flight.
+		let inFlight = false;
+		const refresh = () => {
+			if (inFlight) return;
+			inFlight = true;
+			loadPendingUpdates()
+				.then((r) => {
+					// Live-test diagnostics: timestamp every pending-count change
+					// so the UI's detection moment can be compared against the
+					// deploy moment. Strip with the loader logs post-verification.
+					const prevCount = state.source === 'loading' ? -1 : state.updates.length;
+					if (r.updates.length !== prevCount) {
+						console.debug(
+							`[contract-updates] ${new Date().toISOString()} pending: ${prevCount === -1 ? '(initial)' : prevCount} → ${r.updates.length} (source: ${r.source})`
+						);
+					}
+					state = r;
+				})
+				.finally(() => {
+					inFlight = false;
+				});
+		};
+		refresh();
+		const handle = setInterval(refresh, 30_000);
+		return () => clearInterval(handle);
+	});
+
+	const pending = $derived<ContractUpdateView[]>(state.source === 'loading' ? [] : state.updates);
+	const isMock = $derived(state.source === 'mock');
+	const mockReason = $derived(state.source === 'mock' ? state.reason : '');
+
+	function shortId(id: string): string {
+		return `${id.slice(0, 8)}…${id.slice(-4)}`;
+	}
+
+	function categoryFor(u: ContractUpdateView): string {
+		return u.metadata?.category ?? 'other';
+	}
+
+	function titleFor(u: ContractUpdateView): string {
+		// Precedence: curated registry name → on-chain contract name
+		// (findContract.name, e.g. "DEX Router") → short id.
+		const name = u.metadata?.name ?? u.chainName;
+		return name ? `Upgrade · ${name}` : `Upgrade · contract ${shortId(u.id)}`;
+	}
+</script>
+
+<Card>
+	<header class="head">
+		<div>
+			<h3>
+				<ShieldAlert size={18} />
+				Contract updates
+			</h3>
+			<p class="lead">
+				System-contract code changes (pools, bridge, gateway, …) are time-locked. Audit the new code
+				before it activates.
+			</p>
+		</div>
+		{#if isMock}
+			<div
+				class="mock-badge"
+				title={`Backend not yet returning data (${mockReason}). Showing mock fixtures until go-vsc-node PR #210 is live on api.vsc.eco.`}
+			>
+				MOCK DATA · PR #210
+			</div>
+		{/if}
+	</header>
+
+	<section>
+		<h4 class="section-heading">
+			<span>Pending</span>
+			{#if pending.length > 0}
+				<span class="count pending">{pending.length}</span>
+			{:else}
+				<span class="count">0</span>
+			{/if}
+		</h4>
+
+		{#if state.source === 'loading'}
+			<p class="empty loading">
+				<Loader2 size={14} class="spin" />
+				Loading pending updates…
+			</p>
+		{:else if pending.length === 0}
+			<p class="empty">No pending contract updates.</p>
+		{:else}
+			<ul class="list">
+				{#each pending as u (u.id)}
+					<li class="row pending-row">
+						<a class="row-main" href={`/witness-assistant/contract-update/${u.id}`}>
+							<div class="row-head">
+								<span class="kind kind-{categoryFor(u)}">
+									{u.metadata?.category ?? 'contract'}
+								</span>
+								<strong class="title">{titleFor(u)}</strong>
+							</div>
+							<div class="row-meta">
+								<span class="proposer">
+									<User size={12} />
+									proposed by <strong>{u.proposer}</strong>
+								</span>
+								<span class="dot">·</span>
+								<span>owner <code>{u.owner}</code></span>
+								<span class="dot">·</span>
+								<span>at block #{u.creation_height.toLocaleString()}</span>
+							</div>
+						</a>
+						<div class="row-countdown">
+							<span class="cd-label">Activates in</span>
+							<Countdown targetUnixSec={tsToUnixSec(u.activation_ts)} />
+							<span class="cd-sub">block #{u.activation_height.toLocaleString()}</span>
+						</div>
+						<div class="row-links">
+							<a
+								href={proposerTxUrl(u.proposer)}
+								target="_blank"
+								rel="noopener"
+								title="Proposer account on explorer"
+							>
+								<ExternalLink size={14} />
+								<span>Proposer</span>
+							</a>
+							<a href={codeIpfsUrl(u.code)} target="_blank" rel="noopener" title="New code on IPFS">
+								<FileCode2 size={14} />
+								<span>New code</span>
+							</a>
+							<a
+								href={contractExplorerUrl(u.id)}
+								target="_blank"
+								rel="noopener"
+								title="Contract on the VSC explorer"
+							>
+								<ExternalLink size={14} />
+								<span>Explorer</span>
+							</a>
+						</div>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</section>
+</Card>
+
+<style lang="scss">
+	.head {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		gap: 1rem;
+		margin-bottom: 1.25rem;
+	}
+	h3 {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin: 0 0 0.25rem;
+		font-size: 1.1rem;
+		font-family: 'Nunito Sans', sans-serif;
+	}
+	.lead {
+		margin: 0;
+		font-size: 0.88rem;
+		color: var(--dash-text-secondary);
+		max-width: 38rem;
+		line-height: 1.45;
+	}
+	.mock-badge {
+		font-size: 0.65rem;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		padding: 0.2rem 0.45rem;
+		border-radius: 4px;
+		background: rgba(255, 200, 0, 0.18);
+		color: #ffdc6b;
+		border: 1px solid rgba(255, 200, 0, 0.35);
+		flex-shrink: 0;
+		cursor: help;
+	}
+
+	.section-heading {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.72rem;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--dash-text-secondary);
+		margin: 0 0 0.75rem;
+		font-weight: 600;
+	}
+	.count {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 1.25rem;
+		height: 1.25rem;
+		padding: 0 0.4rem;
+		border-radius: 999px;
+		background: rgba(255, 255, 255, 0.08);
+		font-size: 0.7rem;
+		font-weight: 700;
+		letter-spacing: 0;
+		color: var(--dash-text-primary);
+	}
+	.count.pending {
+		background: rgba(255, 170, 50, 0.22);
+		color: #ffc48a;
+	}
+
+	.list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.6rem;
+	}
+	.row {
+		display: grid;
+		gap: 0.6rem;
+		padding: 0.85rem 1rem;
+		border-radius: 12px;
+		border: 1px solid rgba(255, 255, 255, 0.08);
+		background: rgba(255, 255, 255, 0.03);
+	}
+	.row.pending-row {
+		grid-template-columns: 1fr auto;
+		grid-template-areas:
+			'main countdown'
+			'links links';
+		border-color: rgba(255, 170, 50, 0.28);
+		background: rgba(255, 170, 50, 0.04);
+	}
+	.row-main {
+		grid-area: main;
+		display: flex;
+		flex-direction: column;
+		gap: 0.3rem;
+		min-width: 0;
+		color: inherit;
+		text-decoration: none;
+	}
+	.row-main:hover .title {
+		color: #b0acff;
+	}
+	.row-head {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+	}
+	.title {
+		font-size: 0.95rem;
+		color: var(--dash-text-primary);
+		transition: color 150ms ease;
+	}
+	.kind {
+		font-size: 0.66rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		padding: 0.18rem 0.5rem;
+		border-radius: 4px;
+		background: rgba(255, 255, 255, 0.08);
+		color: var(--dash-text-secondary);
+	}
+	.kind.kind-pool {
+		background: rgba(111, 106, 248, 0.22);
+		color: #b0acff;
+	}
+	.kind.kind-bridge {
+		background: rgba(60, 180, 230, 0.2);
+		color: #8edcf4;
+	}
+	.kind.kind-gateway {
+		background: rgba(150, 200, 100, 0.2);
+		color: #c8e69b;
+	}
+	.kind.kind-oracle {
+		background: rgba(230, 150, 200, 0.2);
+		color: #f0adcf;
+	}
+	.kind.kind-governance {
+		background: rgba(230, 150, 60, 0.22);
+		color: #ffc48a;
+	}
+	.kind.kind-other {
+		background: rgba(255, 255, 255, 0.08);
+		color: var(--dash-text-secondary);
+	}
+
+	.row-meta {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		flex-wrap: wrap;
+		font-size: 0.78rem;
+		color: var(--dash-text-secondary);
+	}
+	.row-meta .proposer {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+	}
+	.row-meta code {
+		font-family: 'Noto Sans Mono', monospace;
+		font-size: 0.78em;
+		background: rgba(255, 255, 255, 0.06);
+		padding: 0.05rem 0.3rem;
+		border-radius: 4px;
+		color: var(--dash-text-primary);
+	}
+	.dot {
+		opacity: 0.5;
+	}
+
+	.row-countdown {
+		grid-area: countdown;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		gap: 0.15rem;
+	}
+	.cd-label {
+		font-size: 0.66rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--dash-text-secondary);
+		font-weight: 600;
+	}
+	.cd-sub {
+		font-size: 0.7rem;
+		color: var(--dash-text-muted);
+	}
+
+	.row-links {
+		grid-area: links;
+		display: flex;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+		padding-top: 0.5rem;
+		border-top: 1px dashed rgba(255, 255, 255, 0.08);
+	}
+	.row-links a {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3rem;
+		font-size: 0.78rem;
+		padding: 0.3rem 0.55rem;
+		border-radius: 6px;
+		background: rgba(255, 255, 255, 0.06);
+		color: var(--dash-text-primary);
+		text-decoration: none;
+		transition: background-color 150ms ease;
+	}
+	.row-links a:hover {
+		background: rgba(255, 255, 255, 0.12);
+	}
+
+	.empty {
+		margin: 0;
+		font-size: 0.85rem;
+		color: var(--dash-text-muted);
+		font-style: italic;
+	}
+	.empty.loading {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		font-style: normal;
+	}
+	:global(.spin) {
+		animation: spin 1s linear infinite;
+	}
+	@keyframes spin {
+		from {
+			transform: rotate(0deg);
+		}
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	@media (max-width: 600px) {
+		.row.pending-row {
+			grid-template-columns: 1fr;
+			grid-template-areas:
+				'main'
+				'countdown'
+				'links';
+		}
+		.row-countdown {
+			align-items: flex-start;
+		}
+	}
+</style>

--- a/src/lib/witness/contractUpdates/ContractUpdatesSection.svelte
+++ b/src/lib/witness/contractUpdates/ContractUpdatesSection.svelte
@@ -57,6 +57,11 @@
 	const pending = $derived<ContractUpdateView[]>(state.source === 'loading' ? [] : state.updates);
 	const isMock = $derived(state.source === 'mock');
 	const mockReason = $derived(state.source === 'mock' ? state.reason : '');
+	// Dormant: the configured node doesn't serve findPendingContractUpdates
+	// yet (PR #210 not deployed to mainnet). The section renders a grayed,
+	// "awaiting backend" state and auto-activates on the next poll the
+	// instant the field goes live — no redeploy needed.
+	const isDormant = $derived(state.source === 'unavailable');
 
 	function shortId(id: string): string {
 		return `${id.slice(0, 8)}…${id.slice(-4)}`;
@@ -75,6 +80,7 @@
 </script>
 
 <Card>
+	<div class="card-inner" class:dormant={isDormant}>
 	<header class="head">
 		<div>
 			<h3>
@@ -93,6 +99,10 @@
 			>
 				MOCK DATA · PR #210
 			</div>
+		{:else if isDormant}
+			<div class="dormant-badge" title="This node doesn't serve contract updates yet. The section activates automatically when the backend (go-vsc-node PR #210) deploys.">
+				AWAITING BACKEND
+			</div>
 		{/if}
 	</header>
 
@@ -110,6 +120,11 @@
 			<p class="empty loading">
 				<Loader2 size={14} class="spin" />
 				Loading pending updates…
+			</p>
+		{:else if isDormant}
+			<p class="empty dormant-note">
+				Contract-update tracking isn&rsquo;t available on this node yet. It will turn on automatically
+				once the backend is wired up — no action needed.
 			</p>
 		{:else if pending.length === 0}
 			<p class="empty">No pending contract updates.</p>
@@ -169,9 +184,37 @@
 			</ul>
 		{/if}
 	</section>
+	</div>
 </Card>
 
 <style lang="scss">
+	/* Dormant state: backend not wired (PR #210 not on this node). Grayed
+	   + slightly desaturated so it reads as "present but not yet live",
+	   without hiding the feature. Auto-clears when the field goes live. */
+	.card-inner.dormant {
+		opacity: 0.62;
+		filter: grayscale(0.65);
+		transition: opacity 250ms ease, filter 250ms ease;
+	}
+	.dormant-badge {
+		flex-shrink: 0;
+		align-self: flex-start;
+		padding: 0.25rem 0.55rem;
+		border: 1px solid var(--dash-card-border);
+		border-radius: 999px;
+		font-size: 0.62rem;
+		font-weight: 700;
+		letter-spacing: 0.06em;
+		color: var(--dash-text-secondary);
+		background: rgba(255, 255, 255, 0.04);
+		white-space: nowrap;
+		cursor: help;
+	}
+	.dormant-note {
+		max-width: 38rem;
+		line-height: 1.45;
+	}
+
 	.head {
 		display: flex;
 		justify-content: space-between;

--- a/src/lib/witness/contractUpdates/ContractUpdatesSection.svelte.test.ts
+++ b/src/lib/witness/contractUpdates/ContractUpdatesSection.svelte.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tier-B component test for ContractUpdatesSection.
+ *
+ * Mocks `loadPendingUpdates` so we feed deterministic LoadResults into
+ * the Section and assert what the user actually sees:
+ *   - loading spinner before the fetch resolves
+ *   - MOCK DATA badge when the loader returned source='mock'
+ *   - no badge when source='live'
+ *   - empty state on live + empty
+ *   - rows render with title, proposer, owner, block heights
+ *   - row links to /witness-assistant/contract-update/[contractId]
+ *
+ * The Section consumes the same shape PR #210 will produce, joined with
+ * client-side metadata. Loader tests pin the wire shape; this test pins
+ * the rendering contract.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/svelte';
+
+// Mock the loader BEFORE the component imports it, so the $effect picks
+// up the stub rather than the real fetch-based implementation.
+const loadPendingUpdatesMock = vi.fn();
+vi.mock('./loader', () => ({
+	loadPendingUpdates: () => loadPendingUpdatesMock(),
+	loadUpdateById: vi.fn()
+}));
+
+// Import after the mock is in place.
+const { default: ContractUpdatesSection } = await import('./ContractUpdatesSection.svelte');
+
+// Build a fixture matching PR #210's wire shape + the client enrichment.
+function knownUpdateView(overrides: Partial<{ id: string; activation_ts: string }> = {}) {
+	return {
+		id: 'vsc1BoaniA5HW56GuQy6pVdoZfMcVaaDfnC8kp', // HIVE/HBD pool in CONTRACT_REGISTRY
+		code: 'bafkreiHiveHbdNewCidLive',
+		proposer: 'vaultec',
+		owner: 'hive:vsc.dao',
+		creation_height: 107_500_000,
+		activation_height: 107_672_800,
+		activation_ts: '2030-01-01T00:00:00', // far future — countdown stays positive
+		metadata: {
+			name: 'Pool: HIVE / HBD',
+			category: 'pool' as const,
+			description: 'Liquidity pool for HIVE ↔ HBD swaps.'
+		},
+		...overrides
+	};
+}
+
+beforeEach(() => {
+	loadPendingUpdatesMock.mockReset();
+});
+
+describe('ContractUpdatesSection — render contract', () => {
+	it('shows the loading spinner before the fetch resolves', () => {
+		// Loader hangs forever — we should see the loading state.
+		loadPendingUpdatesMock.mockReturnValue(new Promise(() => {}));
+		render(ContractUpdatesSection);
+		expect(screen.getByText(/loading pending updates/i)).toBeInTheDocument();
+	});
+
+	it('renders the MOCK DATA badge when loader returns source=mock', async () => {
+		loadPendingUpdatesMock.mockResolvedValue({
+			source: 'mock',
+			reason: 'Cannot query field "findPendingContractUpdates"',
+			updates: [knownUpdateView()]
+		});
+		render(ContractUpdatesSection);
+		await waitFor(() => {
+			expect(screen.getByText(/mock data/i)).toBeInTheDocument();
+		});
+	});
+
+	it('hides the MOCK DATA badge when loader returns source=live', async () => {
+		loadPendingUpdatesMock.mockResolvedValue({
+			source: 'live',
+			updates: [knownUpdateView()]
+		});
+		render(ContractUpdatesSection);
+		// Wait for content to settle before asserting absence.
+		await waitFor(() => {
+			expect(screen.getByText(/Pool: HIVE \/ HBD/i)).toBeInTheDocument();
+		});
+		expect(screen.queryByText(/mock data/i)).not.toBeInTheDocument();
+	});
+
+	it('shows the empty state when live + no pending updates', async () => {
+		loadPendingUpdatesMock.mockResolvedValue({
+			source: 'live',
+			updates: []
+		});
+		render(ContractUpdatesSection);
+		await waitFor(() => {
+			expect(screen.getByText(/no pending contract updates/i)).toBeInTheDocument();
+		});
+		expect(screen.queryByText(/mock data/i)).not.toBeInTheDocument();
+	});
+
+	it('renders a row with title, proposer, owner, and block height for a known contract', async () => {
+		loadPendingUpdatesMock.mockResolvedValue({
+			source: 'live',
+			updates: [knownUpdateView()]
+		});
+		render(ContractUpdatesSection);
+		await waitFor(() => {
+			// Title uses registry name: "Upgrade · Pool: HIVE / HBD"
+			expect(screen.getByText(/Upgrade · Pool: HIVE \/ HBD/i)).toBeInTheDocument();
+		});
+		// Proposer name visible in row meta.
+		expect(screen.getByText(/vaultec/)).toBeInTheDocument();
+		// Owner rendered in monospace inline.
+		expect(screen.getByText(/hive:vsc.dao/)).toBeInTheDocument();
+		// Creation block height with thousands separators.
+		expect(screen.getByText(/107,500,000/)).toBeInTheDocument();
+	});
+
+	it('falls back to a truncated id when the contract is not in the registry', async () => {
+		const unknown = knownUpdateView({
+			id: 'vsc1UnknownContractXyz'
+		});
+		unknown.metadata = undefined as never; // unknown contract: no enrichment
+		loadPendingUpdatesMock.mockResolvedValue({
+			source: 'live',
+			updates: [unknown]
+		});
+		render(ContractUpdatesSection);
+		await waitFor(() => {
+			// Section's titleFor() helper synthesizes a short-id label when
+			// metadata is absent.
+			expect(screen.getByText(/Upgrade · contract vsc1Unk/i)).toBeInTheDocument();
+		});
+	});
+
+	it('links each row to /witness-assistant/contract-update/[contractId]', async () => {
+		loadPendingUpdatesMock.mockResolvedValue({
+			source: 'live',
+			updates: [knownUpdateView()]
+		});
+		render(ContractUpdatesSection);
+		const link = await waitFor(() => {
+			const el = screen.getByRole('link', { name: /Upgrade · Pool: HIVE \/ HBD/i });
+			expect(el).toBeInTheDocument();
+			return el;
+		});
+		expect(link).toHaveAttribute(
+			'href',
+			'/witness-assistant/contract-update/vsc1BoaniA5HW56GuQy6pVdoZfMcVaaDfnC8kp'
+		);
+	});
+});

--- a/src/lib/witness/contractUpdates/ContractUpdatesSection.svelte.test.ts
+++ b/src/lib/witness/contractUpdates/ContractUpdatesSection.svelte.test.ts
@@ -96,6 +96,23 @@ describe('ContractUpdatesSection — render contract', () => {
 		expect(screen.queryByText(/mock data/i)).not.toBeInTheDocument();
 	});
 
+	it('shows the dormant "awaiting backend" state when the node lacks the field', async () => {
+		loadPendingUpdatesMock.mockResolvedValue({
+			source: 'unavailable',
+			updates: [],
+			reason: 'Cannot query field "findPendingContractUpdates" on type "Query".'
+		});
+		render(ContractUpdatesSection);
+		await waitFor(() => {
+			expect(screen.getByText(/awaiting backend/i)).toBeInTheDocument();
+		});
+		// Dormant note explains auto-activation; NOT the plain empty state,
+		// NOT the mock badge.
+		expect(screen.getByText(/turn on automatically/i)).toBeInTheDocument();
+		expect(screen.queryByText(/^no pending contract updates\.$/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/mock data/i)).not.toBeInTheDocument();
+	});
+
 	it('renders a row with title, proposer, owner, and block height for a known contract', async () => {
 		loadPendingUpdatesMock.mockResolvedValue({
 			source: 'live',

--- a/src/lib/witness/contractUpdates/Countdown.svelte
+++ b/src/lib/witness/contractUpdates/Countdown.svelte
@@ -1,0 +1,67 @@
+<!--
+	Live countdown to a future Unix-seconds timestamp.
+
+	Updates once per second while mounted. Cleanly disposes the interval
+	via $effect's return value. Renders nothing when the target is in
+	the past (parent decides what to show in that case — see
+	ContractUpdatesSection's status badge).
+-->
+<script lang="ts">
+	let { targetUnixSec, compact = false }: { targetUnixSec: number; compact?: boolean } = $props();
+
+	let now = $state(Math.floor(Date.now() / 1000));
+
+	$effect(() => {
+		const handle = setInterval(() => {
+			now = Math.floor(Date.now() / 1000);
+		}, 1000);
+		return () => clearInterval(handle);
+	});
+
+	const secondsRemaining = $derived(Math.max(0, targetUnixSec - now));
+	const expired = $derived(secondsRemaining === 0);
+
+	const days = $derived(Math.floor(secondsRemaining / 86400));
+	const hours = $derived(Math.floor((secondsRemaining % 86400) / 3600));
+	const mins = $derived(Math.floor((secondsRemaining % 3600) / 60));
+	const secs = $derived(secondsRemaining % 60);
+</script>
+
+{#if expired}
+	<span class="countdown expired">unlocked</span>
+{:else if compact}
+	<span class="countdown">
+		{#if days > 0}{days}d
+		{/if}{hours}h {mins}m
+	</span>
+{:else}
+	<span class="countdown">
+		{#if days > 0}<span class="seg">{days}<small>d</small></span>{/if}
+		<span class="seg">{hours.toString().padStart(2, '0')}<small>h</small></span>
+		<span class="seg">{mins.toString().padStart(2, '0')}<small>m</small></span>
+		<span class="seg">{secs.toString().padStart(2, '0')}<small>s</small></span>
+	</span>
+{/if}
+
+<style lang="scss">
+	.countdown {
+		font-variant-numeric: tabular-nums;
+		font-weight: 600;
+		color: var(--dash-text-primary);
+		display: inline-flex;
+		gap: 0.25rem;
+		align-items: baseline;
+	}
+	.countdown.expired {
+		color: #8be08b;
+		text-transform: uppercase;
+		font-size: 0.78rem;
+		letter-spacing: 0.06em;
+	}
+	.seg small {
+		font-size: 0.7em;
+		font-weight: 500;
+		color: var(--dash-text-secondary);
+		margin-left: 0.05rem;
+	}
+</style>

--- a/src/lib/witness/contractUpdates/auditLinks.ts
+++ b/src/lib/witness/contractUpdates/auditLinks.ts
@@ -1,0 +1,60 @@
+/**
+ * Audit-link URL builders for contract updates.
+ *
+ * The witness page surfaces "view raw" links per update so anyone can
+ * independently verify what's about to ship:
+ *   - new code (WASM) on an IPFS gateway
+ *   - previous code (WASM) on an IPFS gateway (when known)
+ *   - diff helper for the two CIDs
+ *   - the proposer account on hivehub
+ *   - the contract id on the VSC explorer
+ *
+ * The IPFS gateway is hardcoded — swap for a self-hosted gateway if
+ * reliability becomes an issue.
+ */
+
+const IPFS_GATEWAY = 'https://ipfs.io/ipfs';
+
+/**
+ * Same semantics as client.ts's isVscTestnet, but self-contained: client.ts
+ * runs localStorage reads at module scope, which crashes the jsdom Vitest
+ * client project (Storage global without callable getItem). Reading the key
+ * lazily through optional chaining keeps this module import-safe anywhere.
+ */
+function isTestnet(): boolean {
+	try {
+		return globalThis.localStorage?.getItem?.('vsc-network-id') === 'vsc-testnet';
+	} catch {
+		return false;
+	}
+}
+
+/** Link to the proposer's Hive account profile. */
+export function proposerTxUrl(account: string): string {
+	// Strip "hive:" prefix if the proposer field includes it.
+	const name = account.startsWith('hive:') ? account.slice(5) : account;
+	return `https://hivehub.dev/@${encodeURIComponent(name)}`;
+}
+
+/** Contract page on the VSC explorer (testnet-aware base, same switch as
+ *  getVscExplorerTxUrl). */
+export function contractExplorerUrl(contractId: string): string {
+	const base = isTestnet() ? 'https://magi-test.techcoderx.com' : 'https://vsc.techcoderx.com';
+	return `${base}/contract/${contractId}`;
+}
+
+export function codeIpfsUrl(cid: string): string {
+	return `${IPFS_GATEWAY}/${cid}`;
+}
+
+/**
+ * Diff helper for two CIDs. There's no public WASM-diff tool integrated,
+ * so today this just returns a search URL the witness can hand off. Wire
+ * this to a real tool when one ships (e.g. a hosted wasm-decompiler
+ * comparison, or a github source-vs-source link).
+ */
+export function codeDiffSearchUrl(previousCid: string, newCid: string): string {
+	return `https://www.google.com/search?q=${encodeURIComponent(
+		`ipfs diff ${previousCid} ${newCid}`
+	)}`;
+}

--- a/src/lib/witness/contractUpdates/contractUpdateDetail.svelte.test.ts
+++ b/src/lib/witness/contractUpdates/contractUpdateDetail.svelte.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tier-B component test for the contract-update detail page.
+ *
+ * Lives next to the witness lib (not under src/routes) because vitest
+ * doesn't traverse SvelteKit route directories the same way the runtime
+ * does. We import the page component directly via its file path.
+ *
+ * Mocks:
+ *   - `$lib/witness/contractUpdates/loader.loadUpdateById` — feeds
+ *     deterministic LoadResult.update into the page's $effect
+ *   - `$app/state.page` — supplies `page.params.id` to drive routing
+ *     without spinning a real router
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/svelte';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────
+
+// `loadUpdateById` is what the page calls inside its $effect.
+const loadUpdateByIdMock = vi.fn();
+vi.mock('$lib/witness/contractUpdates/loader', () => ({
+	loadPendingUpdates: vi.fn(),
+	loadUpdateById: (id: string) => loadUpdateByIdMock(id)
+}));
+
+// `page.params.id` drives which update gets requested. Make it a getter
+// so tests can change `currentId` between renders.
+let currentId = '';
+vi.mock('$app/state', () => ({
+	page: {
+		get params() {
+			return { id: currentId };
+		},
+		url: { pathname: '' },
+		route: { id: null },
+		status: 200,
+		error: null,
+		data: {},
+		state: {},
+		form: undefined
+	}
+}));
+
+// Import the page component AFTER mocks are registered.
+const { default: ContractUpdateDetailPage } =
+	await import('../../../routes/(authed)/witness-assistant/contract-update/[id]/+page.svelte');
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────
+
+function knownUpdateView(
+	overrides: Partial<{
+		id: string;
+		code: string;
+		proposer: string;
+		owner: string;
+		activation_ts: string;
+		previousCode: string;
+		metadata: {
+			name: string;
+			category: 'pool' | 'bridge' | 'gateway' | 'oracle' | 'governance' | 'other';
+			description?: string;
+		};
+	}> = {}
+) {
+	return {
+		id: 'vsc1BoaniA5HW56GuQy6pVdoZfMcVaaDfnC8kp',
+		code: 'bafkreiNEWcodecid12345HiveHbdPoolUpgrade',
+		proposer: 'vaultec',
+		owner: 'hive:vsc.dao',
+		creation_height: 107_500_000,
+		activation_height: 107_672_800,
+		activation_ts: '2030-01-01T00:00:00',
+		metadata: {
+			name: 'Pool: HIVE / HBD',
+			category: 'pool' as const,
+			description: 'Liquidity pool for HIVE ↔ HBD swaps.'
+		},
+		previousCode: 'bafkreiOLDcodecidPreviousHiveHbdPool99',
+		...overrides
+	};
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+	loadUpdateByIdMock.mockReset();
+	currentId = '';
+});
+
+describe('Contract update detail page — render contract', () => {
+	it('shows the loading spinner before the fetch resolves', () => {
+		currentId = 'vsc1Anything';
+		loadUpdateByIdMock.mockReturnValue(new Promise(() => {})); // hang forever
+		render(ContractUpdateDetailPage);
+		expect(screen.getByText(/loading update details/i)).toBeInTheDocument();
+	});
+
+	it('shows the not-found state when the loader returns undefined', async () => {
+		currentId = 'vsc1NonExistentId';
+		loadUpdateByIdMock.mockResolvedValue(undefined);
+		render(ContractUpdateDetailPage);
+		await waitFor(() => {
+			expect(screen.getByText(/no pending update/i)).toBeInTheDocument();
+		});
+		// The unknown id surfaces in the body so the user can confirm what they navigated to.
+		expect(screen.getByText('vsc1NonExistentId')).toBeInTheDocument();
+	});
+
+	it('renders the full update card when a known update is found', async () => {
+		const update = knownUpdateView();
+		currentId = update.id;
+		loadUpdateByIdMock.mockResolvedValue(update);
+		render(ContractUpdateDetailPage);
+
+		await waitFor(() => {
+			// Title uses metadata.name; "Upgrade · Pool: HIVE / HBD"
+			expect(screen.getByText(/Upgrade · Pool: HIVE \/ HBD/i)).toBeInTheDocument();
+		});
+
+		// Description from registry shows up as the lead line.
+		expect(screen.getByText(/Liquidity pool for HIVE/i)).toBeInTheDocument();
+
+		// Meta fields rendered in the dl: proposer, owner, contract id.
+		expect(screen.getByText('vaultec')).toBeInTheDocument();
+		expect(screen.getByText('hive:vsc.dao')).toBeInTheDocument();
+		expect(screen.getByText(update.id)).toBeInTheDocument();
+
+		// Block heights formatted with thousands separators.
+		// Creation height appears exactly once (in the meta dl).
+		expect(screen.getByText(/block #107,500,000/i)).toBeInTheDocument();
+		// Activation height shows up twice: once in the meta dl ("Activates at")
+		// and once in the countdown-box as the under-label. Both are intended;
+		// assert the count rather than uniqueness.
+		expect(screen.getAllByText(/block #107,672,800/i)).toHaveLength(2);
+	});
+
+	it('links proposer to hivehub', async () => {
+		const update = knownUpdateView();
+		currentId = update.id;
+		loadUpdateByIdMock.mockResolvedValue(update);
+		render(ContractUpdateDetailPage);
+
+		const link = await waitFor(() => screen.getByRole('link', { name: /view on hivehub/i }));
+		expect(link).toHaveAttribute('href', 'https://hivehub.dev/@vaultec');
+	});
+
+	it('renders IPFS links for new code (and previous code when present)', async () => {
+		const update = knownUpdateView();
+		currentId = update.id;
+		loadUpdateByIdMock.mockResolvedValue(update);
+		render(ContractUpdateDetailPage);
+
+		await waitFor(() => {
+			// New-code section: short label + full CID rendered for verification.
+			expect(screen.getByText(update.code)).toBeInTheDocument();
+		});
+		expect(screen.getByText(update.previousCode!)).toBeInTheDocument();
+
+		// Both IPFS links present.
+		const ipfsLinks = screen
+			.getAllByRole('link')
+			.filter((el) => el.getAttribute('href')?.startsWith('https://ipfs.io/ipfs/'));
+		expect(ipfsLinks).toHaveLength(2);
+		expect(ipfsLinks[0]).toHaveAttribute('href', `https://ipfs.io/ipfs/${update.code}`);
+		expect(ipfsLinks[1]).toHaveAttribute('href', `https://ipfs.io/ipfs/${update.previousCode}`);
+	});
+
+	it('renders the diff link when both previous and new code CIDs are known', async () => {
+		const update = knownUpdateView();
+		currentId = update.id;
+		loadUpdateByIdMock.mockResolvedValue(update);
+		render(ContractUpdateDetailPage);
+
+		const diffLink = await waitFor(() => screen.getByRole('link', { name: /compare cids/i }));
+		// codeDiffSearchUrl encodes the two CIDs into a google search query
+		// (placeholder until a real WASM diff tool exists).
+		expect(diffLink.getAttribute('href')).toMatch(/^https:\/\/www\.google\.com\/search/);
+		expect(diffLink.getAttribute('href')).toContain(encodeURIComponent(update.code));
+		expect(diffLink.getAttribute('href')).toContain(encodeURIComponent(update.previousCode!));
+	});
+
+	it('shows the "previous code not yet joined" hint when previousCode is absent', async () => {
+		const update = knownUpdateView({ previousCode: undefined as never });
+		// Drop the previousCode in a way the type cooperates with:
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		delete (update as any).previousCode;
+		currentId = update.id;
+		loadUpdateByIdMock.mockResolvedValue(update);
+		render(ContractUpdateDetailPage);
+
+		await waitFor(() => {
+			expect(screen.getByText(/Upgrade · Pool: HIVE \/ HBD/i)).toBeInTheDocument();
+		});
+
+		// New-code link still rendered.
+		expect(screen.getByText(update.code)).toBeInTheDocument();
+		// Hint about findContract(byId) join — explains why diff is unavailable.
+		expect(screen.getByText(/findContract\(byId\)/i)).toBeInTheDocument();
+		// And no diff link.
+		expect(screen.queryByRole('link', { name: /compare cids/i })).not.toBeInTheDocument();
+	});
+
+	it('falls back to a truncated id heading when the contract is not in the registry', async () => {
+		const update = knownUpdateView({ id: 'vsc1Unknown1234567890Whatever' });
+		update.metadata = undefined as never;
+		currentId = update.id;
+		loadUpdateByIdMock.mockResolvedValue(update);
+		render(ContractUpdateDetailPage);
+
+		await waitFor(() => {
+			// Heading synthesizes from a short id prefix when metadata is missing.
+			// The h2 splits "Upgrade · " (static) from `contract <id-prefix>…`
+			// (interpolated) across text nodes, so we match the whole heading
+			// via textContent instead of getByText.
+			const h2 = document.querySelector('h2');
+			// id.slice(0, 12) of "vsc1Unknown1234567890Whatever" = "vsc1Unknown1"
+			expect(h2?.textContent).toMatch(/Upgrade · contract vsc1Unknown1…/);
+		});
+		// Fallback "no registry entry" lead line.
+		expect(screen.getByText(/No registry entry/i)).toBeInTheDocument();
+	});
+});

--- a/src/lib/witness/contractUpdates/loader.test.ts
+++ b/src/lib/witness/contractUpdates/loader.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Loader tests — pin the wire-shape contract against PR #210.
+ *
+ * Each fixture in this file is hand-built from the schema definitions
+ * in `go-vsc-node` PR #210
+ * (https://github.com/vsc-eco/go-vsc-node/pull/210):
+ *
+ *   findPendingContractUpdates(filterOptions: FindContractFilter): [Contract]
+ *
+ *   type Contract adds:
+ *     activation_height: Uint64!
+ *     activation_ts: String        # ISO 8601, same format as creation_ts
+ *     proposer: String
+ *
+ * If the live backend ever returns a different shape, one of these
+ * tests fails loudly — and the diff tells us exactly where to update
+ * `loader.ts` / `types.ts`. That's the whole point: we don't want the
+ * "frontend silently rendering wrong data" failure mode that prompted
+ * the 0.3.15 stabilizer incident.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { loadPendingUpdates, loadUpdateById } from './loader';
+import { CONTRACT_REGISTRY } from './mockData';
+import { tsToUnixSec } from './types';
+
+// ─── Fixtures (PR #210 wire shape) ────────────────────────────────────────
+
+/**
+ * A single pending update for a contract we know about (HIVE/HBD pool).
+ * Should enrich with the registry metadata.
+ */
+const FIXTURE_KNOWN: unknown = {
+	id: 'vsc1BoaniA5HW56GuQy6pVdoZfMcVaaDfnC8kp', // matches CONTRACT_REGISTRY
+	code: 'bafkreibrlaku3dmnexnxz4lbplkotf52mwnwie3tro73jn7wxhwkagi_LIVE_NEWCID',
+	proposer: 'vaultec',
+	owner: 'hive:vsc.dao',
+	creation_height: 107_500_000,
+	activation_height: 107_672_800,
+	activation_ts: '2026-06-08T12:34:56' // matches Contract.creation_ts format on prod
+};
+
+/**
+ * A pending update for an UNKNOWN contract (not in CONTRACT_REGISTRY).
+ * Should still appear in the list, just without `metadata`.
+ */
+const FIXTURE_UNKNOWN: unknown = {
+	id: 'vsc1UnknownContractIdNotInRegistry',
+	code: 'bafkreiUnknownNewCidForUnregisteredContract',
+	proposer: 'someuser',
+	owner: 'hive:someuser',
+	creation_height: 107_510_000,
+	activation_height: 107_682_800,
+	activation_ts: '2026-06-08T13:14:15'
+};
+
+// ─── fetch stub helpers ───────────────────────────────────────────────────
+
+function stubFetchOk(body: unknown) {
+	const fetchMock = vi.fn().mockResolvedValue({
+		ok: true,
+		status: 200,
+		json: () => Promise.resolve(body)
+	});
+	vi.stubGlobal('fetch', fetchMock);
+	return fetchMock;
+}
+
+function stubFetchHttp(status: number) {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn().mockResolvedValue({
+			ok: false,
+			status,
+			json: () => Promise.resolve({})
+		})
+	);
+}
+
+function stubFetchThrows(err: Error) {
+	vi.stubGlobal('fetch', vi.fn().mockRejectedValue(err));
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+// ─── loadPendingUpdates ───────────────────────────────────────────────────
+
+describe('loadPendingUpdates — live path', () => {
+	it('returns source=live with both updates and enriches known ones with metadata', async () => {
+		stubFetchOk({
+			data: {
+				findPendingContractUpdates: [FIXTURE_KNOWN, FIXTURE_UNKNOWN]
+			}
+		});
+
+		const result = await loadPendingUpdates();
+
+		expect(result.source).toBe('live');
+		expect(result.updates).toHaveLength(2);
+
+		const known = result.updates[0];
+		expect(known.id).toBe('vsc1BoaniA5HW56GuQy6pVdoZfMcVaaDfnC8kp');
+		expect(known.code).toMatch(/_LIVE_NEWCID$/);
+		expect(known.proposer).toBe('vaultec');
+		expect(known.owner).toBe('hive:vsc.dao');
+		expect(known.creation_height).toBe(107_500_000);
+		expect(known.activation_height).toBe(107_672_800);
+		expect(known.activation_ts).toBe('2026-06-08T12:34:56');
+		// Enriched with registry metadata:
+		expect(known.metadata).toEqual(CONTRACT_REGISTRY['vsc1BoaniA5HW56GuQy6pVdoZfMcVaaDfnC8kp']);
+		expect(known.metadata?.name).toBe('Pool: HIVE / HBD');
+
+		const unknown = result.updates[1];
+		expect(unknown.id).toBe('vsc1UnknownContractIdNotInRegistry');
+		// Unknown contract: no metadata, but still rendered.
+		expect(unknown.metadata).toBeUndefined();
+	});
+
+	it('returns source=live + empty array when backend has no pending updates', async () => {
+		// Field exists, nothing queued. This is the steady-state "all green" UI.
+		stubFetchOk({
+			data: {
+				findPendingContractUpdates: []
+			}
+		});
+
+		const result = await loadPendingUpdates();
+
+		expect(result.source).toBe('live');
+		expect(result.updates).toEqual([]);
+	});
+
+	it('returns source=live + empty when backend returns null for the field', async () => {
+		// Defensive: some GraphQL servers return null instead of [] for empty lists.
+		stubFetchOk({ data: { findPendingContractUpdates: null } });
+
+		const result = await loadPendingUpdates();
+
+		expect(result.source).toBe('live');
+		expect(result.updates).toEqual([]);
+	});
+});
+
+describe('loadPendingUpdates — fallback paths', () => {
+	it('falls back to mock when backend returns a GraphQL error (field not found)', async () => {
+		// Today's reality on api.vsc.eco until PR #210 deploys.
+		stubFetchOk({
+			errors: [{ message: 'Cannot query field "findPendingContractUpdates" on type "Query".' }]
+		});
+
+		const result = await loadPendingUpdates();
+
+		expect(result.source).toBe('mock');
+		if (result.source !== 'mock') return;
+		expect(result.reason).toMatch(/Cannot query field "findPendingContractUpdates"/);
+		expect(result.updates.length).toBeGreaterThan(0); // mock fixtures
+	});
+
+	it('falls back to mock on HTTP 5xx', async () => {
+		stubFetchHttp(503);
+		const result = await loadPendingUpdates();
+		expect(result.source).toBe('mock');
+		if (result.source !== 'mock') return;
+		expect(result.reason).toMatch(/HTTP 503/);
+	});
+
+	it('falls back to mock on HTTP 4xx', async () => {
+		stubFetchHttp(404);
+		const result = await loadPendingUpdates();
+		expect(result.source).toBe('mock');
+		if (result.source !== 'mock') return;
+		expect(result.reason).toMatch(/HTTP 404/);
+	});
+
+	it('falls back to mock on network error (fetch throws)', async () => {
+		stubFetchThrows(new Error('Network request failed'));
+		const result = await loadPendingUpdates();
+		expect(result.source).toBe('mock');
+		if (result.source !== 'mock') return;
+		expect(result.reason).toBe('Network request failed');
+	});
+
+	it('mock fallback still enriches known contracts with metadata', async () => {
+		// Same enrichment contract as the live path — important so the
+		// component renders consistently regardless of source.
+		stubFetchThrows(new Error('boom'));
+		const result = await loadPendingUpdates();
+		expect(result.source).toBe('mock');
+		const known = result.updates.find((u) => CONTRACT_REGISTRY[u.id] !== undefined);
+		expect(known).toBeDefined();
+		expect(known!.metadata).toBeDefined();
+	});
+});
+
+// ─── loadUpdateById ───────────────────────────────────────────────────────
+
+describe('loadUpdateById', () => {
+	it('returns the matching update from a live response', async () => {
+		stubFetchOk({
+			data: {
+				findPendingContractUpdates: [FIXTURE_KNOWN, FIXTURE_UNKNOWN]
+			}
+		});
+		const found = await loadUpdateById('vsc1UnknownContractIdNotInRegistry');
+		expect(found?.id).toBe('vsc1UnknownContractIdNotInRegistry');
+		expect(found?.proposer).toBe('someuser');
+	});
+
+	it('returns undefined when the id is not in the result set', async () => {
+		stubFetchOk({
+			data: {
+				findPendingContractUpdates: [FIXTURE_KNOWN]
+			}
+		});
+		const found = await loadUpdateById('vsc1NotInList');
+		expect(found).toBeUndefined();
+	});
+
+	it('finds a mock entry when backend is down', async () => {
+		stubFetchThrows(new Error('offline'));
+		// HIVE/HBD pool mock id from mockData.ts MOCK_PENDING_UPDATES[0].
+		const found = await loadUpdateById('vsc1BoaniA5HW56GuQy6pVdoZfMcVaaDfnC8kp');
+		expect(found).toBeDefined();
+		expect(found?.metadata?.name).toBe('Pool: HIVE / HBD');
+	});
+});
+
+// ─── ISO timestamp parsing (used by the Countdown component) ──────────────
+
+describe('tsToUnixSec — activation_ts parsing', () => {
+	it('parses bare timestamps as UTC — exact value (live-verified format)', () => {
+		// Live wire sample from the 2026-06-12 testnet contract-update test:
+		// activation_ts arrives WITHOUT a timezone designator but IS UTC.
+		// Naive Date.parse treats it as local time, which shifted the
+		// activation by the user's UTC offset and made the countdown show
+		// "unlocked" for a pending update. Pin the exact UTC epoch so a
+		// regression can't sneak back regardless of the test runner's TZ.
+		expect(tsToUnixSec('2026-06-12T14:08:45')).toBe(Date.parse('2026-06-12T14:08:45Z') / 1000);
+	});
+
+	it('parses ISO with Z suffix as well (defensive)', () => {
+		const sec = tsToUnixSec('2026-06-08T12:34:56Z');
+		expect(Number.isFinite(sec)).toBe(true);
+		expect(sec).toBeGreaterThan(0);
+	});
+});

--- a/src/lib/witness/contractUpdates/loader.ts
+++ b/src/lib/witness/contractUpdates/loader.ts
@@ -1,0 +1,195 @@
+/**
+ * Pending contract updates loader.
+ *
+ * Hits the VSC GraphQL endpoint directly (plain fetch — not Houdini)
+ * for the `findPendingContractUpdates` field landing in go-vsc-node
+ * PR #210. Houdini codegen would fail today because the schema on
+ * api.vsc.eco doesn't have this field yet; using fetch bypasses
+ * codegen entirely.
+ *
+ * Behavior:
+ *   - happy path: returns { source: 'live', updates }
+ *   - field missing / network error / empty result: falls back to mock
+ *     and returns { source: 'mock', reason }
+ *
+ * The day PR #210 ships, the same code starts returning `source: 'live'`
+ * automatically — no swap, no deploy needed beyond it being on prod.
+ *
+ * If we want to migrate to a real Houdini store later (for caching,
+ * pagination, subscriptions), the fetch can be replaced one-for-one.
+ */
+import { CONTRACT_REGISTRY, MOCK_PENDING_UPDATES } from './mockData';
+import type { ContractUpdateView, PendingContractUpdate } from './types';
+import { GQL_PROXY_VSC, currentGqlUrl, gqlUpstreamHeaders } from '../../../client';
+
+// Follow the app's configured VSC node (localStorage `vsc-gql-url` /
+// network toggle) — but through the same-origin /api/gql proxy the rest
+// of the app uses, with the chosen node passed via x-gql-upstream.
+// Direct browser fetches to the nodes can be blocked by their CORS
+// policy; the proxy sidesteps that for prod, testnet and dev alike.
+
+/**
+ * No-filter query. PR #210's `filterOptions` accepts `byId`, but the
+ * witness page wants every pending update; we let the registry decide
+ * which ones get the friendly label.
+ */
+const QUERY = `
+  query FindPendingContractUpdates {
+    findPendingContractUpdates(filterOptions: {}) {
+      id
+      code
+      proposer
+      owner
+      creation_height
+      activation_height
+      activation_ts
+    }
+  }
+`;
+
+/**
+ * Diagnostic logging for the live-verification phase (testnet window
+ * catching). Logs the upstream node, raw wire payloads and the
+ * mock-fallback reason so a failed live test is debuggable from the
+ * browser console alone. Downgrade to console.debug (or strip) once
+ * the live path is verified on prod.
+ */
+const LOG_TAG = '[contract-updates]';
+
+export type LoadResult =
+	| { source: 'live'; updates: ContractUpdateView[] }
+	/** Dev-only: mock fixtures (error fallback, or forced via ?mock=1). */
+	| { source: 'mock'; updates: ContractUpdateView[]; reason: string }
+	/** Prod: backend doesn't serve the field (or transport failed) — the UI
+	 *  shows the plain empty state, never fake data. */
+	| { source: 'unavailable'; updates: ContractUpdateView[]; reason: string };
+
+/** Dev-only escape hatch to SEE entries without a live pending update:
+ *  open /witness-assistant?mock=1 (or set localStorage
+ *  'contract-updates-mock' = '1'). Ignored in production builds. */
+function mockForced(): boolean {
+	if (!import.meta.env.DEV) return false;
+	try {
+		if (typeof location !== 'undefined' && new URLSearchParams(location.search).has('mock'))
+			return true;
+		return globalThis.localStorage?.getItem?.('contract-updates-mock') === '1';
+	} catch {
+		return false;
+	}
+}
+
+/** Join a raw on-chain update with our curated client-side metadata. */
+function enrich(u: PendingContractUpdate): ContractUpdateView {
+	return { ...u, metadata: CONTRACT_REGISTRY[u.id] };
+}
+
+/**
+ * Resolve on-chain names for contracts that aren't in the curated
+ * registry, via findContract(byId). Best-effort: a failed lookup just
+ * leaves chainName undefined and the UI falls back to the short id.
+ * Pending updates are one-per-contract and rare, so per-id queries are
+ * fine (no batch filter exists on FindContractFilter).
+ */
+async function resolveChainNames(updates: ContractUpdateView[]): Promise<void> {
+	const unnamed = updates.filter((u) => !u.metadata);
+	await Promise.all(
+		unnamed.map(async (u) => {
+			try {
+				const res = await fetch(GQL_PROXY_VSC, {
+					method: 'POST',
+					headers: gqlUpstreamHeaders(currentGqlUrl),
+					body: JSON.stringify({
+						query: `query { findContract(filterOptions: {byId: ${JSON.stringify(u.id)}}) { id name } }`
+					})
+				});
+				const json = (await res.json().catch(() => null)) as null | {
+					data?: { findContract?: { id: string; name?: string | null }[] | null };
+				};
+				const name = json?.data?.findContract?.[0]?.name;
+				if (name) {
+					u.chainName = name;
+					console.debug(`${LOG_TAG} resolved on-chain name for ${u.id}: ${name}`);
+				}
+			} catch {
+				/* best-effort */
+			}
+		})
+	);
+}
+
+function mockFallback(reason: string): LoadResult {
+	// Mock fixtures are a development aid — production users must never see
+	// fake contract updates. On prod a failed/unsupported fetch renders the
+	// plain empty state instead.
+	if (import.meta.env.DEV) {
+		return { source: 'mock', updates: MOCK_PENDING_UPDATES.map(enrich), reason };
+	}
+	return { source: 'unavailable', updates: [], reason };
+}
+
+/**
+ * Fetch pending updates. Never throws — failure surfaces as
+ * `source: 'mock'` with a diagnostic `reason` string the UI can show
+ * in a tooltip.
+ */
+export async function loadPendingUpdates(): Promise<LoadResult> {
+	if (mockForced()) {
+		return {
+			source: 'mock',
+			updates: MOCK_PENDING_UPDATES.map(enrich),
+			reason: 'forced via ?mock=1'
+		};
+	}
+	try {
+		console.debug(`${LOG_TAG} fetching via ${GQL_PROXY_VSC} → upstream ${currentGqlUrl}`);
+		const res = await fetch(GQL_PROXY_VSC, {
+			method: 'POST',
+			headers: gqlUpstreamHeaders(currentGqlUrl),
+			body: JSON.stringify({ query: QUERY })
+		});
+		// Don't bail on a non-2xx status alone: this upstream returns GraphQL
+		// validation failures as HTTP 422 with the errors in the JSON body —
+		// read the body first so the mock-fallback reason carries the actual
+		// GraphQL message ("Cannot query field …") instead of a bare status.
+		const json = (await res.json().catch(() => null)) as null | {
+			data?: { findPendingContractUpdates?: PendingContractUpdate[] | null };
+			errors?: { message: string }[];
+		};
+		if (json === null) {
+			console.warn(`${LOG_TAG} HTTP ${res.status} with non-JSON body — falling back to mock`);
+			return mockFallback(`HTTP ${res.status} from VSC GraphQL`);
+		}
+		if (!res.ok && !json.errors?.length) {
+			// Non-2xx without a GraphQL error payload (gateway 5xx, proxy 4xx):
+			// genuine transport failure, not a schema rejection.
+			console.warn(`${LOG_TAG} HTTP ${res.status} from proxy/upstream — falling back to mock`);
+			return mockFallback(`HTTP ${res.status} from VSC GraphQL`);
+		}
+		if (json.errors?.length) {
+			console.warn(`${LOG_TAG} GraphQL error — falling back to mock:`, json.errors[0].message);
+			return mockFallback(json.errors[0].message);
+		}
+		const raw = json.data?.findPendingContractUpdates;
+		if (!raw || raw.length === 0) {
+			// No errors but empty payload: could be "field exists, nothing pending"
+			// once PR #210 ships, OR could be a permissive schema returning [] for
+			// an unknown query. Either way we return live + empty so the UI shows
+			// the proper empty state (instead of confusing mock data).
+			console.debug(`${LOG_TAG} live response, no pending updates`);
+			return { source: 'live', updates: [] };
+		}
+		console.debug(`${LOG_TAG} live response, ${raw.length} pending update(s):`, raw);
+		const updates = raw.map(enrich);
+		await resolveChainNames(updates);
+		return { source: 'live', updates };
+	} catch (e) {
+		console.warn(`${LOG_TAG} fetch threw — falling back to mock:`, e);
+		return mockFallback(e instanceof Error ? e.message : String(e));
+	}
+}
+
+/** Look up a single update by contract id. Same fallback behavior. */
+export async function loadUpdateById(id: string): Promise<ContractUpdateView | undefined> {
+	const result = await loadPendingUpdates();
+	return result.updates.find((u) => u.id === id);
+}

--- a/src/lib/witness/contractUpdates/mockData.ts
+++ b/src/lib/witness/contractUpdates/mockData.ts
@@ -1,0 +1,103 @@
+/**
+ * ⚠️ MOCK DATA — see `types.ts` for the spec. Live data lands when
+ * go-vsc-node PR #210 ships `findPendingContractUpdates`.
+ *
+ * Replacement path (once PR #210 is on api.vsc.eco):
+ *   - Replace `MOCK_PENDING_UPDATES` with the result of
+ *     `FindPendingContractUpdatesStore` (already staged at
+ *     `FindPendingContractUpdates.gql`).
+ *   - Keep `CONTRACT_REGISTRY` — chain has no name/category, so a
+ *     curated client-side registry stays. Move it to its own file
+ *     (or a tiny JSON the witness team can PR against) when it grows.
+ *
+ * Contract ids in this fixture mirror real ones returned by
+ * `findContract` on production today so they look familiar in review.
+ */
+import type { ContractMetadata, ContractUpdateView, PendingContractUpdate } from './types';
+
+const NOW_MS = Date.now();
+const HOUR_MS = 60 * 60 * 1000;
+
+function isoFromNow(deltaMs: number): string {
+	// Match Contract.creation_ts / activation_ts format observed on prod:
+	// "2026-06-02T23:23:33" (no Z suffix). toISOString gives Z; we strip
+	// it to mirror exactly.
+	return new Date(NOW_MS + deltaMs).toISOString().replace(/\.\d{3}Z$/, '');
+}
+
+/**
+ * Curated metadata for contracts the witness page recognizes. Keys are
+ * contract ids. Anything not in the registry falls back to a short id
+ * preview and the `other` category.
+ */
+export const CONTRACT_REGISTRY: Record<string, ContractMetadata> = {
+	vsc1BoaniA5HW56GuQy6pVdoZfMcVaaDfnC8kp: {
+		name: 'Pool: HIVE / HBD',
+		category: 'pool',
+		description: 'Liquidity pool for HIVE ↔ HBD swaps.'
+	},
+	vsc1BVb95YKRHAEy24XgRSaW4L6d9vB88AdwjM: {
+		name: 'Pool: BTC / HBD',
+		category: 'pool',
+		description: 'Liquidity pool for BTC ↔ HBD swaps.'
+	},
+	vsc1Brvi4YZHLkocYNAFd7Gf1JpsPjzNnv4i45: {
+		name: 'DEX router',
+		category: 'gateway',
+		description: 'Routes swap requests across registered pools.'
+	},
+	vsc1BdrQ6EtbQ64rq2PkPd21x4MaLnVRcJj85d: {
+		name: 'Bridge: BTC mapping',
+		category: 'bridge',
+		description: 'Maps BTC deposits into the Magi UTXO contract.'
+	}
+};
+
+/** Mock pending updates — matches the real `PendingContractUpdate` shape. */
+export const MOCK_PENDING_UPDATES: PendingContractUpdate[] = [
+	{
+		id: 'vsc1BoaniA5HW56GuQy6pVdoZfMcVaaDfnC8kp',
+		code: 'bafkreibrlaku3dmnexnxz4lbplkotf52mwnwie3tro73jn7wxhwkagi_NEWCID',
+		proposer: 'vaultec',
+		owner: 'hive:vsc.dao',
+		creation_height: 107_000_000,
+		activation_height: 107_172_800, // ~48h of Hive blocks (3s × 57.6k = 172.8k)
+		activation_ts: isoFromNow(46 * HOUR_MS)
+	},
+	{
+		id: 'vsc1BdrQ6EtbQ64rq2PkPd21x4MaLnVRcJj85d',
+		code: 'bafkreidr2ylwc7r4jilauhmrjrzgpoahfk76pxdgivqxiwvk5tduwes_NEWCID',
+		proposer: 'theycallmedan',
+		owner: 'hive:vsc.dao',
+		creation_height: 107_010_000,
+		activation_height: 107_182_800,
+		activation_ts: isoFromNow(12 * HOUR_MS)
+	}
+];
+
+/** Mock "previous" code CIDs (what's on chain today). For real data this
+ *  comes from a `findContract(byId)` lookup. */
+const MOCK_PREVIOUS_CODE: Record<string, string> = {
+	vsc1BoaniA5HW56GuQy6pVdoZfMcVaaDfnC8kp:
+		'bafkreibrlaku3dmnexnxz4lbplkotf52mwnwie3tro73jn7wxhwkagie5m',
+	vsc1BdrQ6EtbQ64rq2PkPd21x4MaLnVRcJj85d:
+		'bafkreidr2ylwc7r4jilauhmrjrzgpoahfk76pxdgivqxiwvk5tduwespce'
+};
+
+/** Build a display view from a raw update by joining metadata + previous code. */
+export function buildView(update: PendingContractUpdate): ContractUpdateView {
+	return {
+		...update,
+		metadata: CONTRACT_REGISTRY[update.id],
+		previousCode: MOCK_PREVIOUS_CODE[update.id]
+	};
+}
+
+export function getMockPendingViews(): ContractUpdateView[] {
+	return MOCK_PENDING_UPDATES.map(buildView);
+}
+
+export function getMockUpdateView(id: string): ContractUpdateView | undefined {
+	const u = MOCK_PENDING_UPDATES.find((x) => x.id === id);
+	return u ? buildView(u) : undefined;
+}

--- a/src/lib/witness/contractUpdates/types.ts
+++ b/src/lib/witness/contractUpdates/types.ts
@@ -1,0 +1,82 @@
+/**
+ * Contract update types.
+ *
+ * Aligned with the `findPendingContractUpdates` GraphQL field landing in
+ * go-vsc-node PR #210 (https://github.com/vsc-eco/go-vsc-node/pull/210).
+ *
+ * Two layers:
+ *
+ *   1. `PendingContractUpdate` — the raw GraphQL shape. Backend canonical.
+ *      Once PR #210 merges, this is what Houdini returns from
+ *      `findPendingContractUpdatesQuery`.
+ *
+ *   2. `ContractMetadata` — client-side enrichment (human name, category,
+ *      title/description, repo link). The chain has no concept of these
+ *      and never will — names come from `findContract.name` and the rest
+ *      from a committed registry in `mockData.ts` (later: a tiny YAML /
+ *      markdown registry the VSC team curates).
+ *
+ * The view layer renders `ContractUpdateView` (raw + enrichment).
+ */
+
+/**
+ * Subset of `Contract` fields returned by `findPendingContractUpdates`.
+ *
+ * Note: PR #210 doesn't introduce a new type — it adds `activation_height`,
+ * `activation_ts`, and `proposer` to the existing `Contract` type, and
+ * exposes `findPendingContractUpdates(filterOptions: FindContractFilter): [Contract]`.
+ * This shape is just the projection we query.
+ */
+export type PendingContractUpdate = {
+	/** Contract id being updated (e.g. "vsc1Boa..."). NOT a proposal id. */
+	id: string;
+	/** IPFS CID of the new WASM code waiting to activate. */
+	code: string;
+	/** Account that signed the update transaction. */
+	proposer: string;
+	/** Contract owner account (governance authority that can sign updates). */
+	owner: string;
+	/** Block height when the update was queued. */
+	creation_height: number;
+	/** Block height when the timelock unlocks and the update activates. */
+	activation_height: number;
+	/** ISO 8601 date-time string — estimated wall-clock activation. */
+	activation_ts: string;
+};
+
+/**
+ * Parse an ISO 8601 date-time string (Contract.activation_ts /
+ * creation_ts) to unix seconds.
+ *
+ * The node emits bare timestamps without a timezone designator
+ * ("2026-06-12T14:08:45" — verified live on testnet 2026-06-12) which
+ * JS parses as LOCAL time, shifting the activation by the user's UTC
+ * offset (the countdown showed "unlocked" for a pending update). The
+ * values are UTC — append Z when no designator is present, same as
+ * txStores.getTimestamp does for anchr_ts.
+ */
+export function tsToUnixSec(iso: string): number {
+	const hasTimezone = /(?:Z|[+-]\d{2}:?\d{2})$/.test(iso);
+	return Math.floor(Date.parse(hasTimezone ? iso : iso + 'Z') / 1000);
+}
+
+/** Off-chain metadata for a known contract — display only. */
+export type ContractMetadata = {
+	/** Human-readable contract name (e.g. "Pool: HIVE/HBD"). */
+	name: string;
+	/** Tag drives color coding + filtering. */
+	category: 'pool' | 'bridge' | 'gateway' | 'oracle' | 'governance' | 'other';
+	/** Optional one-line summary of what this contract does. */
+	description?: string;
+};
+
+/** Raw update + optional enrichment + optional previous code (for diff). */
+export type ContractUpdateView = PendingContractUpdate & {
+	/** Joined from the curated registry or a `findContract(byId)` lookup. */
+	metadata?: ContractMetadata;
+	/** On-chain contract name from `findContract(byId)` — fallback label
+	 *  when the contract isn't in the curated registry. */
+	chainName?: string;
+	/** Current on-chain code CID — what will be replaced. From `findContract`. */
+	previousCode?: string;
+};

--- a/src/routes/(authed)/witness-assistant/+page.svelte
+++ b/src/routes/(authed)/witness-assistant/+page.svelte
@@ -3,6 +3,7 @@
 	import ConsensusUnstakeModal from './ConsensusUnstakeModal.svelte';
 	import { getAuth } from '$lib/auth/store';
 	import StakeUnstakeTabsModal from './StakeUnstakeTabsModal.svelte';
+	import ContractUpdatesSection from '$lib/witness/contractUpdates/ContractUpdatesSection.svelte';
 	let auth = $derived(getAuth()());
 </script>
 
@@ -13,6 +14,10 @@
 <h1>Witness Assistant</h1>
 
 <div>
+	<!-- Contract updates — visible regardless of auth provider, since
+	     auditing pending changes doesn't require a Hive account. -->
+	<ContractUpdatesSection />
+
 	{#if auth.value == undefined || auth.value.username != undefined}
 		<StakeUnstakeTabsModal />
 	{:else}

--- a/src/routes/(authed)/witness-assistant/contract-update/[id]/+page.svelte
+++ b/src/routes/(authed)/witness-assistant/contract-update/[id]/+page.svelte
@@ -1,0 +1,504 @@
+<!--
+	Contract-update detail page.
+
+	Routed by contract id (the `id` field of PendingContractUpdate).
+	Shows the queued WASM CID, the proposer + owner, the timelock window
+	(creation_height + activation_height + activation_ts), and audit
+	links for IPFS code fetch and code diff.
+
+	Data shape aligned with `findPendingContractUpdates` (go-vsc-node
+	PR #210). Reads from `mockData.ts` until that field is live.
+-->
+<script lang="ts">
+	import { page } from '$app/state';
+	import Card from '$lib/cards/Card.svelte';
+	import Countdown from '$lib/witness/contractUpdates/Countdown.svelte';
+	import { loadUpdateById } from '$lib/witness/contractUpdates/loader';
+	import { tsToUnixSec, type ContractUpdateView } from '$lib/witness/contractUpdates/types';
+	import {
+		codeDiffSearchUrl,
+		codeIpfsUrl,
+		contractExplorerUrl,
+		proposerTxUrl
+	} from '$lib/witness/contractUpdates/auditLinks';
+	import { ArrowLeft, ExternalLink, FileCode2, GitCompare, Loader2, User } from '@lucide/svelte';
+
+	let state = $state<
+		{ source: 'loading' } | { source: 'loaded'; update: ContractUpdateView | undefined }
+	>({ source: 'loading' });
+
+	$effect(() => {
+		const id = page.params.id;
+		// Stale-response guard: rapid navigation between detail routes could
+		// otherwise let a slower earlier response overwrite the newer one.
+		let stale = false;
+		loadUpdateById(id).then((update) => {
+			if (!stale) state = { source: 'loaded', update };
+		});
+		return () => {
+			stale = true;
+		};
+	});
+
+	const update = $derived(state.source === 'loaded' ? state.update : undefined);
+
+	function fmtIsoLocal(iso: string): string {
+		// Bare ISO timestamps from the node are UTC — route through
+		// tsToUnixSec (which appends Z) before converting to local display,
+		// otherwise the shown time shifts by the user's UTC offset (same
+		// bug class the countdown had).
+		return new Date(tsToUnixSec(iso) * 1000).toLocaleString();
+	}
+</script>
+
+<svelte:head>
+	<title>
+		{update?.metadata?.name ?? 'Contract update'} · Witness
+	</title>
+</svelte:head>
+
+<div class="wrap">
+	<a class="back" href="/witness-assistant">
+		<ArrowLeft size={14} />
+		Back to witness page
+	</a>
+
+	{#if state.source === 'loading'}
+		<Card>
+			<p class="loading-row">
+				<Loader2 size={14} class="spin" />
+				Loading update details…
+			</p>
+		</Card>
+	{:else if !update}
+		<Card>
+			<h2>No pending update</h2>
+			<p>
+				No pending contract update is queued for <code>{page.params.id}</code>. It may have already
+				activated, been cancelled, or never existed.
+			</p>
+		</Card>
+	{:else}
+		<Card>
+			<header class="head">
+				<div>
+					<div class="tags">
+						<span class="kind kind-{update.metadata?.category ?? 'other'}">
+							{update.metadata?.category ?? 'contract'}
+						</span>
+						<span class="status status-pending">pending</span>
+					</div>
+					<h2>
+						Upgrade · {update.metadata?.name ??
+							update.chainName ??
+							`contract ${update.id.slice(0, 12)}…`}
+					</h2>
+					{#if update.metadata?.description}
+						<p class="lead">{update.metadata.description}</p>
+					{:else}
+						<p class="lead">
+							No registry entry for this contract — only on-chain fields are shown.
+						</p>
+					{/if}
+				</div>
+				<div class="countdown-box">
+					<span class="cd-label">Activates in</span>
+					<Countdown targetUnixSec={tsToUnixSec(update.activation_ts)} />
+					<span class="cd-sub">block #{update.activation_height.toLocaleString()}</span>
+				</div>
+			</header>
+
+			<dl class="meta">
+				<div>
+					<dt>Contract id</dt>
+					<dd>
+						<code>{update.id}</code>
+						<a
+							class="inline-link"
+							href={contractExplorerUrl(update.id)}
+							target="_blank"
+							rel="noopener"
+						>
+							view on explorer
+							<ExternalLink size={12} />
+						</a>
+					</dd>
+				</div>
+				<div>
+					<dt>Proposer</dt>
+					<dd>
+						<User size={14} />
+						<strong>{update.proposer}</strong>
+						<a
+							class="inline-link"
+							href={proposerTxUrl(update.proposer)}
+							target="_blank"
+							rel="noopener"
+						>
+							view on hivehub
+							<ExternalLink size={12} />
+						</a>
+					</dd>
+				</div>
+				<div>
+					<dt>Owner</dt>
+					<dd><code>{update.owner}</code></dd>
+				</div>
+				<div>
+					<dt>Queued at</dt>
+					<dd>block #{update.creation_height.toLocaleString()}</dd>
+				</div>
+				<div>
+					<dt>Activates at</dt>
+					<dd>
+						block #{update.activation_height.toLocaleString()}
+						<span class="muted">· {fmtIsoLocal(update.activation_ts)}</span>
+					</dd>
+				</div>
+			</dl>
+		</Card>
+
+		<Card>
+			<h3>Exact code</h3>
+			<p class="lead">
+				Verify what's about to execute by fetching the WASM blobs from IPFS and comparing them
+				against the source.
+			</p>
+
+			<ul class="code-links">
+				<li>
+					<FileCode2 size={16} />
+					<div class="link-body">
+						<div class="link-row">
+							<span class="link-label">New code (WASM)</span>
+							<a href={codeIpfsUrl(update.code)} target="_blank" rel="noopener">
+								ipfs.io/ipfs/{update.code.slice(0, 14)}…
+								<ExternalLink size={12} />
+							</a>
+						</div>
+						<code class="cid">{update.code}</code>
+					</div>
+				</li>
+				{#if update.previousCode}
+					<li>
+						<FileCode2 size={16} />
+						<div class="link-body">
+							<div class="link-row">
+								<span class="link-label">Previous code (WASM)</span>
+								<a href={codeIpfsUrl(update.previousCode)} target="_blank" rel="noopener">
+									ipfs.io/ipfs/{update.previousCode.slice(0, 14)}…
+									<ExternalLink size={12} />
+								</a>
+							</div>
+							<code class="cid">{update.previousCode}</code>
+						</div>
+					</li>
+					<li>
+						<GitCompare size={16} />
+						<div class="link-body">
+							<div class="link-row">
+								<span class="link-label">Diff</span>
+								<a
+									href={codeDiffSearchUrl(update.previousCode, update.code)}
+									target="_blank"
+									rel="noopener"
+								>
+									compare CIDs
+									<ExternalLink size={12} />
+								</a>
+							</div>
+							<p class="hint">
+								No public WASM diff tool integrated yet — link is a starting point.
+							</p>
+						</div>
+					</li>
+				{:else}
+					<li class="muted-row">
+						<FileCode2 size={16} />
+						<div class="link-body">
+							<span class="link-label muted">Previous code</span>
+							<p class="hint">
+								Current on-chain code CID isn't joined yet — will be fetched via
+								<code>findContract(byId)</code> alongside the real query.
+							</p>
+						</div>
+					</li>
+				{/if}
+			</ul>
+		</Card>
+	{/if}
+</div>
+
+<style lang="scss">
+	.wrap {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		max-width: 56rem;
+		padding-bottom: 3rem;
+	}
+	.back {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3rem;
+		color: var(--dash-text-secondary);
+		text-decoration: none;
+		font-size: 0.88rem;
+		width: fit-content;
+		padding: 0.3rem 0.5rem;
+		margin-left: -0.5rem;
+		border-radius: 6px;
+		transition: background-color 150ms ease;
+	}
+	.back:hover {
+		background: rgba(255, 255, 255, 0.05);
+		color: var(--dash-text-primary);
+	}
+
+	.head {
+		display: flex;
+		justify-content: space-between;
+		gap: 1.5rem;
+		margin-bottom: 1.25rem;
+		align-items: flex-start;
+	}
+	.tags {
+		display: flex;
+		gap: 0.4rem;
+		margin-bottom: 0.5rem;
+	}
+	h2 {
+		margin: 0 0 0.25rem;
+		font-size: 1.35rem;
+		color: var(--dash-text-primary);
+		font-family: 'Nunito Sans', sans-serif;
+	}
+	h3 {
+		margin: 0 0 0.5rem;
+		font-size: 1.05rem;
+		color: var(--dash-text-primary);
+		font-family: 'Nunito Sans', sans-serif;
+	}
+	.lead {
+		margin: 0 0 1rem;
+		color: var(--dash-text-secondary);
+		font-size: 0.88rem;
+		line-height: 1.5;
+		max-width: 38rem;
+	}
+
+	.kind,
+	.status {
+		font-size: 0.7rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		padding: 0.22rem 0.55rem;
+		border-radius: 4px;
+		background: rgba(255, 255, 255, 0.08);
+		color: var(--dash-text-secondary);
+	}
+	.kind.kind-pool {
+		background: rgba(111, 106, 248, 0.22);
+		color: #b0acff;
+	}
+	.kind.kind-bridge {
+		background: rgba(60, 180, 230, 0.2);
+		color: #8edcf4;
+	}
+	.kind.kind-gateway {
+		background: rgba(150, 200, 100, 0.2);
+		color: #c8e69b;
+	}
+	.kind.kind-oracle {
+		background: rgba(230, 150, 200, 0.2);
+		color: #f0adcf;
+	}
+	.kind.kind-governance {
+		background: rgba(230, 150, 60, 0.22);
+		color: #ffc48a;
+	}
+	.kind.kind-other {
+		background: rgba(255, 255, 255, 0.08);
+		color: var(--dash-text-secondary);
+	}
+	.status-pending {
+		background: rgba(255, 170, 50, 0.22);
+		color: #ffc48a;
+	}
+
+	.countdown-box {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		gap: 0.2rem;
+		padding: 0.65rem 0.9rem;
+		border-radius: 10px;
+		background: rgba(255, 170, 50, 0.08);
+		border: 1px solid rgba(255, 170, 50, 0.28);
+	}
+	.cd-label {
+		font-size: 0.66rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--dash-text-secondary);
+		font-weight: 600;
+	}
+	.cd-sub {
+		font-size: 0.7rem;
+		color: var(--dash-text-muted);
+	}
+
+	.meta {
+		display: grid;
+		grid-template-columns: 8rem 1fr;
+		gap: 0.65rem 1rem;
+		margin: 0;
+	}
+	.meta > div {
+		display: contents;
+	}
+	.meta dt {
+		font-size: 0.72rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--dash-text-secondary);
+		font-weight: 600;
+		padding-top: 0.15rem;
+	}
+	.meta dd {
+		margin: 0;
+		color: var(--dash-text-primary);
+		font-size: 0.9rem;
+		line-height: 1.5;
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.4rem;
+	}
+	.meta code,
+	.cid {
+		font-family: 'Noto Sans Mono', monospace;
+		background: rgba(255, 255, 255, 0.06);
+		padding: 0.15rem 0.4rem;
+		border-radius: 4px;
+		font-size: 0.82em;
+		word-break: break-all;
+	}
+	.muted {
+		color: var(--dash-text-muted);
+		font-weight: 400;
+	}
+	.inline-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.2rem;
+		color: #b0acff;
+		text-decoration: none;
+		font-size: 0.85rem;
+	}
+	.inline-link:hover {
+		text-decoration: underline;
+	}
+
+	.code-links {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.85rem;
+	}
+	.code-links li {
+		display: grid;
+		grid-template-columns: auto 1fr;
+		gap: 0.75rem;
+		padding: 0.85rem 1rem;
+		border-radius: 10px;
+		background: rgba(255, 255, 255, 0.03);
+		border: 1px solid rgba(255, 255, 255, 0.08);
+	}
+	.code-links .muted-row {
+		opacity: 0.7;
+	}
+	.link-body {
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+	}
+	.link-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+	}
+	.link-label {
+		font-weight: 600;
+		font-size: 0.88rem;
+	}
+	.link-row a {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		color: #b0acff;
+		font-size: 0.82rem;
+		text-decoration: none;
+	}
+	.link-row a:hover {
+		text-decoration: underline;
+	}
+	.cid {
+		background: rgba(0, 0, 0, 0.25);
+		padding: 0.4rem 0.55rem;
+		font-size: 0.75rem;
+		color: var(--dash-text-secondary);
+		display: block;
+	}
+	.hint {
+		margin: 0;
+		font-size: 0.78rem;
+		color: var(--dash-text-muted);
+		font-style: italic;
+	}
+
+	.loading-row {
+		margin: 0;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		color: var(--dash-text-secondary);
+		font-size: 0.9rem;
+	}
+	:global(.spin) {
+		animation: spin 1s linear infinite;
+	}
+	@keyframes spin {
+		from {
+			transform: rotate(0deg);
+		}
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	@media (max-width: 600px) {
+		.head {
+			flex-direction: column;
+		}
+		.countdown-box {
+			align-self: flex-start;
+		}
+		.meta {
+			grid-template-columns: 1fr;
+		}
+		.meta > div {
+			display: block;
+			padding-bottom: 0.5rem;
+		}
+		.meta dd {
+			margin-top: 0.15rem;
+		}
+	}
+</style>


### PR DESCRIPTION
## Summary

Adds a "Contract updates" section to the witness page that surfaces
pending, time-locked system-contract upgrades (go-vsc-node PR #210's
`findPendingContractUpdates`): which contract, the new WASM CID, who
proposed it, and a live countdown to activation. Each row links to the
proposer, the new code on IPFS, and the contract on the VSC explorer;
a detail page per update lives at
`/witness-assistant/contract-update/[id]`.

## Live-verified

Tested end-to-end against testnet on 2026-06-12 (tibfox's timelock
demo deploy): the queued update appeared in the UI within one poll,
the wire shape matched our types, on-chain names resolved ("DEX
Router" via `findContract`), and the run surfaced a real bug — the
node emits `activation_ts` without a timezone designator, which naive
parsing shifted by the local UTC offset (countdown read "unlocked").
Fixed: bare timestamps are now parsed as UTC, pinned by a TZ-
independent test.

## Ships safely before the backend

Mainnet nodes don't serve the field yet (PR #210 is testnet-only as of
this PR). The section handles that with a **dormant state**: a grayed,
clearly-labeled "awaiting backend" card — never fake data, never an
error. The 30s poll auto-activates it the instant the backend deploys,
no redeploy needed.

## What it shows / how it filters

- Every pending update is shown, not just known contracts. Curated
  pools/router/bridge get a friendly name + category badge; unknown
  contracts show the on-chain name (or a short id) — so nothing is
  ever hidden from a witness.
- Data layer fetches through the same-origin `/api/gql` proxy
  following the app's configured node; dev-only mock fixtures
  (`?mock=1`) for visual review, compiled out of prod.

## Also in this branch

- `fix(test-infra)`: hardened module-scope localStorage access in
  client.ts / select.ts / dhive.ts behind safe accessors — the jsdom
  client-test project crashed on import; 33 pre-existing client tests
  un-broke (suite now 296+).

## Verification

- 29 witness tests (wire-shape contract, all render states incl.
  dormant, fallback paths, UTC parsing)
- Full suite green; svelte-check at the repo baseline (the +jest-dom
  type-noise in the new test files matches the rest of the repo)