### PR TITLE
fix(pools): read fees from pre-aggregated views — Fee Earned no longer ~$0 (0.3.19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to Altera are documented here.
 > CI / build-banner / release-script use, and so a glance at `package.json`
 > matches reality.
 
+## [0.3.19] — 2026-06-12
+
+### Fixes
+
+- **Pool "Fee Earned" read ~$0.02 for recent windows** (e.g. 7d on the busy HIVE pool) — far too low. Two compounding read-side causes: (1) the 2026-06-02 contract redeploy rewrote the on-chain fee event to the pendulum layout, moving the protocol fee out of `magi_fee` (now NULL on new rows) into a new split, so `fetchPoolFees` summing `magi_fee` counted the bulk of the fee as 0; (2) the raw `dex_pool_fee_events` query hit Hasura's default 100-row cap, under-counting busy pools regardless. `fetchPoolFees` now reads the indexer's pre-aggregated per-(pool, asset) views (`dex_pool_fees_by_asset_24h` / `_7d` / `_30d` / the suffix-less all-time view), selected by range, mapping `protocol_fees` → `magiFee` and `lp_fees` → `lpFee`. Server-aggregated, no row cap, consistent across all three indexers (per tibfox). The `PoolAssetFee` output shape is unchanged, so the USD pricing in `mapStateToPoolRow` and its tests are untouched. 10 new tests pin the range→view selection and the column mapping (including the NULL-`magi_fee` regression and string-numeric coercion)
+
 ## [0.3.18] — 2026-06-12
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.3.18",
+	"version": "0.3.19",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {

--- a/src/lib/indexer/poolQueries.test.ts
+++ b/src/lib/indexer/poolQueries.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for fetchPoolFees — the read-side fee fix.
+ *
+ * Pins the two things the 2026-06-12 rewrite is responsible for:
+ *   1. range → pre-aggregated view selection (24h / 7d / 30d / all-time)
+ *   2. view-column → PoolAssetFee mapping (protocol_fees → magiFee,
+ *      lp_fees → lpFee), which is what fixed the "$0.02 / 7d" bug where
+ *      the pendulum-era NULL `magi_fee` zeroed out the protocol fee.
+ *
+ * The network boundary (`hasuraQuery`) is mocked; the per-view response
+ * key is keyed by the same view name the query selects.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const hasuraQueryMock = vi.fn();
+vi.mock('./query', () => ({
+	hasuraQuery: (...args: unknown[]) => hasuraQueryMock(...args)
+}));
+
+const { fetchPoolFees } = await import('./poolQueries');
+
+afterEach(() => hasuraQueryMock.mockReset());
+
+// Sample matching tibfox's live 7d payload shape for the HIVE pool.
+const POOL = 'vsc1BoaniA5HW56GuQy6pVdoZfMcVaaDfnC8kp';
+
+describe('fetchPoolFees — view selection', () => {
+	it.each([
+		['1d', 'dex_pool_fees_by_asset_24h'],
+		['7d', 'dex_pool_fees_by_asset_7d'],
+		['30d', 'dex_pool_fees_by_asset_30d'],
+		['max', 'dex_pool_fees_by_asset']
+	] as const)('range %s queries the %s view', async (range, view) => {
+		hasuraQueryMock.mockResolvedValue({ [view]: [] });
+		await fetchPoolFees(POOL, range);
+		const sentQuery = hasuraQueryMock.mock.calls[0][0] as string;
+		expect(sentQuery).toContain(`${view}(where:`);
+		// pool id passed as a variable, not interpolated
+		expect(hasuraQueryMock.mock.calls[0][1]).toEqual({ pool: POOL });
+	});
+});
+
+describe('fetchPoolFees — column mapping', () => {
+	it('maps protocol_fees → magiFee and lp_fees → lpFee per asset', async () => {
+		hasuraQueryMock.mockResolvedValue({
+			dex_pool_fees_by_asset_7d: [
+				{ asset: 'hive', protocol_fees: 16947, lp_fees: 113 },
+				{ asset: 'hbd', protocol_fees: 990, lp_fees: 1 }
+			]
+		});
+		const out = await fetchPoolFees(POOL, '7d');
+		expect(out).toEqual([
+			{ asset: 'hive', magiFee: 16947, lpFee: 113 },
+			{ asset: 'hbd', magiFee: 990, lpFee: 1 }
+		]);
+	});
+
+	it('treats the protocol fee as a real value (not the old NULL magi_fee)', async () => {
+		// The bug: pendulum rows have protocol fee in protocol_fees, NOT
+		// magi_fee. The old code read magi_fee → 0. This asserts the bulk
+		// of the fee now lands in magiFee.
+		hasuraQueryMock.mockResolvedValue({
+			dex_pool_fees_by_asset_7d: [{ asset: 'btc', protocol_fees: 18738, lp_fees: 159 }]
+		});
+		const [btc] = await fetchPoolFees(POOL, '7d');
+		expect(btc.magiFee).toBe(18738);
+		expect(btc.magiFee).toBeGreaterThan(btc.lpFee);
+	});
+
+	it('coerces string-encoded numerics (Hasura may return NUMERIC as string)', async () => {
+		hasuraQueryMock.mockResolvedValue({
+			dex_pool_fees_by_asset_30d: [{ asset: 'hive', protocol_fees: '5000', lp_fees: '40' }]
+		});
+		const [hive] = await fetchPoolFees(POOL, '30d');
+		expect(hive).toEqual({ asset: 'hive', magiFee: 5000, lpFee: 40 });
+	});
+
+	it('drops null-asset rows defensively', async () => {
+		hasuraQueryMock.mockResolvedValue({
+			dex_pool_fees_by_asset_7d: [
+				{ asset: null, protocol_fees: 99, lp_fees: 9 },
+				{ asset: 'hive', protocol_fees: 10, lp_fees: 1 }
+			]
+		});
+		const out = await fetchPoolFees(POOL, '7d');
+		expect(out).toEqual([{ asset: 'hive', magiFee: 10, lpFee: 1 }]);
+	});
+
+	it('returns [] when the view has no rows for the pool', async () => {
+		hasuraQueryMock.mockResolvedValue({ dex_pool_fees_by_asset_7d: [] });
+		expect(await fetchPoolFees(POOL, '7d')).toEqual([]);
+	});
+
+	it('returns [] when the response is missing the view key', async () => {
+		hasuraQueryMock.mockResolvedValue({});
+		expect(await fetchPoolFees(POOL, '7d')).toEqual([]);
+	});
+});

--- a/src/lib/indexer/poolQueries.ts
+++ b/src/lib/indexer/poolQueries.ts
@@ -71,50 +71,58 @@ export async function fetchPoolVolume(
 export type PoolAssetFee = { asset: string; magiFee: number; lpFee: number };
 
 /**
+ * Pre-aggregated per-(pool, asset) fee views, one per time window. The
+ * suffix-less view is all-time ("max"). Using these instead of summing raw
+ * `dex_pool_fee_events` client-side fixes two bugs at once:
+ *   1. The raw query was capped at Hasura's default 100-row limit, so busy
+ *      pools (e.g. 7d on the HIVE pool) under-counted fees.
+ *   2. The pendulum fee rewrite (2026-06-02 contract redeploy) leaves
+ *      `magi_fee` NULL and splits the protocol fee across new columns, so
+ *      summing `magi_fee` counted the bulk of the fee as 0 (~$0.02/7d).
+ * The views expose the canonical split (`protocol_fees` + `lp_fees`),
+ * aggregated server-side with no row cap, consistent across all three
+ * indexers (per tibfox, 2026-06-12).
+ */
+const FEE_VIEW_BY_RANGE: Record<TimeRange, string> = {
+	'1d': 'dex_pool_fees_by_asset_24h',
+	'7d': 'dex_pool_fees_by_asset_7d',
+	'30d': 'dex_pool_fees_by_asset_30d',
+	max: 'dex_pool_fees_by_asset'
+};
+
+/**
  * Per-asset fee breakdown for a pool, over the selected time window.
  *
- * A pool collects fees in BOTH of its assets — one per swap direction — so the
- * old approach (summing into a single number and pricing it as one asset)
- * inflated the figure several-fold (HIVE fees counted as HBD). We aggregate the
- * raw `dex_pool_fee_events` (which carry `asset` + `indexer_ts`) per asset for
- * the chosen range, so fees stay correct AND track the timeframe like volume;
- * the caller values each asset at its own price.
- *
- * PERF: for wide windows (30d/max) across the whole pool list this pulls a few
- * hundred rows per pool. When the indexer exposes a per-asset rollup that takes
- * a `$since` timestamp (e.g. `fees_by_asset_since(pool, since)`), swap the query
- * below for a single aggregated call — the return shape stays the same.
+ * A pool collects fees in BOTH of its assets (one per swap direction); the
+ * caller values each asset at its own price. Reads the pre-aggregated
+ * `dex_pool_fees_by_asset_*` view for the range and maps its columns to our
+ * `PoolAssetFee` shape: `protocol_fees → magiFee`, `lp_fees → lpFee`.
  */
 export async function fetchPoolFees(poolId: string, range: TimeRange): Promise<PoolAssetFee[]> {
-	const gte = getTimeGte(range);
-	// Exclude rows with no `asset` tag. A 3-day indexer window (2026-04-16..18)
-	// emitted fee events with a null asset; they only surface in the `max`
-	// range (older than 30d), where they were aggregating under the key
-	// "null" and rendering as a bogus "… NULL" currency in the breakdown.
-	const whereClause = gte
-		? `{indexer_contract_id: {_eq: $pool}, indexer_ts: {_gte: "${gte}"}, asset: {_is_null: false}}`
-		: `{indexer_contract_id: {_eq: $pool}, asset: {_is_null: false}}`;
-
+	// View name comes from a fixed internal map (never user input) so
+	// interpolating it is safe; the pool id is passed as a variable.
+	const view = FEE_VIEW_BY_RANGE[range];
 	const query = `
-		query PoolFeeEvents($pool: String!) {
-			dex_pool_fee_events(where: ${whereClause}) {
-				asset lp_fee magi_fee
+		query PoolFeesByAsset($pool: String!) {
+			${view}(where: { pool_contract: { _eq: $pool } }) {
+				asset
+				protocol_fees
+				lp_fees
 			}
 		}
 	`;
 	const data = await hasuraQuery(query, { pool: poolId });
-	const rows =
-		(data?.dex_pool_fee_events as Array<Record<string, number | string>> | undefined) ?? [];
+	const rows = (data?.[view] as Array<Record<string, number | string>> | undefined) ?? [];
 
+	// Views are already one row per asset; the Map keeps it idempotent if
+	// that ever changes and drops any null-asset row defensively.
 	const byAsset = new Map<string, PoolAssetFee>();
 	for (const r of rows) {
-		// Defensive: skip any untagged row that slips past the query filter so
-		// it can't create a "null"/"NULL" asset bucket.
 		if (r.asset == null) continue;
 		const asset = String(r.asset);
 		const entry = byAsset.get(asset) ?? { asset, lpFee: 0, magiFee: 0 };
-		entry.lpFee += Number(r.lp_fee) || 0;
-		entry.magiFee += Number(r.magi_fee) || 0;
+		entry.lpFee += Number(r.lp_fees) || 0;
+		entry.magiFee += Number(r.protocol_fees) || 0;
 		byAsset.set(asset, entry);
 	}
 	return [...byAsset.values()];


### PR DESCRIPTION
## Summary

Pool "Fee Earned" showed ~$0.02 for recent windows (7d on the busy
HIVE pool) — far too low. Two compounding read-side causes:

1. The 2026-06-02 contract redeploy rewrote the on-chain fee event to
   the pendulum layout: the protocol fee moved out of `magi_fee` (now
   NULL on new rows) into a new split, so `fetchPoolFees` summing
   `magi_fee` counted the bulk of the fee as 0.
2. The raw `dex_pool_fee_events` query hit Hasura's default 100-row
   cap, under-counting busy pools regardless.

## The change

`fetchPoolFees` (single function in `poolQueries.ts`) now reads the
indexer's pre-aggregated per-(pool, asset) views instead of summing
raw events client-side:

| range | view |
|---|---|
| 1d | `dex_pool_fees_by_asset_24h` |
| 7d | `dex_pool_fees_by_asset_7d` |
| 30d | `dex_pool_fees_by_asset_30d` |
| max | `dex_pool_fees_by_asset` (all-time) |

Columns map `protocol_fees → magiFee`, `lp_fees → lpFee`. Server-
aggregated, no row cap, consistent across all three indexers (per
tibfox, 2026-06-12; views verified live).

The `PoolAssetFee` output shape is unchanged, so `mapStateToPoolRow`
and its 62 pricing tests are untouched. `getTimeGte` stays (still used
by `fetchPoolVolume`).

## Verification

- Live: `dex_pool_fees_by_asset_7d` for the HIVE pool returns real fees
  (~17 HIVE/7d) vs the old ~$0.02
- 10 new tests pin range→view selection + the column mapping, incl.
  the NULL-`magi_fee` regression and string-numeric coercion
- Full suite green (307 passing); svelte-check at the repo baseline