### PR TITLE
Feat/dash is login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,56 @@
+# ============================================================================
+# Altera client — environment variable template
+# ============================================================================
+# Copy this file to `.env` (gitignored) and fill in for your deployment.
+# Vars prefixed `PUBLIC_` are exposed to the browser at build time; vars
+# without the prefix are server-only.
+#
+# To switch between testnet and mainnet, change BOTH:
+#   PUBLIC_DASH_NETWORK  (consumed by client-side DID-namespace selection)
+#   PUBLIC_IS_SERVICE_URL (consumed by client to reach the IS service)
+# A mismatch between the two is caught at first Dash-login render and
+# throws a hard error (see src/lib/auth/dash/config.ts).
+# ============================================================================
+
+
+# ---- 3rd-party / server-only --------------------------------------------
+# Server-only API keys, never exposed to the browser.
+CMC_API_KEY=placeholder
+COINBASE_ID=placeholder
+COINBASE_PRIVATE_KEY=placeholder
+
+
+# ---- Altera-wide settings -----------------------------------------------
+# Public origin of this Altera deployment (used by Coinbase Pay return URLs,
+# canonical-link tags, etc.). Set to your deployed URL in prod.
+ALTERA_ORIGIN=https://altera.okinoko.io
+
+# Comma-separated lists; client picks one per request with a fallback chain.
+PUBLIC_INDEXER_NODES=https://api.okinoko.io/hasura,https://indexer.magi.milohpr.com
+PUBLIC_VSC_API_NODES=https://api.vsc.eco,https://vsc.techcoderx.com
+PUBLIC_HIVE_RPC_NODES=https://api.hive.blog,https://api.openhive.network,https://techcoderx.com,https://api.deathwing.me
+
+
+# ---- Dash InstantSend login (workstream 5/8) ----------------------------
+# REQUIRED — no safe default. If unset, /login throws on first render.
+# Reason: silent fall-back to testnet would issue wrong-DID-namespace
+# identities on mainnet (see R5-OP-01 audit, config.ts:resolveDashNetwork).
+# Allowed values:  mainnet  |  testnet
+PUBLIC_DASH_NETWORK=testnet
+
+# IS service base URL. Defaults to the testnet host when unset. Override
+# for staging or mainnet deploys.
+#   testnet (default): https://is-service-testnet.okinoko.io
+#   staging:           https://is-service.staging.okinoko.io  (example)
+#   mainnet:           TBD post-cutover (see MAINNET_HOST_SUFFIXES in
+#                      src/lib/auth/dash/config.ts — populate before flip)
+# The hostname MUST match PUBLIC_DASH_NETWORK against the known-suffix
+# allow-list in config.ts; mismatch = hard error.
+PUBLIC_IS_SERVICE_URL=https://is-service-testnet.okinoko.io
+
+# Pinned IS-service public key (hex, BLS or ECDSA per spec §5.7). When
+# blank/unset, the frontend falls back to the address-fingerprint visual
+# check (see addressFingerprint in src/lib/auth/dash/isClient.ts).
+# REQUIRED for mainnet — pin the IS-service signer before flip. Until
+# wired, mainnet users see only the visual-fingerprint fallback.
+PUBLIC_IS_SERVICE_SIGNER_PUBKEY=

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Thumbs.db
 .env
 .env.*
 !.env.example
+!.env.example
 !.env.test
 
 # Vite

--- a/src/lib/auth/DashLogin.svelte
+++ b/src/lib/auth/DashLogin.svelte
@@ -3,12 +3,12 @@
 	import Dialog from '$lib/zag/Dialog.svelte';
 	import Qr from '$lib/zag/QR.svelte';
 	import { ArrowRight, RefreshCw, ShieldAlert, ShieldCheck, ShieldQuestion } from '@lucide/svelte';
-	import { isServiceUrl, isServiceSignerPubkey, dashNetwork } from './dash/config';
+	import { isServiceUrl, isServiceSignerPubkey, getDashNetwork } from './dash/config';
 	import { createDashSession } from './dash/session.svelte';
 	import { addressFingerprint, buildDashUri, type IsSessionState } from './dash/isClient';
 	import { verifyAddressSignature, type SignatureVerdict } from './dash/signature';
 	import { buildDashDID } from './dashCaip';
-	import { _dashAuthStore } from './store';
+	import { _dashAuthStore, cleanUpLogout } from './store';
 
 	// Component-local. We only support op=auth here; op=call is a future
 	// surface (contract-call deep-link from inside the app's swap flow).
@@ -53,7 +53,7 @@
 				void session.cancel();
 				return;
 			}
-			const did = buildDashDID(dashNetwork, senderAddr);
+			const did = buildDashDID(getDashNetwork(), senderAddr);
 			// Round-4 audit R4-CSM-03: write to _dashAuthStore, not
 			// _hiveAuthStore. Sharing storage with Hive let
 			// account_changed / hiveLogout / init events destroy the
@@ -72,7 +72,14 @@
 					// dhive lookups against the synthetic 'dash:XYabc...' username).
 					provider: 'dash-instantsend',
 					logout: async () => {
+						// Round-5 audit R5-003: mirror hiveLogout — wipe
+						// balances, transaction store, and route back to
+						// /login. Without cleanUpLogout(), stale Hive-
+						// shaped account state lingers in
+						// accountBalance/accountBalanceHistory/txStores
+						// after a Dash logout.
 						_dashAuthStore.set({ status: 'none' });
+						cleanUpLogout();
 					},
 					openSettings: () => {},
 					profilePicUrl: undefined

--- a/src/lib/auth/DashLogin.svelte
+++ b/src/lib/auth/DashLogin.svelte
@@ -34,12 +34,14 @@
 	// cancel. We track open state through Dialog's open binding.
 	let open = $state(false);
 	$effect(() => {
-		// Round-9 audit R9-DESIGN-RETRY-01: also fire begin() on
-		// re-open after a 'failed' state so the retry() flow
-		// (close-then-open) actually restarts the session. Pre-R9
-		// the gate was 'idle'-only, so retry left the modal stuck
-		// on the failed screen.
-		if (open && (session.phase === 'idle' || session.phase === 'failed')) {
+		// Round-9 audit R9-DESIGN-RETRY-01 / round-10 audit R10-CORR-02:
+		// reverted to 'idle'-only gate. The broadened
+		// 'idle'||'failed' gate let a fast-rejecting startSession
+		// flip phase=failed→starting→failed→starting in a tight
+		// loop, hammering the server. The retry() flow now calls
+		// session.begin() explicitly after cancel + reopen so a
+		// single retry click triggers exactly one begin() attempt.
+		if (open && session.phase === 'idle') {
 			void session.begin();
 		}
 		if (!open && session.phase === 'waiting') {
@@ -184,18 +186,17 @@
 	}
 
 	async function retry() {
-		// Round-9 audit R9-DESIGN-RETRY-01: cancel + close/open is
-		// not enough — the session object is bound once at the top
-		// of the file (not re-created) and begin() only used to
-		// re-fire when phase was 'idle'. We broadened the open
-		// effect's gate to admit 'failed' too, so this flow now
-		// actually restarts the session. The 50ms close/open is
-		// preserved as the UX signal that the dialog briefly
-		// resets, but the gate fix is the real work.
+		// Round-10 audit R10-CORR-02: retry() drives begin() once,
+		// explicitly. The pre-R10 'broaden the effect gate' approach
+		// (R9-DESIGN-RETRY-01) flipped failed→starting→failed in a
+		// tight loop against a fast-rejecting server. The 50ms
+		// close/open is preserved for UX (visible reset feedback);
+		// the begin() call is what actually restarts the session.
 		await session.cancel();
 		open = false;
 		setTimeout(() => {
 			open = true;
+			void session.begin();
 		}, 50);
 	}
 </script>
@@ -243,6 +244,19 @@
 					<dd class="mono">{session.status.senderAddress}</dd>
 				{/if}
 			</dl>
+			{#if session.postCancelConflict}
+				<!-- Round-10 audit R10-DRIFT-DASHSESSION-UNUSED-PROPS:
+					 surface the R6-SEC-01 post-cancel-conflict banner
+					 so the user understands why the modal is still
+					 spinning after they clicked cancel: the server
+					 was mid-attestation and is finishing the on-chain
+					 step. Auto-clears when a terminal state arrives or
+					 the trap-deadline fires. -->
+				<p class="muted">
+					Cancel acknowledged. The validator attestation has already
+					started — finishing the on-chain step before unwinding…
+				</p>
+			{/if}
 			<p class="footnote">
 				The fingerprint should match the value Altera shows in its docs. If it doesn't, do
 				not pay — close this dialog and report the discrepancy.

--- a/src/lib/auth/DashLogin.svelte
+++ b/src/lib/auth/DashLogin.svelte
@@ -8,7 +8,7 @@
 	import { addressFingerprint, buildDashUri, type IsSessionState } from './dash/isClient';
 	import { verifyAddressSignature, type SignatureVerdict } from './dash/signature';
 	import { buildDashDID } from './dashCaip';
-	import { _hiveAuthStore } from './store';
+	import { _dashAuthStore } from './store';
 
 	// Component-local. We only support op=auth here; op=call is a future
 	// surface (contract-call deep-link from inside the app's swap flow).
@@ -54,7 +54,12 @@
 				return;
 			}
 			const did = buildDashDID(dashNetwork, senderAddr);
-			_hiveAuthStore.set({
+			// Round-4 audit R4-CSM-03: write to _dashAuthStore, not
+			// _hiveAuthStore. Sharing storage with Hive let
+			// account_changed / hiveLogout / init events destroy the
+			// logged-in Dash session and made Hive's profile-pic
+			// subscriber dispatch dhive lookups against the DashDID.
+			_dashAuthStore.set({
 				status: 'authenticated',
 				value: {
 					username: 'dash:' + senderAddr.slice(0, 8),
@@ -67,7 +72,7 @@
 					// dhive lookups against the synthetic 'dash:XYabc...' username).
 					provider: 'dash-instantsend',
 					logout: async () => {
-						_hiveAuthStore.set({ status: 'none' });
+						_dashAuthStore.set({ status: 'none' });
 					},
 					openSettings: () => {},
 					profilePicUrl: undefined
@@ -134,6 +139,12 @@
 				return 'Payment seen, gathering validator signatures…';
 			case 'ATTESTING':
 				return 'Gathering validator signatures…';
+			case 'L2_SUBMITTED':
+				// Round-4 audit R4-CSM-04: the IS service emits this
+				// during reconcileL2 (seconds to minutes); without a
+				// matching switch case the Status line rendered blank
+				// for the entire reconcile window.
+				return 'Submitted on-chain, awaiting confirmation…';
 			case 'ON_CHAIN':
 				return 'Logged in';
 			case 'ATTESTATION_TIMEOUT':

--- a/src/lib/auth/DashLogin.svelte
+++ b/src/lib/auth/DashLogin.svelte
@@ -34,7 +34,12 @@
 	// cancel. We track open state through Dialog's open binding.
 	let open = $state(false);
 	$effect(() => {
-		if (open && session.phase === 'idle') {
+		// Round-9 audit R9-DESIGN-RETRY-01: also fire begin() on
+		// re-open after a 'failed' state so the retry() flow
+		// (close-then-open) actually restarts the session. Pre-R9
+		// the gate was 'idle'-only, so retry left the modal stuck
+		// on the failed screen.
+		if (open && (session.phase === 'idle' || session.phase === 'failed')) {
 			void session.begin();
 		}
 		if (!open && session.phase === 'waiting') {
@@ -179,9 +184,15 @@
 	}
 
 	async function retry() {
+		// Round-9 audit R9-DESIGN-RETRY-01: cancel + close/open is
+		// not enough — the session object is bound once at the top
+		// of the file (not re-created) and begin() only used to
+		// re-fire when phase was 'idle'. We broadened the open
+		// effect's gate to admit 'failed' too, so this flow now
+		// actually restarts the session. The 50ms close/open is
+		// preserved as the UX signal that the dialog briefly
+		// resets, but the gate fix is the real work.
 		await session.cancel();
-		// createDashSession is closed-over; re-create on retry to reset
-		// state cleanly. Svelte will re-run the open effect.
 		open = false;
 		setTimeout(() => {
 			open = true;

--- a/src/lib/auth/DashLogin.svelte
+++ b/src/lib/auth/DashLogin.svelte
@@ -287,17 +287,22 @@
 			<p class="muted">Pay the address below from your DashPay wallet via InstantSend.</p>
 			{#if sigVerdict?.kind === 'unsupported' || sigVerdict?.kind === 'unconfigured'}
 				<!-- Audit R16-SEC-altera-sigverdict-unsupported-renders-qr
-					 (MED): when the browser can't run Ed25519 WebCrypto
-					 (older Chrome/Firefox/Safari) OR the operator hasn't
-					 pinned PUBLIC_IS_SERVICE_SIGNER_PUBKEY, the QR still
-					 renders. We don't fail-closed in this branch (it
-					 would brick legitimate older-browser users), but we
-					 elevate the fingerprint check from an inline badge
-					 to a prominent banner so the user can't miss it.
-					 The fingerprint below the QR is the SAME 6-char hash
-					 the operator publishes out-of-band; matching it is
-					 the manual fallback when crypto-verify isn't
-					 available. -->
+					 (MED) + R19-SEC-fingerprint-warn-panel-no-canonical-
+					 source-exists + R21 cluster (R20 claimed to rewrite
+					 this comment but the diff missed it): when the browser
+					 can't run Ed25519 WebCrypto (older Chrome/Firefox/
+					 Safari) OR the operator hasn't pinned PUBLIC_IS_
+					 SERVICE_SIGNER_PUBKEY, the QR still renders. We don't
+					 fail-closed in this branch (it would brick legitimate
+					 older-browser users), but we surface the missing-
+					 verification state as a prominent yellow warn-panel so
+					 the user can't miss it. The panel does NOT instruct
+					 comparing the on-screen fingerprint against any
+					 operator-published value — per R19 the fingerprint is
+					 per-session-internal (regenerated every session) and
+					 no canonical source exists to compare against. The
+					 user's defense is to judge the website name + the
+					 operator they trust, NOT a hash comparison. -->
 				<div class="sig-warn-panel">
 					<p class="sig-warn-title">
 						<ShieldQuestion size={16} />

--- a/src/lib/auth/DashLogin.svelte
+++ b/src/lib/auth/DashLogin.svelte
@@ -2,10 +2,11 @@
 	import PillButton from '$lib/PillButton.svelte';
 	import Dialog from '$lib/zag/Dialog.svelte';
 	import Qr from '$lib/zag/QR.svelte';
-	import { ArrowRight, RefreshCw } from '@lucide/svelte';
-	import { isServiceUrl } from './dash/config';
+	import { ArrowRight, RefreshCw, ShieldAlert, ShieldCheck, ShieldQuestion } from '@lucide/svelte';
+	import { isServiceUrl, isServiceSignerPubkey } from './dash/config';
 	import { createDashSession } from './dash/session.svelte';
 	import { addressFingerprint, buildDashUri, type IsSessionState } from './dash/isClient';
+	import { verifyAddressSignature, type SignatureVerdict } from './dash/signature';
 	import { _hiveAuthStore } from './store';
 
 	// Component-local. We only support op=auth here; op=call is a future
@@ -33,19 +34,21 @@
 	// layout + protected routes) treats this as the logged-in subject.
 	$effect(() => {
 		if (session.phase === 'done' && session.status?.sessionToken && session.status?.dashTxId) {
-			const token = session.status.sessionToken;
 			const txid = session.status.dashTxId;
-			// We don't (yet) know the user's Dash L1 address from the
-			// status response — the IS service has it (it's in the rawTx),
-			// but doesn't surface it back. For v1 we use the txid as the
-			// identity anchor; the dashboard fills in the L1 address from
-			// the dash-mapping-contract state via DashDID -> address.
+			const senderAddr = session.status.senderAddress;
+			// Prefer the L1 Dash address (surfaced from IS_OBSERVED onwards)
+			// as the identity anchor. Fall back to the txid only when the
+			// IS service couldn't resolve the sender (multi-address inputs
+			// or unsupported script type — both already get rejected by
+			// the contract, but the UI shouldn't crash on the fallback path).
+			const idAnchor = senderAddr ?? txid;
+			const username = senderAddr ? 'dash:' + senderAddr.slice(0, 8) : 'dash:' + txid.slice(0, 8);
 			_hiveAuthStore.set({
 				status: 'authenticated',
 				value: {
-					username: 'dash:' + txid.slice(0, 8),
-					address: 'did:vsc:dash:' + txid,
-					did: 'did:vsc:dash:' + txid,
+					username,
+					address: 'did:pkh:bip122:dash:' + idAnchor,
+					did: 'did:pkh:bip122:dash:' + idAnchor,
 					provider: 'aioha',
 					logout: async () => {
 						_hiveAuthStore.set({ status: 'none' });
@@ -57,6 +60,39 @@
 			close();
 		}
 	});
+
+	// Verify the address signature against the pinned IS-service pubkey.
+	// Runs once when the start response arrives; result drives the badge
+	// shown next to the address. When `unconfigured` (no pubkey set),
+	// users still get the 6-char fingerprint check.
+	let sigVerdict = $state<SignatureVerdict | undefined>(undefined);
+	$effect(() => {
+		const r = session.startResponse;
+		if (!r) {
+			sigVerdict = undefined;
+			return;
+		}
+		void verifyAddressSignature({
+			depositAddress: r.depositAddress,
+			instruction: hexToString(r.depositInstructionHex),
+			signatureB64: r.addressSignature,
+			pinnedPubkey: isServiceSignerPubkey
+		}).then((v) => {
+			sigVerdict = v;
+		});
+	});
+
+	function hexToString(h: string): string {
+		// depositInstructionHex is hex(instruction string) — opt-out of
+		// shell-escaping. Decode back to the ASCII bytes the IS-service
+		// signed.
+		if (!h) return '';
+		let out = '';
+		for (let i = 0; i < h.length; i += 2) {
+			out += String.fromCharCode(parseInt(h.slice(i, i + 2), 16));
+		}
+		return out;
+	}
 
 	const stateLabel = $derived(humanState(session.status?.state));
 	const requiredDash = $derived(
@@ -122,13 +158,32 @@
 			{/if}
 			<dl class="meta">
 				<dt>Address</dt>
-				<dd class="mono">{session.startResponse.depositAddress}</dd>
+				<dd class="mono">
+					{session.startResponse.depositAddress}
+					{#if sigVerdict?.kind === 'valid'}
+						<span class="sig sig-ok" title="address signature verified"
+							><ShieldCheck size={12} /> verified</span
+						>
+					{:else if sigVerdict?.kind === 'invalid'}
+						<span class="sig sig-bad" title="address signature DID NOT verify — do not pay"
+							><ShieldAlert size={12} /> signature mismatch</span
+						>
+					{:else if sigVerdict?.kind === 'unconfigured' || sigVerdict?.kind === 'unsupported'}
+						<span class="sig sig-unknown" title="fall back to fingerprint check"
+							><ShieldQuestion size={12} /> check fingerprint</span
+						>
+					{/if}
+				</dd>
 				<dt>Fingerprint</dt>
 				<dd class="mono">{fingerprint}</dd>
 				<dt>Amount</dt>
 				<dd>{requiredDash} DASH</dd>
 				<dt>Status</dt>
 				<dd>{stateLabel}</dd>
+				{#if session.status?.senderAddress}
+					<dt>From</dt>
+					<dd class="mono">{session.status.senderAddress}</dd>
+				{/if}
 			</dl>
 			<p class="footnote">
 				The fingerprint should match the value Altera shows in its docs. If it doesn't, do
@@ -238,5 +293,27 @@
 		color: #fda4af;
 		text-align: center;
 		margin: 0.5rem 0 1rem;
+	}
+	.sig {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.2rem;
+		margin-left: 0.4rem;
+		padding: 0.05rem 0.4rem;
+		border-radius: 1rem;
+		font-size: 0.7rem;
+		vertical-align: middle;
+	}
+	.sig-ok {
+		background: rgba(74, 222, 128, 0.15);
+		color: #4ade80;
+	}
+	.sig-bad {
+		background: rgba(248, 113, 113, 0.15);
+		color: #f87171;
+	}
+	.sig-unknown {
+		background: rgba(251, 191, 36, 0.1);
+		color: #facc15;
 	}
 </style>

--- a/src/lib/auth/DashLogin.svelte
+++ b/src/lib/auth/DashLogin.svelte
@@ -302,17 +302,17 @@
 							: 'IS-service signer pubkey not pinned'}
 					</p>
 					<p>
-						<strong>Match the 6-character fingerprint shown below
-						against the value your IS-service operator publishes
-						before paying.</strong> The canonical source is the
-						same place the operator declares which IS-service
-						Altera should talk to (status page, docs, or
-						out-of-band announcement).
+						Altera could not cryptographically verify the
+						deposit address against the IS-service's signer.
+						The deposit address shown below cannot be
+						automatically authenticated.
 					</p>
 					<p>
-						<strong>If the fingerprint does not match, or you
-						don't have a canonical source for it, do not pay</strong>
-						— close this dialog and report it.
+						<strong>Only proceed if you trust this Altera
+						deployment and the IS-service URL it talks to.</strong>
+						If the URL in your address bar isn't the one you
+						expect, or anything else about this dialog looks
+						wrong, do not pay — close this dialog and report it.
 					</p>
 				</div>
 			{/if}
@@ -356,8 +356,12 @@
 				</p>
 			{/if}
 			<p class="footnote">
-				The fingerprint should match the value Altera shows in its docs. If it doesn't, do
-				not pay — close this dialog and report the discrepancy.
+				The fingerprint is a short visual identifier for this
+				session's deposit address — useful for spotting an obvious
+				mid-flight swap when comparing the dialog and your wallet
+				side-by-side. The cryptographic check that actually
+				authenticates the response is the signed-address
+				verification (signaled by the verified/mismatch badge above).
 			</p>
 		{:else if session.phase === 'done'}
 			<p>Signed in. Redirecting…</p>

--- a/src/lib/auth/DashLogin.svelte
+++ b/src/lib/auth/DashLogin.svelte
@@ -228,6 +228,34 @@
 	{#snippet content()}
 		{#if session.phase === 'starting' || (session.phase === 'waiting' && !session.startResponse)}
 			<p class="muted">Preparing your session…</p>
+		{:else if session.phase === 'waiting' && session.startResponse && sigVerdict?.kind === 'invalid'}
+			<!-- Audit SEC-2 (R15): hard fail-closed when the IS-service
+				 address signature does NOT verify against the pinned
+				 PUBLIC_IS_SERVICE_SIGNER_PUBKEY. Pre-fix the QR + address
+				 still rendered with only an inline red-shield badge — a
+				 user who'd successfully scanned + paid in prior sessions
+				 was nudged toward doing it again. The signer exists
+				 precisely so the client can detect adversary-controlled
+				 IS-service responses; rendering the QR anyway defeats it. -->
+			<div class="sig-fail-panel">
+				<p class="sig-fail-title">
+					<ShieldAlert size={16} /> IS-service signature did not verify
+				</p>
+				<p>
+					The address Altera received from the IS service could
+					not be cryptographically tied to the pinned signer
+					public key. <strong>Do not scan or pay anything.</strong>
+					This can mean a network-level interception, a hostile
+					proxy, or an operator-side key rotation that has not
+					been propagated to this build.
+				</p>
+				<p class="muted">
+					If you maintain this Altera deployment, verify
+					<code>PUBLIC_IS_SERVICE_SIGNER_PUBKEY</code> matches
+					the IS-service operator's current signer fingerprint,
+					then reload.
+				</p>
+			</div>
 		{:else if session.phase === 'waiting' && session.startResponse}
 			<p class="muted">Pay the address below from your DashPay wallet via InstantSend.</p>
 			{#if dashUri}
@@ -240,10 +268,6 @@
 					{#if sigVerdict?.kind === 'valid'}
 						<span class="sig sig-ok" title="address signature verified"
 							><ShieldCheck size={12} /> verified</span
-						>
-					{:else if sigVerdict?.kind === 'invalid'}
-						<span class="sig sig-bad" title="address signature DID NOT verify — do not pay"
-							><ShieldAlert size={12} /> signature mismatch</span
 						>
 					{:else if sigVerdict?.kind === 'unconfigured' || sigVerdict?.kind === 'unsupported'}
 						<span class="sig sig-unknown" title="fall back to fingerprint check"
@@ -396,12 +420,34 @@
 		background: rgba(74, 222, 128, 0.15);
 		color: #4ade80;
 	}
-	.sig-bad {
-		background: rgba(248, 113, 113, 0.15);
-		color: #f87171;
-	}
 	.sig-unknown {
 		background: rgba(251, 191, 36, 0.1);
 		color: #facc15;
+	}
+	.sig-fail-panel {
+		display: flex;
+		flex-direction: column;
+		gap: 0.6em;
+		padding: 1em;
+		border: 1px solid rgba(248, 113, 113, 0.5);
+		background: rgba(248, 113, 113, 0.1);
+		border-radius: 4px;
+		color: #f87171;
+		strong {
+			color: #fca5a5;
+		}
+		code {
+			background: rgba(0, 0, 0, 0.25);
+			padding: 0 0.3em;
+			border-radius: 2px;
+			font-size: 0.9em;
+		}
+	}
+	.sig-fail-title {
+		display: flex;
+		align-items: center;
+		gap: 0.4em;
+		font-weight: 600;
+		margin: 0;
 	}
 </style>

--- a/src/lib/auth/DashLogin.svelte
+++ b/src/lib/auth/DashLogin.svelte
@@ -60,7 +60,12 @@
 					username: 'dash:' + senderAddr.slice(0, 8),
 					address: did,
 					did,
-					provider: 'aioha',
+					// Round-3 audit R3-003: distinct provider tag so downstream
+					// (QuickSwap / currentBalance / Portfolio / transactions /
+					// (authed)/+layout) can branch on Dash vs Hive rather than
+					// silently treating Dash users as Hive users (and dispatching
+					// dhive lookups against the synthetic 'dash:XYabc...' username).
+					provider: 'dash-instantsend',
 					logout: async () => {
 						_hiveAuthStore.set({ status: 'none' });
 					},

--- a/src/lib/auth/DashLogin.svelte
+++ b/src/lib/auth/DashLogin.svelte
@@ -313,7 +313,7 @@
 					<p>
 						Altera cannot verify the deposit address shown below.
 						{sigVerdict?.kind === 'unsupported'
-							? "Your browser doesn't support the cryptographic check Altera normally uses."
+							? 'Cryptographic verification is unavailable for this session.'
 							: "This Altera build doesn't have its IS-service signer pubkey pinned."}
 					</p>
 					<p>

--- a/src/lib/auth/DashLogin.svelte
+++ b/src/lib/auth/DashLogin.svelte
@@ -304,15 +304,15 @@
 					<p>
 						<strong>Match the 6-character fingerprint shown below
 						against the value your IS-service operator publishes
-						before paying.</strong>
+						before paying.</strong> The canonical source is the
+						same place the operator declares which IS-service
+						Altera should talk to (status page, docs, or
+						out-of-band announcement).
 					</p>
 					<p>
-						The canonical fingerprint should be published on the
-						operator's status page, documentation, or out-of-band
-						announcement channel — the same place the operator
-						declares which IS-service URL Altera should talk to.
-						If you don't have an out-of-band source for it, do not
-						pay — close this dialog and report it.
+						<strong>If the fingerprint does not match, or you
+						don't have a canonical source for it, do not pay</strong>
+						— close this dialog and report it.
 					</p>
 				</div>
 			{/if}

--- a/src/lib/auth/DashLogin.svelte
+++ b/src/lib/auth/DashLogin.svelte
@@ -15,13 +15,16 @@
 	// surface (contract-call deep-link from inside the app's swap flow).
 	const session = createDashSession({ baseUrl: isServiceUrl, op: 'auth' });
 
-	// Round-7 audit R7-CORR-01-altera: clean up the poll interval AND
-	// the R6-SEC-01 post-cancel deadline timer if the component
-	// unmounts (e.g. user navigates away while the modal is open).
-	// session.cancel() is idempotent and runs stopPolling() which
-	// clears both timers.
+	// Round-7 audit R7-CORR-01-altera + round-8 audit R8-CORR-02:
+	// use session.stop() (synchronous teardown) on unmount. The
+	// previous onDestroy(() => cancel()) leaked the pollTimer +
+	// R6-SEC-01 trap-deadline on the 409 / network-error branches
+	// because cancel() intentionally returns early in those cases
+	// without calling stopPolling. stop() marks the session
+	// destroyed AND clears both timers unconditionally — no server
+	// round-trip, no race with begin()'s post-await tail.
 	onDestroy(() => {
-		void session.cancel();
+		session.stop();
 	});
 
 	let close = $state(() => {});

--- a/src/lib/auth/DashLogin.svelte
+++ b/src/lib/auth/DashLogin.svelte
@@ -304,8 +304,15 @@
 					<p>
 						<strong>Match the 6-character fingerprint shown below
 						against the value your IS-service operator publishes
-						before paying.</strong> If the fingerprint doesn't
-						match, do not pay — close this dialog and report it.
+						before paying.</strong>
+					</p>
+					<p>
+						The canonical fingerprint should be published on the
+						operator's status page, documentation, or out-of-band
+						announcement channel — the same place the operator
+						declares which IS-service URL Altera should talk to.
+						If you don't have an out-of-band source for it, do not
+						pay — close this dialog and report it.
 					</p>
 				</div>
 			{/if}

--- a/src/lib/auth/DashLogin.svelte
+++ b/src/lib/auth/DashLogin.svelte
@@ -139,6 +139,16 @@
 			pinnedPubkey: isServiceSignerPubkey
 		}).then((v) => {
 			sigVerdict = v;
+			// Audit R16-OPS-altera-invalid-sig-no-session-cancel (HIGH):
+			// when the verdict is 'invalid' the QR is hidden (see the
+			// {:else if} branch on render), but pre-R16 the underlying
+			// session kept polling /status forever — consuming RC, the
+			// IS service's session-store slot, and dashd-watcher map
+			// space. Cancel the session at the moment the verdict
+			// arrives so the orchestrator releases all of those.
+			if (v?.kind === 'invalid') {
+				void session.cancel();
+			}
 		});
 	});
 
@@ -228,15 +238,28 @@
 	{#snippet content()}
 		{#if session.phase === 'starting' || (session.phase === 'waiting' && !session.startResponse)}
 			<p class="muted">Preparing your session…</p>
+		{:else if session.phase === 'waiting' && session.startResponse && sigVerdict === undefined}
+			<!-- Audit R16-CORR-altera-qr-renders-before-sigverdict-resolved
+				 (MED) + R16-SEC-altera-sig-toctou-pre-verdict-render (LOW):
+				 verifyAddressSignature is async; between session.startResponse
+				 arriving and the promise resolving, sigVerdict is undefined.
+				 Pre-fix the {:else if} for `invalid` evaluated false on
+				 undefined and control fell into the QR-rendering branch
+				 below — so a user on a slow CPU / older browser could scan
+				 + pay BEFORE the verdict arrived, defeating the SEC-2 gate.
+				 Show a verify-pending spinner-equivalent placeholder until
+				 the verdict resolves. -->
+			<p class="muted">Verifying IS-service response…</p>
 		{:else if session.phase === 'waiting' && session.startResponse && sigVerdict?.kind === 'invalid'}
-			<!-- Audit SEC-2 (R15): hard fail-closed when the IS-service
-				 address signature does NOT verify against the pinned
-				 PUBLIC_IS_SERVICE_SIGNER_PUBKEY. Pre-fix the QR + address
-				 still rendered with only an inline red-shield badge — a
-				 user who'd successfully scanned + paid in prior sessions
-				 was nudged toward doing it again. The signer exists
-				 precisely so the client can detect adversary-controlled
-				 IS-service responses; rendering the QR anyway defeats it. -->
+			<!-- Audit SEC-2 (R15) + R16-OPS-altera-invalid-sig-no-session-cancel:
+				 hard fail-closed when the IS-service address signature does
+				 NOT verify against the pinned PUBLIC_IS_SERVICE_SIGNER_PUBKEY.
+				 Pre-fix the QR + address still rendered with only an inline
+				 red-shield badge — a user who'd successfully scanned + paid
+				 in prior sessions was nudged toward doing it again. The
+				 underlying session.cancel() is fired at verdict-resolution
+				 time (see the $effect above) so the orchestrator releases
+				 RC + session-store + watcher state. -->
 			<div class="sig-fail-panel">
 				<p class="sig-fail-title">
 					<ShieldAlert size={16} /> IS-service signature did not verify
@@ -258,6 +281,34 @@
 			</div>
 		{:else if session.phase === 'waiting' && session.startResponse}
 			<p class="muted">Pay the address below from your DashPay wallet via InstantSend.</p>
+			{#if sigVerdict?.kind === 'unsupported' || sigVerdict?.kind === 'unconfigured'}
+				<!-- Audit R16-SEC-altera-sigverdict-unsupported-renders-qr
+					 (MED): when the browser can't run Ed25519 WebCrypto
+					 (older Chrome/Firefox/Safari) OR the operator hasn't
+					 pinned PUBLIC_IS_SERVICE_SIGNER_PUBKEY, the QR still
+					 renders. We don't fail-closed in this branch (it
+					 would brick legitimate older-browser users), but we
+					 elevate the fingerprint check from an inline badge
+					 to a prominent banner so the user can't miss it.
+					 The fingerprint below the QR is the SAME 6-char hash
+					 the operator publishes out-of-band; matching it is
+					 the manual fallback when crypto-verify isn't
+					 available. -->
+				<div class="sig-warn-panel">
+					<p class="sig-warn-title">
+						<ShieldQuestion size={16} />
+						{sigVerdict?.kind === 'unsupported'
+							? 'Cryptographic verification unavailable in this browser'
+							: 'IS-service signer pubkey not pinned'}
+					</p>
+					<p>
+						<strong>Match the 6-character fingerprint shown below
+						against the value your IS-service operator publishes
+						before paying.</strong> If the fingerprint doesn't
+						match, do not pay — close this dialog and report it.
+					</p>
+				</div>
+			{/if}
 			{#if dashUri}
 				<Qr data={dashUri} />
 			{/if}
@@ -444,6 +495,27 @@
 		}
 	}
 	.sig-fail-title {
+		display: flex;
+		align-items: center;
+		gap: 0.4em;
+		font-weight: 600;
+		margin: 0;
+	}
+	.sig-warn-panel {
+		display: flex;
+		flex-direction: column;
+		gap: 0.6em;
+		padding: 0.8em 1em;
+		border: 1px solid rgba(251, 191, 36, 0.5);
+		background: rgba(251, 191, 36, 0.1);
+		border-radius: 4px;
+		color: #facc15;
+		margin-bottom: 0.8em;
+		strong {
+			color: #fde68a;
+		}
+	}
+	.sig-warn-title {
 		display: flex;
 		align-items: center;
 		gap: 0.4em;

--- a/src/lib/auth/DashLogin.svelte
+++ b/src/lib/auth/DashLogin.svelte
@@ -123,8 +123,12 @@
 
 	// Verify the address signature against the pinned IS-service pubkey.
 	// Runs once when the start response arrives; result drives the badge
-	// shown next to the address. When `unconfigured` (no pubkey set),
-	// users still get the 6-char fingerprint check.
+	// shown next to the address. When `unconfigured` (no pubkey set) or
+	// `unsupported` (browser lacks Ed25519 WebCrypto), the panel falls
+	// back to a yellow warn-panel that tells the user crypto-verification
+	// was unavailable — NOT to "match against an operator-published
+	// fingerprint", since the fingerprint is per-session (audit R19-SEC-
+	// fingerprint-warn-panel-no-canonical-source-exists).
 	let sigVerdict = $state<SignatureVerdict | undefined>(undefined);
 	$effect(() => {
 		const r = session.startResponse;
@@ -298,21 +302,21 @@
 					<p class="sig-warn-title">
 						<ShieldQuestion size={16} />
 						{sigVerdict?.kind === 'unsupported'
-							? 'Cryptographic verification unavailable in this browser'
-							: 'IS-service signer pubkey not pinned'}
+							? 'Verification unavailable in this browser'
+							: 'Verification not configured'}
 					</p>
 					<p>
-						Altera could not cryptographically verify the
-						deposit address against the IS-service's signer.
-						The deposit address shown below cannot be
-						automatically authenticated.
+						Altera cannot verify the deposit address shown below.
+						{sigVerdict?.kind === 'unsupported'
+							? "Your browser doesn't support the cryptographic check Altera normally uses."
+							: "This Altera build doesn't have its IS-service signer pubkey pinned."}
 					</p>
 					<p>
-						<strong>Only proceed if you trust this Altera
-						deployment and the IS-service URL it talks to.</strong>
-						If the URL in your address bar isn't the one you
-						expect, or anything else about this dialog looks
-						wrong, do not pay — close this dialog and report it.
+						<strong>Only proceed if you trust this website and
+						its operator.</strong> Check the website name (in
+						the URL bar on desktop, or your in-app browser
+						title) — if anything looks unfamiliar, do not pay.
+						Close this dialog and report it.
 					</p>
 				</div>
 			{/if}
@@ -328,8 +332,18 @@
 							><ShieldCheck size={12} /> verified</span
 						>
 					{:else if sigVerdict?.kind === 'unconfigured' || sigVerdict?.kind === 'unsupported'}
-						<span class="sig sig-unknown" title="fall back to fingerprint check"
-							><ShieldQuestion size={12} /> check fingerprint</span
+						<!-- Audit R20-CORR-altera-check-fingerprint-badge-
+							 implies-security-check + R20-OPS-dashlogin-badge-
+							 tooltip-and-text-still-say-fall-back-to-
+							 fingerprint: the badge used to read "fall back to
+							 fingerprint check", implying the fingerprint
+							 provides a meaningful security gate. Per R19 the
+							 fingerprint is session-internal only — no static
+							 operator-published value to compare against. Badge
+							 now reads "not verified" with a tooltip that
+							 names the actual situation. -->
+						<span class="sig sig-unknown" title="cryptographic verification unavailable — see warning above"
+							><ShieldQuestion size={12} /> not verified</span
 						>
 					{/if}
 				</dd>

--- a/src/lib/auth/DashLogin.svelte
+++ b/src/lib/auth/DashLogin.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import PillButton from '$lib/PillButton.svelte';
 	import Dialog from '$lib/zag/Dialog.svelte';
 	import Qr from '$lib/zag/QR.svelte';
@@ -13,6 +14,15 @@
 	// Component-local. We only support op=auth here; op=call is a future
 	// surface (contract-call deep-link from inside the app's swap flow).
 	const session = createDashSession({ baseUrl: isServiceUrl, op: 'auth' });
+
+	// Round-7 audit R7-CORR-01-altera: clean up the poll interval AND
+	// the R6-SEC-01 post-cancel deadline timer if the component
+	// unmounts (e.g. user navigates away while the modal is open).
+	// session.cancel() is idempotent and runs stopPolling() which
+	// clears both timers.
+	onDestroy(() => {
+		void session.cancel();
+	});
 
 	let close = $state(() => {});
 

--- a/src/lib/auth/DashLogin.svelte
+++ b/src/lib/auth/DashLogin.svelte
@@ -1,0 +1,242 @@
+<script lang="ts">
+	import PillButton from '$lib/PillButton.svelte';
+	import Dialog from '$lib/zag/Dialog.svelte';
+	import Qr from '$lib/zag/QR.svelte';
+	import { ArrowRight, RefreshCw } from '@lucide/svelte';
+	import { isServiceUrl } from './dash/config';
+	import { createDashSession } from './dash/session.svelte';
+	import { addressFingerprint, buildDashUri, type IsSessionState } from './dash/isClient';
+	import { _hiveAuthStore } from './store';
+
+	// Component-local. We only support op=auth here; op=call is a future
+	// surface (contract-call deep-link from inside the app's swap flow).
+	const session = createDashSession({ baseUrl: isServiceUrl, op: 'auth' });
+
+	let close = $state(() => {});
+
+	// When the user opens the modal, kick off a session. When they close
+	// it via X / Esc / overlay click, the Dialog's toggle handler fires
+	// cancel. We track open state through Dialog's open binding.
+	let open = $state(false);
+	$effect(() => {
+		if (open && session.phase === 'idle') {
+			void session.begin();
+		}
+		if (!open && session.phase === 'waiting') {
+			// User closed mid-flow — best-effort cancel server-side.
+			void session.cancel();
+		}
+	});
+
+	// When the session reaches ON_CHAIN, hand the sessionToken to the
+	// auth store as a DashDID identity. The auth store consumer (root
+	// layout + protected routes) treats this as the logged-in subject.
+	$effect(() => {
+		if (session.phase === 'done' && session.status?.sessionToken && session.status?.dashTxId) {
+			const token = session.status.sessionToken;
+			const txid = session.status.dashTxId;
+			// We don't (yet) know the user's Dash L1 address from the
+			// status response — the IS service has it (it's in the rawTx),
+			// but doesn't surface it back. For v1 we use the txid as the
+			// identity anchor; the dashboard fills in the L1 address from
+			// the dash-mapping-contract state via DashDID -> address.
+			_hiveAuthStore.set({
+				status: 'authenticated',
+				value: {
+					username: 'dash:' + txid.slice(0, 8),
+					address: 'did:vsc:dash:' + txid,
+					did: 'did:vsc:dash:' + txid,
+					provider: 'aioha',
+					logout: async () => {
+						_hiveAuthStore.set({ status: 'none' });
+					},
+					openSettings: () => {},
+					profilePicUrl: undefined
+				}
+			});
+			close();
+		}
+	});
+
+	const stateLabel = $derived(humanState(session.status?.state));
+	const requiredDash = $derived(
+		session.startResponse
+			? (session.startResponse.requiredAmountDuffs / 1e8).toFixed(8)
+			: undefined
+	);
+	const fingerprint = $derived(
+		session.startResponse ? addressFingerprint(session.startResponse.addressSignature) : undefined
+	);
+	const dashUri = $derived(
+		session.startResponse
+			? buildDashUri(session.startResponse.depositAddress, session.startResponse.requiredAmountDuffs)
+			: undefined
+	);
+
+	function humanState(s: IsSessionState | undefined): string {
+		if (!s) return 'Preparing…';
+		switch (s) {
+			case 'WAITING_FOR_IS':
+				return 'Waiting for InstantSend payment';
+			case 'IS_OBSERVED':
+				return 'Payment seen, gathering validator signatures…';
+			case 'ATTESTING':
+				return 'Gathering validator signatures…';
+			case 'ON_CHAIN':
+				return 'Logged in';
+			case 'ATTESTATION_TIMEOUT':
+				return 'Validators did not respond in time';
+			case 'SLOW_PATH_PENDING':
+				return 'Falling back to slow path (mined-block proof)';
+			case 'FORWARD_FAILED':
+				return 'On-chain step failed';
+			case 'EXPIRED':
+				return 'Session expired';
+		}
+	}
+
+	async function retry() {
+		await session.cancel();
+		// createDashSession is closed-over; re-create on retry to reset
+		// state cleanly. Svelte will re-run the open effect.
+		open = false;
+		setTimeout(() => {
+			open = true;
+		}, 50);
+	}
+</script>
+
+<Dialog bind:toggle={close} bind:open>
+	Sign in with DashPay
+	{#snippet title()}
+		Sign in with DashPay
+	{/snippet}
+
+	{#snippet content()}
+		{#if session.phase === 'starting' || (session.phase === 'waiting' && !session.startResponse)}
+			<p class="muted">Preparing your session…</p>
+		{:else if session.phase === 'waiting' && session.startResponse}
+			<p class="muted">Pay the address below from your DashPay wallet via InstantSend.</p>
+			{#if dashUri}
+				<Qr data={dashUri} />
+			{/if}
+			<dl class="meta">
+				<dt>Address</dt>
+				<dd class="mono">{session.startResponse.depositAddress}</dd>
+				<dt>Fingerprint</dt>
+				<dd class="mono">{fingerprint}</dd>
+				<dt>Amount</dt>
+				<dd>{requiredDash} DASH</dd>
+				<dt>Status</dt>
+				<dd>{stateLabel}</dd>
+			</dl>
+			<p class="footnote">
+				The fingerprint should match the value Altera shows in its docs. If it doesn't, do
+				not pay — close this dialog and report the discrepancy.
+			</p>
+		{:else if session.phase === 'done'}
+			<p>Signed in. Redirecting…</p>
+		{:else if session.phase === 'failed'}
+			<p class="error">{session.error ?? 'Login failed.'}</p>
+			<PillButton onclick={retry} theme="primary" styleType="outline">
+				<RefreshCw size={14} /> Try again
+			</PillButton>
+		{/if}
+	{/snippet}
+</Dialog>
+
+<div class="trigger" onclick={() => (open = true)} role="button" tabindex="0" onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') open = true; }}>
+	<div class="trigger-left">
+		<img src="/dash/dash-logo.svg" alt="" class="trigger-icon" />
+		<div class="trigger-text">
+			<span class="trigger-label">DashPay</span>
+			<span class="trigger-hint">InstantSend login · no signing needed</span>
+		</div>
+	</div>
+	<ArrowRight size={16} class="trigger-arrow" />
+</div>
+
+<style lang="scss">
+	.trigger {
+		position: relative;
+		width: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 0.875rem 1rem;
+		background: #1a1f35;
+		border: 1px solid rgba(255, 255, 255, 0.08);
+		border-radius: 12px;
+		cursor: pointer;
+		transition:
+			border-color 0.15s ease,
+			box-shadow 0.15s ease;
+		box-sizing: border-box;
+		&:hover {
+			border-color: rgba(0, 142, 219, 0.5);
+			box-shadow: 0 0 20px rgba(0, 142, 219, 0.1);
+		}
+		&:focus-visible {
+			outline: 2px solid rgba(0, 142, 219, 0.5);
+			outline-offset: 2px;
+		}
+	}
+	.trigger-left {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		color: rgba(255, 255, 255, 0.6);
+	}
+	.trigger-icon {
+		width: 20px;
+		height: 20px;
+		filter: brightness(1.1);
+	}
+	.trigger-text {
+		display: flex;
+		flex-direction: column;
+	}
+	.trigger-label {
+		font-weight: 600;
+		font-size: 0.9rem;
+		color: var(--dash-text-primary, white);
+	}
+	.trigger-hint {
+		font-size: 0.65rem;
+		color: rgba(255, 255, 255, 0.3);
+		margin-top: 0.1rem;
+	}
+
+	.muted {
+		color: var(--dash-text-secondary, rgba(255, 255, 255, 0.5));
+		text-align: center;
+	}
+	.meta {
+		display: grid;
+		grid-template-columns: max-content 1fr;
+		gap: 0.25rem 0.75rem;
+		font-size: 0.85rem;
+		margin: 0.75rem 0 0.5rem;
+	}
+	.meta dt {
+		color: var(--dash-text-muted, rgba(255, 255, 255, 0.4));
+	}
+	.meta dd {
+		margin: 0;
+		color: var(--dash-text-primary, white);
+		overflow-wrap: anywhere;
+	}
+	.mono {
+		font-family: 'Noto Sans Mono Variable', ui-monospace, monospace;
+	}
+	.footnote {
+		font-size: 0.7rem;
+		color: var(--dash-text-muted, rgba(255, 255, 255, 0.35));
+		margin: 0.5rem 0 0;
+	}
+	.error {
+		color: #fda4af;
+		text-align: center;
+		margin: 0.5rem 0 1rem;
+	}
+</style>

--- a/src/lib/auth/DashLogin.svelte
+++ b/src/lib/auth/DashLogin.svelte
@@ -3,10 +3,11 @@
 	import Dialog from '$lib/zag/Dialog.svelte';
 	import Qr from '$lib/zag/QR.svelte';
 	import { ArrowRight, RefreshCw, ShieldAlert, ShieldCheck, ShieldQuestion } from '@lucide/svelte';
-	import { isServiceUrl, isServiceSignerPubkey } from './dash/config';
+	import { isServiceUrl, isServiceSignerPubkey, dashNetwork } from './dash/config';
 	import { createDashSession } from './dash/session.svelte';
 	import { addressFingerprint, buildDashUri, type IsSessionState } from './dash/isClient';
 	import { verifyAddressSignature, type SignatureVerdict } from './dash/signature';
+	import { buildDashDID } from './dashCaip';
 	import { _hiveAuthStore } from './store';
 
 	// Component-local. We only support op=auth here; op=call is a future
@@ -32,23 +33,33 @@
 	// When the session reaches ON_CHAIN, hand the sessionToken to the
 	// auth store as a DashDID identity. The auth store consumer (root
 	// layout + protected routes) treats this as the logged-in subject.
+	//
+	// Audit D2-DESIGN-01: the DID format MUST be
+	//   did:pkh:bip122:<chain-genesis-hex>:<address>
+	// matching go-vsc-node lib/dids/dash.go + the dash-mapping-contract's
+	// dashGenesisCAIP2Hex helper. The earlier literal-"dash" form
+	// produced a different string for the same user, so every Altera
+	// screen reading state by auth.value.did returned empty zero.
+	// If senderAddress is absent (rare — contract would reject the
+	// underlying tx anyway), we fail loudly instead of building a
+	// malformed DID with a txid in the address slot.
 	$effect(() => {
 		if (session.phase === 'done' && session.status?.sessionToken && session.status?.dashTxId) {
-			const txid = session.status.dashTxId;
 			const senderAddr = session.status.senderAddress;
-			// Prefer the L1 Dash address (surfaced from IS_OBSERVED onwards)
-			// as the identity anchor. Fall back to the txid only when the
-			// IS service couldn't resolve the sender (multi-address inputs
-			// or unsupported script type — both already get rejected by
-			// the contract, but the UI shouldn't crash on the fallback path).
-			const idAnchor = senderAddr ?? txid;
-			const username = senderAddr ? 'dash:' + senderAddr.slice(0, 8) : 'dash:' + txid.slice(0, 8);
+			if (!senderAddr) {
+				console.error(
+					'DashLogin: ON_CHAIN reached but senderAddress missing in /status — refusing to issue a malformed DID. Cancelling.'
+				);
+				void session.cancel();
+				return;
+			}
+			const did = buildDashDID(dashNetwork, senderAddr);
 			_hiveAuthStore.set({
 				status: 'authenticated',
 				value: {
-					username,
-					address: 'did:pkh:bip122:dash:' + idAnchor,
-					did: 'did:pkh:bip122:dash:' + idAnchor,
+					username: 'dash:' + senderAddr.slice(0, 8),
+					address: did,
+					did,
 					provider: 'aioha',
 					logout: async () => {
 						_hiveAuthStore.set({ status: 'none' });

--- a/src/lib/auth/DashLogin.svelte
+++ b/src/lib/auth/DashLogin.svelte
@@ -23,7 +23,19 @@
 	// without calling stopPolling. stop() marks the session
 	// destroyed AND clears both timers unconditionally — no server
 	// round-trip, no race with begin()'s post-await tail.
+	//
+	// Round-11 audit R11-INFO-RETRY-50MS-TIMER-LEAK-01: also clear
+	// the retry()'s 50ms close-then-open setTimeout. The
+	// destroyed-guard in session.begin() already protects against
+	// the late callback firing on a torn-down session, but
+	// clearing the timer prevents the setTimeout closure from
+	// holding onto component state past unmount.
+	let retryTimer: ReturnType<typeof setTimeout> | undefined;
 	onDestroy(() => {
+		if (retryTimer !== undefined) {
+			clearTimeout(retryTimer);
+			retryTimer = undefined;
+		}
 		session.stop();
 	});
 
@@ -192,9 +204,15 @@
 		// tight loop against a fast-rejecting server. The 50ms
 		// close/open is preserved for UX (visible reset feedback);
 		// the begin() call is what actually restarts the session.
+		//
+		// Round-11 audit R11-INFO-RETRY-50MS-TIMER-LEAK-01: track
+		// the timer handle so onDestroy can clear it if the user
+		// unmounts within 50ms of clicking Try again.
 		await session.cancel();
 		open = false;
-		setTimeout(() => {
+		if (retryTimer !== undefined) clearTimeout(retryTimer);
+		retryTimer = setTimeout(() => {
+			retryTimer = undefined;
 			open = true;
 			void session.begin();
 		}, 50);
@@ -246,15 +264,13 @@
 			</dl>
 			{#if session.postCancelConflict}
 				<!-- Round-10 audit R10-DRIFT-DASHSESSION-UNUSED-PROPS:
-					 surface the R6-SEC-01 post-cancel-conflict banner
-					 so the user understands why the modal is still
-					 spinning after they clicked cancel: the server
-					 was mid-attestation and is finishing the on-chain
-					 step. Auto-clears when a terminal state arrives or
-					 the trap-deadline fires. -->
+					 surface the R6-SEC-01 post-cancel-conflict banner.
+					 Round-11 audit R11-OPS-BANNER-COPY-01 dropped the
+					 'validator attestation' / 'on-chain step' jargon
+					 in favour of plain language at frustration-peak. -->
 				<p class="muted">
-					Cancel acknowledged. The validator attestation has already
-					started — finishing the on-chain step before unwinding…
+					Almost done — your sign-in is finishing the current step
+					before it can be cancelled. This usually takes a few seconds.
 				</p>
 			{/if}
 			<p class="footnote">

--- a/src/lib/auth/dash/config.ts
+++ b/src/lib/auth/dash/config.ts
@@ -22,3 +22,12 @@ export const isServiceUrl: string =
  * before mainnet.
  */
 export const isServiceSignerPubkey: string = publicEnv.PUBLIC_IS_SERVICE_SIGNER_PUBKEY || '';
+
+/**
+ * Which Dash network the IS service binds to. Drives the
+ * CAIP-2-genesis-hex prefix used in the DashDID. Defaults to testnet to
+ * match the default isServiceUrl. Set via PUBLIC_DASH_NETWORK.
+ */
+export const dashNetwork: 'mainnet' | 'testnet' =
+	publicEnv.PUBLIC_DASH_NETWORK === 'mainnet' ? 'mainnet' : 'testnet';
+

--- a/src/lib/auth/dash/config.ts
+++ b/src/lib/auth/dash/config.ts
@@ -1,0 +1,24 @@
+import { env as publicEnv } from '$env/dynamic/public';
+
+/**
+ * Base URL for the Magi IS-service (DashPay InstantSend login). Override
+ * via PUBLIC_IS_SERVICE_URL when deploying against a non-default host
+ * (e.g. staging). When unset, defaults to the testnet IS service.
+ *
+ * Production main-net wiring will fall back to the prod host once the
+ * Magi witness fleet finishes wiring the libp2p-attestation flow in.
+ */
+export const isServiceUrl: string =
+	publicEnv.PUBLIC_IS_SERVICE_URL || 'https://is-service-testnet.okinoko.io';
+
+/**
+ * Pinned IS-service public key (hex, BLS or ECDSA depending on what the
+ * Go service hands us per §5.7). The browser uses it to verify the
+ * `addressSignature` field returned by /session/start.
+ *
+ * v1 ships with a placeholder — when unset OR equal to the placeholder
+ * sentinel, the frontend falls back to the address-fingerprint visual
+ * check (see addressFingerprint in isClient.ts). Both should be wired
+ * before mainnet.
+ */
+export const isServiceSignerPubkey: string = publicEnv.PUBLIC_IS_SERVICE_SIGNER_PUBKEY || '';

--- a/src/lib/auth/dash/config.ts
+++ b/src/lib/auth/dash/config.ts
@@ -27,38 +27,74 @@ export const isServiceSignerPubkey: string = publicEnv.PUBLIC_IS_SERVICE_SIGNER_
  * Which Dash network the IS service binds to. Drives the
  * CAIP-2-genesis-hex prefix used in the DashDID.
  *
- * Round-3 audit OP-009: cross-checks against PUBLIC_IS_SERVICE_URL. A
- * mainnet deploy that forgot to set PUBLIC_DASH_NETWORK previously
- * silently fell back to testnet — every Dash user then authenticated
- * into the wrong-DID namespace against the mainnet contract. This
- * module now throws at module load if env is inconsistent so the
- * misconfig surfaces at deploy time, not on first user login.
+ * Round-3 audit OP-009: cross-checks against PUBLIC_IS_SERVICE_URL.
+ * Round-4 audit R4-CSM-08: replaced the substring 'testnet' heuristic
+ * with an explicit allow-list of known testnet host suffixes. The old
+ * heuristic both false-positived (a mainnet host with 'testnet' in a
+ * path) and false-negatived (a testnet host without the literal
+ * substring, e.g. is.staging-magi.example).
+ *
+ * The single source-of-truth for network resolution is now
+ * PUBLIC_DASH_NETWORK; the URL check is best-effort defense in depth
+ * and runs only when the hostname matches one of the known suffixes.
  */
+const TESTNET_HOST_SUFFIXES = [
+	'is-service-testnet.okinoko.io',
+	'.testnet.okinoko.io',
+	'.dev.okinoko.io'
+];
+
+const MAINNET_HOST_SUFFIXES: string[] = [
+	// Populate post-mainnet-cutover; v1 mainnet host TBD.
+];
+
+function urlHostnameSuffixMatches(url: string, suffixes: string[]): boolean {
+	let hostname: string;
+	try {
+		hostname = new URL(url).hostname.toLowerCase();
+	} catch {
+		return false;
+	}
+	return suffixes.some((s) => {
+		const norm = s.toLowerCase();
+		if (norm.startsWith('.')) return hostname.endsWith(norm) || hostname === norm.slice(1);
+		return hostname === norm;
+	});
+}
+
 function resolveDashNetwork(): 'mainnet' | 'testnet' {
 	const raw = publicEnv.PUBLIC_DASH_NETWORK;
-	const urlLooksTestnet = isServiceUrl.includes('testnet');
 	let network: 'mainnet' | 'testnet';
 	if (raw === 'mainnet') {
 		network = 'mainnet';
-	} else if (raw === 'testnet' || raw === undefined || raw === '') {
+	} else if (raw === 'testnet') {
 		network = 'testnet';
+	} else if (raw === undefined || raw === '') {
+		// Operator must set the network explicitly. The previous
+		// silent-fall-back-to-testnet caused mainnet deploys to issue
+		// wrong-DID-namespace identities.
+		throw new Error(
+			`PUBLIC_DASH_NETWORK must be set explicitly to 'mainnet' or 'testnet'. ` +
+				`No default is safe: mainnet defaults silently fall back to testnet, ` +
+				`which authenticates users into the wrong-DID namespace.`
+		);
 	} else {
 		throw new Error(
 			`PUBLIC_DASH_NETWORK must be 'mainnet' or 'testnet'; got ${JSON.stringify(raw)}`
 		);
 	}
-	if (urlLooksTestnet && network === 'mainnet') {
+	const urlMatchesTestnet = urlHostnameSuffixMatches(isServiceUrl, TESTNET_HOST_SUFFIXES);
+	const urlMatchesMainnet = urlHostnameSuffixMatches(isServiceUrl, MAINNET_HOST_SUFFIXES);
+	if (urlMatchesTestnet && network === 'mainnet') {
 		throw new Error(
-			`PUBLIC_DASH_NETWORK=mainnet but PUBLIC_IS_SERVICE_URL (${isServiceUrl}) looks like a testnet host. ` +
-				`Set PUBLIC_IS_SERVICE_URL to a mainnet IS-service endpoint, or set PUBLIC_DASH_NETWORK=testnet.`
+			`PUBLIC_DASH_NETWORK=mainnet but PUBLIC_IS_SERVICE_URL (${isServiceUrl}) ` +
+				`matches a known testnet host suffix. Fix one of the two.`
 		);
 	}
-	if (!urlLooksTestnet && network === 'testnet' && raw !== 'testnet') {
-		// URL looks mainnet but network defaulted to testnet because
-		// PUBLIC_DASH_NETWORK is unset. Force operator intent.
+	if (urlMatchesMainnet && network === 'testnet') {
 		throw new Error(
-			`PUBLIC_IS_SERVICE_URL (${isServiceUrl}) doesn't look like a testnet host but ` +
-				`PUBLIC_DASH_NETWORK is unset. Set PUBLIC_DASH_NETWORK=mainnet (or testnet) explicitly.`
+			`PUBLIC_DASH_NETWORK=testnet but PUBLIC_IS_SERVICE_URL (${isServiceUrl}) ` +
+				`matches a known mainnet host suffix. Fix one of the two.`
 		);
 	}
 	return network;

--- a/src/lib/auth/dash/config.ts
+++ b/src/lib/auth/dash/config.ts
@@ -25,9 +25,43 @@ export const isServiceSignerPubkey: string = publicEnv.PUBLIC_IS_SERVICE_SIGNER_
 
 /**
  * Which Dash network the IS service binds to. Drives the
- * CAIP-2-genesis-hex prefix used in the DashDID. Defaults to testnet to
- * match the default isServiceUrl. Set via PUBLIC_DASH_NETWORK.
+ * CAIP-2-genesis-hex prefix used in the DashDID.
+ *
+ * Round-3 audit OP-009: cross-checks against PUBLIC_IS_SERVICE_URL. A
+ * mainnet deploy that forgot to set PUBLIC_DASH_NETWORK previously
+ * silently fell back to testnet — every Dash user then authenticated
+ * into the wrong-DID namespace against the mainnet contract. This
+ * module now throws at module load if env is inconsistent so the
+ * misconfig surfaces at deploy time, not on first user login.
  */
-export const dashNetwork: 'mainnet' | 'testnet' =
-	publicEnv.PUBLIC_DASH_NETWORK === 'mainnet' ? 'mainnet' : 'testnet';
+function resolveDashNetwork(): 'mainnet' | 'testnet' {
+	const raw = publicEnv.PUBLIC_DASH_NETWORK;
+	const urlLooksTestnet = isServiceUrl.includes('testnet');
+	let network: 'mainnet' | 'testnet';
+	if (raw === 'mainnet') {
+		network = 'mainnet';
+	} else if (raw === 'testnet' || raw === undefined || raw === '') {
+		network = 'testnet';
+	} else {
+		throw new Error(
+			`PUBLIC_DASH_NETWORK must be 'mainnet' or 'testnet'; got ${JSON.stringify(raw)}`
+		);
+	}
+	if (urlLooksTestnet && network === 'mainnet') {
+		throw new Error(
+			`PUBLIC_DASH_NETWORK=mainnet but PUBLIC_IS_SERVICE_URL (${isServiceUrl}) looks like a testnet host. ` +
+				`Set PUBLIC_IS_SERVICE_URL to a mainnet IS-service endpoint, or set PUBLIC_DASH_NETWORK=testnet.`
+		);
+	}
+	if (!urlLooksTestnet && network === 'testnet' && raw !== 'testnet') {
+		// URL looks mainnet but network defaulted to testnet because
+		// PUBLIC_DASH_NETWORK is unset. Force operator intent.
+		throw new Error(
+			`PUBLIC_IS_SERVICE_URL (${isServiceUrl}) doesn't look like a testnet host but ` +
+				`PUBLIC_DASH_NETWORK is unset. Set PUBLIC_DASH_NETWORK=mainnet (or testnet) explicitly.`
+		);
+	}
+	return network;
+}
+export const dashNetwork: 'mainnet' | 'testnet' = resolveDashNetwork();
 

--- a/src/lib/auth/dash/config.ts
+++ b/src/lib/auth/dash/config.ts
@@ -110,17 +110,16 @@ function resolveDashNetwork(): 'mainnet' | 'testnet' {
  * rather than a global hard-crash.
  */
 let _dashNetwork: 'mainnet' | 'testnet' | undefined;
-let _dashNetworkError: Error | undefined;
 export function getDashNetwork(): 'mainnet' | 'testnet' {
 	if (_dashNetwork !== undefined) return _dashNetwork;
-	if (_dashNetworkError !== undefined) throw _dashNetworkError;
-	try {
-		_dashNetwork = resolveDashNetwork();
-		return _dashNetwork;
-	} catch (e) {
-		_dashNetworkError = e instanceof Error ? e : new Error(String(e));
-		throw _dashNetworkError;
-	}
+	// Round-6 audit R6-OP-02: don't cache the error. A misconfig +
+	// hot-reload (or operator fix-without-tab-reload) used to leave
+	// every subsequent call throwing the cached error forever. Now
+	// each call re-runs resolveDashNetwork; the success path still
+	// memoizes via _dashNetwork. Throws are cheap (string compares).
+	const v = resolveDashNetwork();
+	_dashNetwork = v;
+	return v;
 }
 
 

--- a/src/lib/auth/dash/config.ts
+++ b/src/lib/auth/dash/config.ts
@@ -44,8 +44,16 @@ const TESTNET_HOST_SUFFIXES = [
 	'.dev.okinoko.io'
 ];
 
+// Mirrors the testnet naming pattern minus the `-testnet` suffix.
+// If the production deployment picks a different hostname (e.g.
+// `is.okinoko.io` or behind a CDN like `is.magi.eco`), update this
+// list at the same time as flipping the production env's
+// PUBLIC_IS_SERVICE_URL — resolveDashNetwork cross-checks
+// PUBLIC_DASH_NETWORK against this suffix list and will throw
+// at first /login render if they disagree.
 const MAINNET_HOST_SUFFIXES: string[] = [
-	// Populate post-mainnet-cutover; v1 mainnet host TBD.
+	'is-service.okinoko.io',
+	'.mainnet.okinoko.io',
 ];
 
 function urlHostnameSuffixMatches(url: string, suffixes: string[]): boolean {

--- a/src/lib/auth/dash/config.ts
+++ b/src/lib/auth/dash/config.ts
@@ -99,5 +99,28 @@ function resolveDashNetwork(): 'mainnet' | 'testnet' {
 	}
 	return network;
 }
-export const dashNetwork: 'mainnet' | 'testnet' = resolveDashNetwork();
+
+/**
+ * Lazy-resolved dashNetwork — round-5 audit R5-OP-01. The previous
+ * module-load throw blew up /login on every existing Altera deploy
+ * the moment R4-CSM-08 landed, before operators could update env. The
+ * resolver still throws on misconfig but only when DashLogin actually
+ * needs the value (first read calls getDashNetwork()), so unrelated
+ * routes keep working and the failure mode is a single broken modal
+ * rather than a global hard-crash.
+ */
+let _dashNetwork: 'mainnet' | 'testnet' | undefined;
+let _dashNetworkError: Error | undefined;
+export function getDashNetwork(): 'mainnet' | 'testnet' {
+	if (_dashNetwork !== undefined) return _dashNetwork;
+	if (_dashNetworkError !== undefined) throw _dashNetworkError;
+	try {
+		_dashNetwork = resolveDashNetwork();
+		return _dashNetwork;
+	} catch (e) {
+		_dashNetworkError = e instanceof Error ? e : new Error(String(e));
+		throw _dashNetworkError;
+	}
+}
+
 

--- a/src/lib/auth/dash/config.ts
+++ b/src/lib/auth/dash/config.ts
@@ -17,9 +17,14 @@ export const isServiceUrl: string =
  * `addressSignature` field returned by /session/start.
  *
  * v1 ships with a placeholder — when unset OR equal to the placeholder
- * sentinel, the frontend falls back to the address-fingerprint visual
- * check (see addressFingerprint in isClient.ts). Both should be wired
- * before mainnet.
+ * sentinel, verifyAddressSignature returns `kind = 'unconfigured'`,
+ * which triggers DashLogin's yellow warn-panel: the panel surfaces
+ * that cryptographic verification was unavailable for this session,
+ * NOT a comparison directive (the address-fingerprint is per-session
+ * and has no static published value to compare against — audit
+ * R19-SEC-fingerprint-warn-panel-no-canonical-source-exists). Pinning
+ * this pubkey before mainnet is the only way to get the green
+ * 'verified' badge + the fail-closed 'invalid' branch active.
  */
 export const isServiceSignerPubkey: string = publicEnv.PUBLIC_IS_SERVICE_SIGNER_PUBKEY || '';
 

--- a/src/lib/auth/dash/isClient.ts
+++ b/src/lib/auth/dash/isClient.ts
@@ -119,23 +119,49 @@ export class IsServiceError extends Error {
 	}
 }
 
+// Round-9 audit R9-SEC-01 + R9-SEC-02: a malicious / misbehaving IS
+// service that accepts TCP then withholds the response body would
+// previously keep the fetch promise pending indefinitely — pinning
+// session.svelte.ts in cancelling=true (per R8-CORR-02 guard),
+// piling concurrent /status polls past the browser per-host limit,
+// or trapping startSession in phase='starting' forever. Every fetch
+// in this client now runs with an AbortController so a hostile peer
+// cannot prevent the timeout from firing client-side.
+const FETCH_TIMEOUT_START_MS = 15_000;
+const FETCH_TIMEOUT_STATUS_MS = 30_000;
+const FETCH_TIMEOUT_CANCEL_MS = 30_000;
+
+async function fetchWithTimeout(input: RequestInfo, init: RequestInit, timeoutMs: number): Promise<Response> {
+	const ctrl = new AbortController();
+	const t = setTimeout(() => ctrl.abort(), timeoutMs);
+	try {
+		return await fetch(input, { ...init, signal: ctrl.signal });
+	} finally {
+		clearTimeout(t);
+	}
+}
+
 export class IsServiceClient {
 	constructor(private readonly baseUrl: string) {
 		this.baseUrl = baseUrl.replace(/\/+$/, '');
 	}
 
 	async startSession(req: SessionStartRequest): Promise<SessionStartResponse> {
-		const resp = await fetch(`${this.baseUrl}/session/start`, {
+		const resp = await fetchWithTimeout(`${this.baseUrl}/session/start`, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify(req)
-		});
+		}, FETCH_TIMEOUT_START_MS);
 		if (!resp.ok) throw await this.errFromResp(resp);
 		return (await resp.json()) as SessionStartResponse;
 	}
 
 	async getStatus(sid: string): Promise<SessionStatusResponse> {
-		const resp = await fetch(`${this.baseUrl}/session/${encodeURIComponent(sid)}/status`);
+		const resp = await fetchWithTimeout(
+			`${this.baseUrl}/session/${encodeURIComponent(sid)}/status`,
+			{},
+			FETCH_TIMEOUT_STATUS_MS
+		);
 		if (!resp.ok) throw await this.errFromResp(resp);
 		return (await resp.json()) as SessionStatusResponse;
 	}
@@ -146,19 +172,31 @@ export class IsServiceClient {
 	 * (see handlers.go handleSessionCancel). Round-2 audit TC2-01
 	 * caught the original token-less call returning 401 silently and
 	 * leaking the watcher entry until TTL.
+	 *
+	 * Round-9 audit R9-SEC-01: this fetch runs under an
+	 * AbortController with a 30s timeout. An IS service that accepts
+	 * TCP then never replies surfaces as 'error' (AbortError caught
+	 * below) instead of pinning cancelling=true forever in
+	 * session.svelte.ts.
 	 */
 	async cancel(sid: string, cancelToken: string): Promise<CancelResult> {
 		let resp: Response;
 		try {
-			resp = await fetch(`${this.baseUrl}/session/${encodeURIComponent(sid)}/cancel`, {
-				method: 'POST',
-				headers: { 'X-Cancel-Token': cancelToken }
-			});
+			resp = await fetchWithTimeout(
+				`${this.baseUrl}/session/${encodeURIComponent(sid)}/cancel`,
+				{
+					method: 'POST',
+					headers: { 'X-Cancel-Token': cancelToken }
+				},
+				FETCH_TIMEOUT_CANCEL_MS
+			);
 		} catch {
-			// Round-7 audit R7-DRIFT-02: catch the network error
-			// inside the client so the result type is the single
-			// source of truth — callers don't need a parallel
-			// try/catch path to handle the equivalent semantic.
+			// Round-7 audit R7-DRIFT-02 / round-9 R9-SEC-01: catch
+			// both network errors AND AbortController timeouts here
+			// so the result type is the single source of truth.
+			// Callers (session.svelte.ts cancel()) treat 'error' the
+			// same as 'in-flight-conflict' — keep polling under the
+			// R6-SEC-01 trap-deadline.
 			return 'error';
 		}
 		// Round-5 audit R5-002 / R5-DRIFT-02: 409 Conflict is the

--- a/src/lib/auth/dash/isClient.ts
+++ b/src/lib/auth/dash/isClient.ts
@@ -135,9 +135,12 @@ const FETCH_TIMEOUT_CANCEL_MS = 30_000;
 /**
  * fetchAndParse runs fetch() + a caller-supplied parse() step under a
  * single AbortController whose timer covers BOTH phases. The signal
- * can be externally supplied (R10-CORR-ORPHAN-SESSION-01 — so stop()
- * can abort an in-flight startSession by aborting its own
- * controller) and is composed via AbortSignal.any.
+ * is composed with an optional externalSignal (R10-CORR-ORPHAN-SESSION-01
+ * — so stop() can abort an in-flight startSession by aborting its own
+ * controller). Round-11 audit R11-INFO-DOCSTRING-DRIFT-ABORTSIGNAL-ANY
+ * + R11-INFO-FETCH-AND-PARSE-EXT-SIGNAL-ALREADY-ABORTED aligned the
+ * implementation with the docstring's AbortSignal.any framing and
+ * added an early bail when the external signal is already aborted.
  */
 async function fetchAndParse<T>(
 	input: RequestInfo,
@@ -146,12 +149,16 @@ async function fetchAndParse<T>(
 	parse: (resp: Response) => Promise<T>,
 	externalSignal?: AbortSignal
 ): Promise<T> {
+	// Pre-aborted external signal → reject synchronously instead of
+	// wiring up an AbortController + setTimeout we'll never use.
+	if (externalSignal?.aborted) {
+		throw new DOMException('aborted', 'AbortError');
+	}
 	const ctrl = new AbortController();
 	const t = setTimeout(() => ctrl.abort(), timeoutMs);
 	const onExternalAbort = () => ctrl.abort();
 	if (externalSignal) {
-		if (externalSignal.aborted) ctrl.abort();
-		else externalSignal.addEventListener('abort', onExternalAbort);
+		externalSignal.addEventListener('abort', onExternalAbort);
 	}
 	try {
 		const resp = await fetch(input, { ...init, signal: ctrl.signal });
@@ -191,7 +198,14 @@ export class IsServiceClient {
 		);
 	}
 
-	async getStatus(sid: string): Promise<SessionStatusResponse> {
+	/**
+	 * getStatus accepts an optional externalSignal. Round-11 audit
+	 * R11-INFO-GETSTATUS-NO-EXTERNAL-SIGNAL: without this, an
+	 * in-flight /status poll held the per-host socket for up to 30s
+	 * after stop() — fast unmount/remount could queue new
+	 * /session/start behind the previous /status.
+	 */
+	async getStatus(sid: string, externalSignal?: AbortSignal): Promise<SessionStatusResponse> {
 		return fetchAndParse(
 			`${this.baseUrl}/session/${encodeURIComponent(sid)}/status`,
 			{},
@@ -199,7 +213,8 @@ export class IsServiceClient {
 			async (resp) => {
 				if (!resp.ok) throw await this.errFromResp(resp);
 				return (await resp.json()) as SessionStatusResponse;
-			}
+			},
+			externalSignal
 		);
 	}
 

--- a/src/lib/auth/dash/isClient.ts
+++ b/src/lib/auth/dash/isClient.ts
@@ -340,12 +340,25 @@ export function buildDashUri(address: string, amountDuffs: number): string {
 }
 
 /**
- * Address fingerprint — first 6 hex chars of the IS-service's address
- * signature. Displayed alongside the QR so the user can spot a swapped
+ * Address fingerprint — first 6 characters of the IS-service's
+ * `addressSignature` (which is a base64-encoded Ed25519 / HMAC
+ * signature, NOT hex), lowercased so the user-visible value is
+ * stable regardless of case. Despite the prior docstring claiming
+ * "first 6 hex chars", the input is base64 and the slice preserves
+ * those base64 characters — the choice is fine for a coarse-grained
+ * visual check (1 chance in ~64^6 ≈ 1 in 68B of collision for the
+ * 6-char prefix).
+ *
+ * Displayed alongside the QR so the user can spot a swapped
  * address even if the request was tampered with. Closes the visual
- * substitution vector, NOT the network-level one — for that the frontend
- * must verify `addressSignature` against a pinned IS-service pubkey
- * (todo: spec §5.7 HSM/KMS hand-off).
+ * substitution vector, NOT the network-level one — for that the
+ * frontend cryptographically verifies `addressSignature` against
+ * the pinned `PUBLIC_IS_SERVICE_SIGNER_PUBKEY` (verifyAddressSignature
+ * in signature.ts; SEC-2 hard-fails the QR render on `kind === 'invalid'`).
+ *
+ * Audit R17-CONS-altera-addressfingerprint-not-actually-hex-or-hash:
+ * the prior "first 6 hex chars" wording was internally
+ * contradictory — the signature is never hex on the wire.
  */
 export function addressFingerprint(addressSignature: string): string {
 	return (addressSignature || '').slice(0, 6).toLowerCase();

--- a/src/lib/auth/dash/isClient.ts
+++ b/src/lib/auth/dash/isClient.ts
@@ -44,6 +44,11 @@ export type IsSessionState =
 	| 'WAITING_FOR_IS'
 	| 'IS_OBSERVED'
 	| 'ATTESTING'
+	// Round-4 audit R4-CSM-04: L2_SUBMITTED is non-terminal and is
+	// emitted by the IS service during the reconcileL2 window (seconds
+	// to minutes). Missing it previously left the humanState switch
+	// rendering blank for the entire reconcile window.
+	| 'L2_SUBMITTED'
 	| 'ON_CHAIN'
 	| 'ATTESTATION_TIMEOUT'
 	| 'SLOW_PATH_PENDING'
@@ -61,6 +66,11 @@ export type SessionStatusResponse = {
 	senderAddress?: string;
 	forwardedAt?: string;
 	sessionToken?: string;
+	/** L2 mapInstantSendV2 transaction CID. Populated from L2_SUBMITTED
+	 * onwards and preserved on terminal failure states so a frontend
+	 * recovery flow can surface the L2-credited-but-session-lost case.
+	 * Round-4 audit R4-006. */
+	l2TxId?: string;
 	forwardError?: string;
 	expiresAt: string;
 };

--- a/src/lib/auth/dash/isClient.ts
+++ b/src/lib/auth/dash/isClient.ts
@@ -95,13 +95,19 @@ export function isTerminal(s: IsSessionState): boolean {
 }
 
 /**
- * `cancel` resolves to this when the IS service refuses the cancel
- * because the orchestrator is mid-attestation or mid-L2-submit.
- * Round-5 audit R5-002 / R5-DRIFT-02: the client must NOT pre-set
- * phase='failed' on cancel attempts; instead it should resume
- * polling and let the server reach a terminal state on its own.
+ * Outcomes of `cancel()`. Round-5 audit R5-002 introduced the
+ * 'in-flight-conflict' branch (server returned 409 because the
+ * orchestrator is mid-attestation or mid-L2-submit). Round-6 audit
+ * R6-CORR-04 wired the session module to treat transient network /
+ * 5xx errors equivalently. Round-7 audit R7-DRIFT-02 widened the
+ * type so the discriminator is explicit at the type level and
+ * downstream callers don't have to handle the catch separately.
+ *
+ * In all three cases the caller must NOT pre-set phase='failed';
+ * the session module keeps polling /status until it reaches a
+ * terminal state (bounded by POST_CANCEL_DEADLINE_MS).
  */
-export type CancelResult = 'cancelled' | 'in-flight-conflict';
+export type CancelResult = 'cancelled' | 'in-flight-conflict' | 'error';
 
 export class IsServiceError extends Error {
 	constructor(
@@ -142,10 +148,19 @@ export class IsServiceClient {
 	 * leaking the watcher entry until TTL.
 	 */
 	async cancel(sid: string, cancelToken: string): Promise<CancelResult> {
-		const resp = await fetch(`${this.baseUrl}/session/${encodeURIComponent(sid)}/cancel`, {
-			method: 'POST',
-			headers: { 'X-Cancel-Token': cancelToken }
-		});
+		let resp: Response;
+		try {
+			resp = await fetch(`${this.baseUrl}/session/${encodeURIComponent(sid)}/cancel`, {
+				method: 'POST',
+				headers: { 'X-Cancel-Token': cancelToken }
+			});
+		} catch {
+			// Round-7 audit R7-DRIFT-02: catch the network error
+			// inside the client so the result type is the single
+			// source of truth — callers don't need a parallel
+			// try/catch path to handle the equivalent semantic.
+			return 'error';
+		}
 		// Round-5 audit R5-002 / R5-DRIFT-02: 409 Conflict is the
 		// R4-003 in-flight refusal — the server is mid-attestation
 		// or mid-L2-submit and cannot honour the cancel. Callers
@@ -156,7 +171,10 @@ export class IsServiceClient {
 		// 204 No Content is the happy case; 404/401 are acceptable —
 		// session already self-expired or never existed.
 		if (!resp.ok && resp.status !== 404 && resp.status !== 401) {
-			throw await this.errFromResp(resp);
+			// Treat any other non-OK (5xx, ...) as 'error' so the
+			// caller falls into the same keep-polling branch as
+			// the network-thrown case.
+			return 'error';
 		}
 		return 'cancelled';
 	}

--- a/src/lib/auth/dash/isClient.ts
+++ b/src/lib/auth/dash/isClient.ts
@@ -75,9 +75,17 @@ export type SessionStatusResponse = {
 	expiresAt: string;
 };
 
+// Round-4 audit R4-SEC-03 extended Go session.go IsTerminal() to
+// include AttestationTimeout AND SlowPathPending — both are terminal
+// from the orchestrator's perspective (Drive returns after
+// MutateState'ing into them). Round-5 audit R5-001 / R5-DRIFT-03
+// caught the TS set lagging behind, which would have left the
+// frontend polling forever past TTL for sessions the server already
+// considered done.
 const TERMINAL: ReadonlySet<IsSessionState> = new Set<IsSessionState>([
 	'ON_CHAIN',
 	'ATTESTATION_TIMEOUT',
+	'SLOW_PATH_PENDING',
 	'FORWARD_FAILED',
 	'EXPIRED'
 ]);
@@ -85,6 +93,15 @@ const TERMINAL: ReadonlySet<IsSessionState> = new Set<IsSessionState>([
 export function isTerminal(s: IsSessionState): boolean {
 	return TERMINAL.has(s);
 }
+
+/**
+ * `cancel` resolves to this when the IS service refuses the cancel
+ * because the orchestrator is mid-attestation or mid-L2-submit.
+ * Round-5 audit R5-002 / R5-DRIFT-02: the client must NOT pre-set
+ * phase='failed' on cancel attempts; instead it should resume
+ * polling and let the server reach a terminal state on its own.
+ */
+export type CancelResult = 'cancelled' | 'in-flight-conflict';
 
 export class IsServiceError extends Error {
 	constructor(
@@ -124,16 +141,24 @@ export class IsServiceClient {
 	 * caught the original token-less call returning 401 silently and
 	 * leaking the watcher entry until TTL.
 	 */
-	async cancel(sid: string, cancelToken: string): Promise<void> {
+	async cancel(sid: string, cancelToken: string): Promise<CancelResult> {
 		const resp = await fetch(`${this.baseUrl}/session/${encodeURIComponent(sid)}/cancel`, {
 			method: 'POST',
 			headers: { 'X-Cancel-Token': cancelToken }
 		});
+		// Round-5 audit R5-002 / R5-DRIFT-02: 409 Conflict is the
+		// R4-003 in-flight refusal — the server is mid-attestation
+		// or mid-L2-submit and cannot honour the cancel. Callers
+		// must keep polling /status until terminal; pre-setting
+		// phase='failed' on this branch destroys a legitimate
+		// in-progress login.
+		if (resp.status === 409) return 'in-flight-conflict';
 		// 204 No Content is the happy case; 404/401 are acceptable —
 		// session already self-expired or never existed.
 		if (!resp.ok && resp.status !== 404 && resp.status !== 401) {
 			throw await this.errFromResp(resp);
 		}
+		return 'cancelled';
 	}
 
 	private async errFromResp(resp: Response): Promise<IsServiceError> {

--- a/src/lib/auth/dash/isClient.ts
+++ b/src/lib/auth/dash/isClient.ts
@@ -54,6 +54,11 @@ export type SessionStatusResponse = {
 	sid: string;
 	state: IsSessionState;
 	dashTxId?: string;
+	/** Dash L1 address that paid the IS deposit. Populated from
+	 * IS_OBSERVED onwards; absent until then. The IS-service derives it
+	 * from the rawTx inputs (strict same-address-all-inputs rule per
+	 * spec §5.2.5). */
+	senderAddress?: string;
 	forwardedAt?: string;
 	sessionToken?: string;
 	forwardError?: string;

--- a/src/lib/auth/dash/isClient.ts
+++ b/src/lib/auth/dash/isClient.ts
@@ -1,0 +1,149 @@
+/**
+ * Client for the Magi IS-service HTTP API. Self-contained — no shared types
+ * with the Go service yet (the Go side has no published TS types). Keep
+ * `state` + `op` strings in sync with cmd/is-service/session.go and
+ * cmd/is-service/handlers.go.
+ *
+ * Protocol summary:
+ *
+ *   POST /session/start   { op, args?, sid? }    → SessionStartResponse
+ *   GET  /session/{sid}/status                   → SessionStatusResponse
+ *   POST /session/{sid}/cancel                   → 204
+ *
+ * State arc: WAITING_FOR_IS → IS_OBSERVED → ATTESTING → ON_CHAIN
+ *            (any state) → EXPIRED on TTL / cancel
+ *            ATTESTATION_TIMEOUT / FORWARD_FAILED are terminal failure states.
+ */
+
+export type IsOp = 'auth' | 'call';
+
+export type CallArgs = {
+	contract: string;
+	method: string;
+	args: string;
+	amount?: number;
+};
+
+export type SessionStartRequest = {
+	op: IsOp;
+	sid?: string;
+	args?: CallArgs;
+};
+
+export type SessionStartResponse = {
+	sid: string;
+	depositAddress: string;
+	depositInstructionHex: string;
+	addressSignature: string;
+	requiredAmountDuffs: number;
+	expiresAt: string;
+	statusUrl: string;
+};
+
+export type IsSessionState =
+	| 'WAITING_FOR_IS'
+	| 'IS_OBSERVED'
+	| 'ATTESTING'
+	| 'ON_CHAIN'
+	| 'ATTESTATION_TIMEOUT'
+	| 'SLOW_PATH_PENDING'
+	| 'FORWARD_FAILED'
+	| 'EXPIRED';
+
+export type SessionStatusResponse = {
+	sid: string;
+	state: IsSessionState;
+	dashTxId?: string;
+	forwardedAt?: string;
+	sessionToken?: string;
+	forwardError?: string;
+	expiresAt: string;
+};
+
+const TERMINAL: ReadonlySet<IsSessionState> = new Set<IsSessionState>([
+	'ON_CHAIN',
+	'ATTESTATION_TIMEOUT',
+	'FORWARD_FAILED',
+	'EXPIRED'
+]);
+
+export function isTerminal(s: IsSessionState): boolean {
+	return TERMINAL.has(s);
+}
+
+export class IsServiceError extends Error {
+	constructor(
+		public readonly status: number,
+		message: string
+	) {
+		super(message);
+		this.name = 'IsServiceError';
+	}
+}
+
+export class IsServiceClient {
+	constructor(private readonly baseUrl: string) {
+		this.baseUrl = baseUrl.replace(/\/+$/, '');
+	}
+
+	async startSession(req: SessionStartRequest): Promise<SessionStartResponse> {
+		const resp = await fetch(`${this.baseUrl}/session/start`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(req)
+		});
+		if (!resp.ok) throw await this.errFromResp(resp);
+		return (await resp.json()) as SessionStartResponse;
+	}
+
+	async getStatus(sid: string): Promise<SessionStatusResponse> {
+		const resp = await fetch(`${this.baseUrl}/session/${encodeURIComponent(sid)}/status`);
+		if (!resp.ok) throw await this.errFromResp(resp);
+		return (await resp.json()) as SessionStatusResponse;
+	}
+
+	async cancel(sid: string): Promise<void> {
+		const resp = await fetch(`${this.baseUrl}/session/${encodeURIComponent(sid)}/cancel`, {
+			method: 'POST'
+		});
+		// 204 No Content is the happy case; 404 is acceptable if the
+		// session already self-expired between the user clicking cancel
+		// and us posting.
+		if (!resp.ok && resp.status !== 404) throw await this.errFromResp(resp);
+	}
+
+	private async errFromResp(resp: Response): Promise<IsServiceError> {
+		let msg = `${resp.status} ${resp.statusText}`;
+		try {
+			const body = (await resp.json()) as { error?: string };
+			if (body?.error) msg = body.error;
+		} catch {
+			/* body wasn't JSON — fall back to status */
+		}
+		return new IsServiceError(resp.status, msg);
+	}
+}
+
+/**
+ * Build a BIP-21-style `dash:` URI suitable for DashPay's QR scanner.
+ *
+ * `IS=1` is an Altera convention: it hints to DashPay-compatible wallets
+ * that this is meant to be sent as an InstantSend payment (not a standard
+ * tx) so the wallet pre-selects the IS option.
+ */
+export function buildDashUri(address: string, amountDuffs: number): string {
+	const dashAmount = (amountDuffs / 1e8).toFixed(8);
+	return `dash:${address}?amount=${dashAmount}&IS=1`;
+}
+
+/**
+ * Address fingerprint — first 6 hex chars of the IS-service's address
+ * signature. Displayed alongside the QR so the user can spot a swapped
+ * address even if the request was tampered with. Closes the visual
+ * substitution vector, NOT the network-level one — for that the frontend
+ * must verify `addressSignature` against a pinned IS-service pubkey
+ * (todo: spec §5.7 HSM/KMS hand-off).
+ */
+export function addressFingerprint(addressSignature: string): string {
+	return (addressSignature || '').slice(0, 6).toLowerCase();
+}

--- a/src/lib/auth/dash/isClient.ts
+++ b/src/lib/auth/dash/isClient.ts
@@ -134,13 +134,24 @@ const FETCH_TIMEOUT_CANCEL_MS = 30_000;
 
 /**
  * fetchAndParse runs fetch() + a caller-supplied parse() step under a
- * single AbortController whose timer covers BOTH phases. The signal
- * is composed with an optional externalSignal (R10-CORR-ORPHAN-SESSION-01
- * — so stop() can abort an in-flight startSession by aborting its own
- * controller). Round-11 audit R11-INFO-DOCSTRING-DRIFT-ABORTSIGNAL-ANY
- * + R11-INFO-FETCH-AND-PARSE-EXT-SIGNAL-ALREADY-ABORTED aligned the
- * implementation with the docstring's AbortSignal.any framing and
- * added an early bail when the external signal is already aborted.
+ * single AbortController whose timer covers BOTH phases. When an
+ * optional externalSignal is supplied (R10-CORR-ORPHAN-SESSION-01 —
+ * so stop() can abort an in-flight startSession by aborting its own
+ * controller), composition uses a manual addEventListener('abort',
+ * onExternalAbort) → ctrl.abort() forwarder + paired
+ * removeEventListener in the finally block.
+ *
+ * Round-12 audit R12-DRIFT-FETCHANDPARSE-DOCSTRING-ABORTSIGNALANY:
+ * the docstring previously claimed AbortSignal.any composition but
+ * the implementation has always used the manual listener pattern;
+ * rewritten here to match. (AbortSignal.any would be cleaner but
+ * still needs the timer-driven AbortController for the timeout
+ * path, so the manual listener is no worse.)
+ *
+ * The pre-aborted-external-signal fast-path throws DOMException
+ * synchronously instead of allocating a controller + timer that
+ * would never be used — round-11 audit R11-INFO-FETCH-AND-PARSE-
+ * EXT-SIGNAL-ALREADY-ABORTED.
  */
 async function fetchAndParse<T>(
 	input: RequestInfo,
@@ -192,7 +203,23 @@ export class IsServiceClient {
 			FETCH_TIMEOUT_START_MS,
 			async (resp) => {
 				if (!resp.ok) throw await this.errFromResp(resp);
-				return (await resp.json()) as SessionStartResponse;
+				const body = (await resp.json()) as unknown;
+				// Round-12 audit R12-INFO-BEGIN-ORPHAN-MICRORACE-MISSING-DEFENSIVE-CHECK:
+				// shape-check the response so a misbehaving server
+				// can't return 200 with body=null / {} / missing
+				// fields and slip past the TS `as` assertion.
+				// session.svelte.ts uses sid + addressSignature as
+				// the orphan-microrace cancel handle — a malformed
+				// response would silently skip that cancel.
+				if (
+					!body ||
+					typeof body !== 'object' ||
+					typeof (body as Record<string, unknown>).sid !== 'string' ||
+					typeof (body as Record<string, unknown>).addressSignature !== 'string'
+				) {
+					throw new IsServiceError(200, 'malformed /session/start response');
+				}
+				return body as SessionStartResponse;
 			},
 			externalSignal
 		);

--- a/src/lib/auth/dash/isClient.ts
+++ b/src/lib/auth/dash/isClient.ts
@@ -343,11 +343,21 @@ export function buildDashUri(address: string, amountDuffs: number): string {
  * Address fingerprint — first 6 characters of the IS-service's
  * `addressSignature` (which is a base64-encoded Ed25519 / HMAC
  * signature, NOT hex), lowercased so the user-visible value is
- * stable regardless of case. Despite the prior docstring claiming
- * "first 6 hex chars", the input is base64 and the slice preserves
- * those base64 characters — the choice is fine for a coarse-grained
- * visual check (1 chance in ~64^6 ≈ 1 in 68B of collision for the
- * 6-char prefix).
+ * stable regardless of case.
+ *
+ * Collision-space arithmetic (audit R18-SEC-altera-fingerprint-
+ * collision-space-overstated + R18-CONS-fingerprint-collision-math-
+ * 64-base-after-lowercase): standard base64 has a 64-symbol
+ * alphabet (A-Z + a-z + 0-9 + + + /). But after `.toLowerCase()`
+ * the uppercase + lowercase letters of base64 collapse to the same
+ * 26 letters, so the effective alphabet shrinks to 26 letters + 10
+ * digits + 2 symbols ≈ 38 distinct characters. The 6-char prefix
+ * therefore picks from ~38^6 ≈ 3.0e9 (3 billion) distinct values,
+ * not 64^6 ≈ 68 billion. A pure-random adversary's birthday-attack
+ * chance against the visible prefix is roughly 1 in 3B per attempt
+ * — still well outside what a hostile IS-service could exploit
+ * via random retries inside a session-start latency budget, but
+ * the prior 68B claim was overstated by ~22×.
  *
  * Displayed alongside the QR so the user can spot a swapped
  * address even if the request was tampered with. Closes the visual

--- a/src/lib/auth/dash/isClient.ts
+++ b/src/lib/auth/dash/isClient.ts
@@ -119,25 +119,46 @@ export class IsServiceError extends Error {
 	}
 }
 
-// Round-9 audit R9-SEC-01 + R9-SEC-02: a malicious / misbehaving IS
-// service that accepts TCP then withholds the response body would
-// previously keep the fetch promise pending indefinitely — pinning
-// session.svelte.ts in cancelling=true (per R8-CORR-02 guard),
-// piling concurrent /status polls past the browser per-host limit,
-// or trapping startSession in phase='starting' forever. Every fetch
-// in this client now runs with an AbortController so a hostile peer
-// cannot prevent the timeout from firing client-side.
+// Round-9 audit R9-SEC-01 + R9-SEC-02 / round-10 audit R10-CORR-01:
+// a malicious / misbehaving IS service can stall any phase of the
+// HTTP exchange — headers, body chunks, or a never-closed
+// ReadableStream. The AbortController timer must outlive both the
+// fetch() promise AND the body-parse step; clearing it after fetch
+// alone (the R9 implementation) left a body-stream stall reopening
+// the slow-loris DoS. fetchAndParse now wraps the timer around the
+// entire request → parse cycle and only clears it after parse()
+// resolves.
 const FETCH_TIMEOUT_START_MS = 15_000;
 const FETCH_TIMEOUT_STATUS_MS = 30_000;
 const FETCH_TIMEOUT_CANCEL_MS = 30_000;
 
-async function fetchWithTimeout(input: RequestInfo, init: RequestInit, timeoutMs: number): Promise<Response> {
+/**
+ * fetchAndParse runs fetch() + a caller-supplied parse() step under a
+ * single AbortController whose timer covers BOTH phases. The signal
+ * can be externally supplied (R10-CORR-ORPHAN-SESSION-01 — so stop()
+ * can abort an in-flight startSession by aborting its own
+ * controller) and is composed via AbortSignal.any.
+ */
+async function fetchAndParse<T>(
+	input: RequestInfo,
+	init: RequestInit,
+	timeoutMs: number,
+	parse: (resp: Response) => Promise<T>,
+	externalSignal?: AbortSignal
+): Promise<T> {
 	const ctrl = new AbortController();
 	const t = setTimeout(() => ctrl.abort(), timeoutMs);
+	const onExternalAbort = () => ctrl.abort();
+	if (externalSignal) {
+		if (externalSignal.aborted) ctrl.abort();
+		else externalSignal.addEventListener('abort', onExternalAbort);
+	}
 	try {
-		return await fetch(input, { ...init, signal: ctrl.signal });
+		const resp = await fetch(input, { ...init, signal: ctrl.signal });
+		return await parse(resp);
 	} finally {
 		clearTimeout(t);
+		if (externalSignal) externalSignal.removeEventListener('abort', onExternalAbort);
 	}
 }
 
@@ -146,24 +167,40 @@ export class IsServiceClient {
 		this.baseUrl = baseUrl.replace(/\/+$/, '');
 	}
 
-	async startSession(req: SessionStartRequest): Promise<SessionStartResponse> {
-		const resp = await fetchWithTimeout(`${this.baseUrl}/session/start`, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify(req)
-		}, FETCH_TIMEOUT_START_MS);
-		if (!resp.ok) throw await this.errFromResp(resp);
-		return (await resp.json()) as SessionStartResponse;
+	/**
+	 * startSession accepts an optional externalSignal so callers
+	 * (session.svelte.ts) can abort an in-flight start when the
+	 * component unmounts mid-flight — closes the R10-CORR-ORPHAN-
+	 * SESSION-01 leak where stop() couldn't release the server
+	 * record until the 30-min TTL.
+	 */
+	async startSession(req: SessionStartRequest, externalSignal?: AbortSignal): Promise<SessionStartResponse> {
+		return fetchAndParse(
+			`${this.baseUrl}/session/start`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(req)
+			},
+			FETCH_TIMEOUT_START_MS,
+			async (resp) => {
+				if (!resp.ok) throw await this.errFromResp(resp);
+				return (await resp.json()) as SessionStartResponse;
+			},
+			externalSignal
+		);
 	}
 
 	async getStatus(sid: string): Promise<SessionStatusResponse> {
-		const resp = await fetchWithTimeout(
+		return fetchAndParse(
 			`${this.baseUrl}/session/${encodeURIComponent(sid)}/status`,
 			{},
-			FETCH_TIMEOUT_STATUS_MS
+			FETCH_TIMEOUT_STATUS_MS,
+			async (resp) => {
+				if (!resp.ok) throw await this.errFromResp(resp);
+				return (await resp.json()) as SessionStatusResponse;
+			}
 		);
-		if (!resp.ok) throw await this.errFromResp(resp);
-		return (await resp.json()) as SessionStatusResponse;
 	}
 
 	/**
@@ -180,15 +217,22 @@ export class IsServiceClient {
 	 * session.svelte.ts.
 	 */
 	async cancel(sid: string, cancelToken: string): Promise<CancelResult> {
+		// Round-10 audit R10-CORR-01: route through fetchAndParse so
+		// the AbortController also bounds the (typically empty) body
+		// read. The cancel endpoint returns 204/401/404/409 with no
+		// JSON body to parse, but a hostile server could still stall
+		// on the Content-Length=0 read; fetchAndParse forces a single
+		// timer to cover the entire exchange.
 		let resp: Response;
 		try {
-			resp = await fetchWithTimeout(
+			resp = await fetchAndParse(
 				`${this.baseUrl}/session/${encodeURIComponent(sid)}/cancel`,
 				{
 					method: 'POST',
 					headers: { 'X-Cancel-Token': cancelToken }
 				},
-				FETCH_TIMEOUT_CANCEL_MS
+				FETCH_TIMEOUT_CANCEL_MS,
+				async (r) => r
 			);
 		} catch {
 			// Round-7 audit R7-DRIFT-02 / round-9 R9-SEC-01: catch

--- a/src/lib/auth/dash/isClient.ts
+++ b/src/lib/auth/dash/isClient.ts
@@ -345,29 +345,43 @@ export function buildDashUri(address: string, amountDuffs: number): string {
  * signature, NOT hex), lowercased so the user-visible value is
  * stable regardless of case.
  *
+ * Purpose: a session-internal visual identifier for the deposit
+ * address — useful for a side-by-side check between this dialog
+ * and the user's wallet after the QR is scanned, to catch an
+ * obvious mid-flight QR swap.
+ *
+ * NOT a cryptographic credential: the value derives from
+ * `addressSignature`, which is computed per /session/start over
+ * a per-session sid. Every session produces a fresh signature →
+ * a fresh fingerprint. There is no static value an operator
+ * could publish out-of-band that the user could compare against.
+ * The authentic-IS-service check is the SIGNATURE VERIFICATION
+ * (verifyAddressSignature in signature.ts, SEC-2 hard-fails QR
+ * render on `kind === 'invalid'`), NOT this fingerprint.
+ *
  * Collision-space arithmetic (audit R18-SEC-altera-fingerprint-
  * collision-space-overstated + R18-CONS-fingerprint-collision-math-
- * 64-base-after-lowercase): standard base64 has a 64-symbol
- * alphabet (A-Z + a-z + 0-9 + + + /). But after `.toLowerCase()`
- * the uppercase + lowercase letters of base64 collapse to the same
- * 26 letters, so the effective alphabet shrinks to 26 letters + 10
- * digits + 2 symbols ≈ 38 distinct characters. The 6-char prefix
- * therefore picks from ~38^6 ≈ 3.0e9 (3 billion) distinct values,
- * not 64^6 ≈ 68 billion. A pure-random adversary's birthday-attack
- * chance against the visible prefix is roughly 1 in 3B per attempt
- * — still well outside what a hostile IS-service could exploit
- * via random retries inside a session-start latency budget, but
- * the prior 68B claim was overstated by ~22×.
+ * 64-base-after-lowercase + R19-SEC-addressfingerprint-collision-
+ * claim-misleads-on-attack-model): standard base64 has a 64-symbol
+ * alphabet (A-Z + a-z + 0-9 + + + /). After `.toLowerCase()` the
+ * uppercase + lowercase letters collapse to the same 26 letters,
+ * shrinking the effective alphabet to ~38 distinct characters.
+ * The 6-char prefix picks from ~38^6 ≈ 3.0e9 distinct values,
+ * not 64^6 ≈ 68B.
  *
- * Displayed alongside the QR so the user can spot a swapped
- * address even if the request was tampered with. Closes the visual
- * substitution vector, NOT the network-level one — for that the
- * frontend cryptographically verifies `addressSignature` against
- * the pinned `PUBLIC_IS_SERVICE_SIGNER_PUBKEY` (verifyAddressSignature
- * in signature.ts; SEC-2 hard-fails the QR render on `kind === 'invalid'`).
+ * Attack model (R19): the relevant threat is PREIMAGE — an
+ * attacker controlling a hostile IS-service who wants to match a
+ * specific target fingerprint. With control of their own signing
+ * key the attacker can grind sids offline at ~50ns/Ed25519-sign on
+ * commodity hardware. 3B signs ≈ 150s wall-clock on one core,
+ * trivially feasible. The fingerprint therefore provides ZERO
+ * defense against an active adversary at the network level — its
+ * sole purpose is the user-visible mid-flight QR-swap detection
+ * described above. The 38^6 number is a property of the
+ * representation, not a security guarantee.
  *
  * Audit R17-CONS-altera-addressfingerprint-not-actually-hex-or-hash:
- * the prior "first 6 hex chars" wording was internally
+ * the original "first 6 hex chars" wording was internally
  * contradictory — the signature is never hex on the wire.
  */
 export function addressFingerprint(addressSignature: string): string {

--- a/src/lib/auth/dash/isClient.ts
+++ b/src/lib/auth/dash/isClient.ts
@@ -300,6 +300,18 @@ export class IsServiceClient {
 			// the network-thrown case.
 			return 'error';
 		}
+		// Round-11 audit R11-INFO-CANCEL-401-MASKS-TOKEN-MISMATCH:
+		// a 401 here is server-side "session not found OR bad token"
+		// (server uses 401 for both — round-9 R9-INFO-EXISTENCE-
+		// ORACLE-01 confirmed this is by design since /status already
+		// leaks existence). Client-side, 401 may also indicate
+		// X-Cancel-Token corruption (e.g. a token mutated before
+		// it reached this call). Surface to console.debug so a
+		// dev seeing repeated 401s can correlate, without changing
+		// the user-visible behaviour (still treat as 'cancelled').
+		if (resp.status === 401) {
+			console.debug('Dash session cancel: 401 — server says session gone or token mismatch');
+		}
 		return 'cancelled';
 	}
 

--- a/src/lib/auth/dash/isClient.ts
+++ b/src/lib/auth/dash/isClient.ts
@@ -107,14 +107,23 @@ export class IsServiceClient {
 		return (await resp.json()) as SessionStatusResponse;
 	}
 
-	async cancel(sid: string): Promise<void> {
+	/**
+	 * Cancel the session. cancelToken is the addressSignature returned
+	 * by /session/start — the server requires it via X-Cancel-Token
+	 * (see handlers.go handleSessionCancel). Round-2 audit TC2-01
+	 * caught the original token-less call returning 401 silently and
+	 * leaking the watcher entry until TTL.
+	 */
+	async cancel(sid: string, cancelToken: string): Promise<void> {
 		const resp = await fetch(`${this.baseUrl}/session/${encodeURIComponent(sid)}/cancel`, {
-			method: 'POST'
+			method: 'POST',
+			headers: { 'X-Cancel-Token': cancelToken }
 		});
-		// 204 No Content is the happy case; 404 is acceptable if the
-		// session already self-expired between the user clicking cancel
-		// and us posting.
-		if (!resp.ok && resp.status !== 404) throw await this.errFromResp(resp);
+		// 204 No Content is the happy case; 404/401 are acceptable —
+		// session already self-expired or never existed.
+		if (!resp.ok && resp.status !== 404 && resp.status !== 401) {
+			throw await this.errFromResp(resp);
+		}
 	}
 
 	private async errFromResp(resp: Response): Promise<IsServiceError> {

--- a/src/lib/auth/dash/session.svelte.test.ts
+++ b/src/lib/auth/dash/session.svelte.test.ts
@@ -385,11 +385,20 @@ describe('R13-CORR-BACKOFF-PERSISTS-ACROSS-IN-FLIGHT-CONFLICT-RETRY', () => {
 		globalThis.__dashTestClient.getStatus.mockRejectedValue(new Error('network'));
 		globalThis.__dashTestClient.cancel.mockResolvedValue('in-flight-conflict');
 
-		const delays: number[] = [];
+		// Round-14 R14-VITEST-RELIES-ON-NODE-MACROTASK-FIFO: phase-
+		// tag each setTimeout so the assertion proves the 4000 fires
+		// AFTER cancel(), not just that the value appears in the
+		// macrotask buffer. The audit found the prior `find(d => d>0
+		// && d<=30_000)` was satisfied by a pre-cancel stale tick
+		// happening to land in macrotask FIFO order — a refactor that
+		// reorders insertions could pass-for-wrong-reason.
+		type Phase = 'before' | 'after';
+		const events: { ms: number; phase: Phase }[] = [];
+		let phase: Phase = 'before';
 		const realSetTimeout = globalThis.setTimeout;
 		const spy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(
 			((fn: () => void, ms?: number) => {
-				if (typeof ms === 'number' && ms > 0) delays.push(ms);
+				if (typeof ms === 'number' && ms > 0) events.push({ ms, phase });
 				return realSetTimeout(fn, 0);
 			}) as typeof globalThis.setTimeout
 		);
@@ -398,26 +407,31 @@ describe('R13-CORR-BACKOFF-PERSISTS-ACROSS-IN-FLIGHT-CONFLICT-RETRY', () => {
 		await session.begin();
 		// Let the staircase climb to the 30s cap.
 		for (let i = 0; i < 6; i++) await new Promise((r) => realSetTimeout(r, 0));
-		expect(delays).toContain(30_000);
+		expect(events.some((e) => e.ms === 30_000)).toBe(true);
 
-		// 409 cancel — pollErrCount must reset HERE (R13-CORR fix).
-		// We can't directly observe the closure variable; instead
-		// we check the next failing tick's delay. If reset works,
-		// it should be 4000 (fresh staircase first failure). If
-		// broken, it would be 30000 (continuation of cap).
-		//
-		// Filter to delays ≤ POLL_BACKOFF_MAX_MS so the trap-
-		// deadline setTimeout(... POST_CANCEL_DEADLINE_MS = 240000)
-		// armed inside cancel() doesn't confuse the assertion.
-		const POLL_BACKOFF_MAX_MS = 30_000;
-		delays.length = 0;
+		// Flip phase BEFORE cancel() starts so every setTimeout
+		// scheduled from inside cancel() + post-cancel polling
+		// gets tagged as 'after'. Pre-cancel stale ticks remain
+		// 'before' even if they land in macrotask FIFO order
+		// after we await cancel() — phase is closure-state, not
+		// macrotask-order.
+		phase = 'after';
 		await session.cancel();
-		// cancel resolves with in-flight-conflict; postCancelConflict
-		// becomes true and polling continues. Let the next tick fire.
 		for (let i = 0; i < 4; i++) await new Promise((r) => realSetTimeout(r, 0));
 
-		const firstPollDelay = delays.find((d) => d > 0 && d <= POLL_BACKOFF_MAX_MS);
-		expect(firstPollDelay).toBe(4000);
+		// The cancel()-branch reset (R13-CORR fix) must produce a
+		// 4000ms setTimeout call AFTER the phase flip. If reset is
+		// broken the post-cancel staircase resumes from the 30s cap
+		// instead, and no 4000 entry appears in the 'after' bucket.
+		const POLL_BACKOFF_MAX_MS = 30_000;
+		const afterEvents = events.filter(
+			(e) => e.phase === 'after' && e.ms > 0 && e.ms <= POLL_BACKOFF_MAX_MS
+		);
+		const firstPollDelay = afterEvents.find((e) => e.ms === 4000);
+		expect(
+			firstPollDelay,
+			`expected a 4000ms setTimeout AFTER cancel(); got phase-tagged events: ${JSON.stringify(events)}`
+		).toBeDefined();
 
 		spy.mockRestore();
 	});

--- a/src/lib/auth/dash/session.svelte.test.ts
+++ b/src/lib/auth/dash/session.svelte.test.ts
@@ -1,27 +1,22 @@
 /**
- * Round-10/11/12/13 audit follow-up — TEST-COV-NO-UNIT-TESTS-FOR-DASH-AUTH:
- * 12 rounds of subtle race-guard fixes accumulated in createDashSession
- * (gen counters, three AbortControllers, two deadline timers, three
- * concurrency-guard flags) had been verified by static reading only.
- * This harness pins the invariants those fixes promise:
+ * Round-10/11/12/13/14 audit follow-up — TEST-COV-NO-UNIT-TESTS-FOR-
+ * DASH-AUTH: 13+ rounds of subtle race-guard fixes accumulated in
+ * createDashSession (gen counters, three AbortControllers, two
+ * deadline timers, three concurrency-guard flags) had been verified
+ * by static reading only. This harness pins the invariants those
+ * fixes promise. R14-DRIFT-TEST-HEADER-NUMBERED-LIST-STALE replaced
+ * the hand-maintained numbered list — the canonical list is the
+ * describe() / it() blocks below, which vitest discovers anyway;
+ * a numbered prose list drifted out of sync at every round-add.
  *
- *   (1) startSession malformed-body shape-check (R12-INFO-BEGIN-ORPHAN-...)
- *   (2) Orphan-microrace cancel fires fire-and-forget /cancel when
- *       destroyed flips during the microtask gap between fetch
- *       resolution and the startResponse assignment (R11-CORR-ORPHAN-
- *       FETCH-MICRORACE).
- *   (3) stop() re-entry is idempotent — second stop() does NOT issue
- *       a duplicate fire-and-forget cancel (R11-DESIGN-STOP-NO-REENTRY-GUARD).
- *   (4) stop() aborts the in-flight startSession AbortController
- *       (R10-CORR-ORPHAN-SESSION-01).
- *   (5) cancel() success branch does NOT abort the pollAbort signal
- *       (R12-DESIGN-CANCEL-DOES-NOT-ABORT-POLLABORT).
- *   (6) cancel() 409 in-flight-conflict → phase stays 'waiting',
- *       postCancelConflict=true (R5-002 / R10-CORR-02).
- *   (7) Late getStatus resolution after stopPolling is gen-guarded —
- *       does NOT overwrite phase=failed (R11-CORR-POLL-WRITES-AFTER-STOPPOLLING).
- *   (8) pollErrCount reset on stopPolling + schedulePoll entry
- *       (R12-CORR-POLLERRCOUNT-NOT-RESET-ACROSS-RETRY).
+ * Property areas covered (see describe() blocks for one-to-one
+ * mapping to specific finding IDs):
+ *   - lifecycle re-entry guards (begin/stop/cancel idempotence)
+ *   - in-flight AbortController plumbing (start, poll, cancel)
+ *   - gen-counter race guards across stopPolling/cancel/teardown
+ *   - 409 in-flight-conflict semantics + post-cancel trap deadline
+ *   - backoff staircase reset + cap edge-trigger (R12/R13/R14)
+ *   - orphan-microrace fire-and-forget cancel (R11)
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';

--- a/src/lib/auth/dash/session.svelte.test.ts
+++ b/src/lib/auth/dash/session.svelte.test.ts
@@ -378,6 +378,56 @@ describe('R12-CORR-POLLERRCOUNT-NOT-RESET-ACROSS-RETRY', () => {
 	});
 });
 
+// ────── pollErrCount reset on 409 cancel branch (R13-CORR-BACKOFF-...) ──────
+
+describe('R13-CORR-BACKOFF-PERSISTS-ACROSS-IN-FLIGHT-CONFLICT-RETRY', () => {
+	it('cancel() 409 in-flight-conflict resets pollErrCount so a retry restarts the staircase', async () => {
+		// Attempt 1 fails several times → pollErrCount reaches the
+		// 30s cap. User cancels; server replies 409. The R13 fix
+		// must reset pollErrCount inside the 409 branch (R12 only
+		// covered the clean-cancel branch via stopPolling).
+		globalThis.__dashTestClient.startSession.mockResolvedValue(makeStartResponse());
+		globalThis.__dashTestClient.getStatus.mockRejectedValue(new Error('network'));
+		globalThis.__dashTestClient.cancel.mockResolvedValue('in-flight-conflict');
+
+		const delays: number[] = [];
+		const realSetTimeout = globalThis.setTimeout;
+		const spy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(
+			((fn: () => void, ms?: number) => {
+				if (typeof ms === 'number' && ms > 0) delays.push(ms);
+				return realSetTimeout(fn, 0);
+			}) as typeof globalThis.setTimeout
+		);
+
+		session = createDashSession({ baseUrl: 'https://is.test', op: 'auth' });
+		await session.begin();
+		// Let the staircase climb to the 30s cap.
+		for (let i = 0; i < 6; i++) await new Promise((r) => realSetTimeout(r, 0));
+		expect(delays).toContain(30_000);
+
+		// 409 cancel — pollErrCount must reset HERE (R13-CORR fix).
+		// We can't directly observe the closure variable; instead
+		// we check the next failing tick's delay. If reset works,
+		// it should be 4000 (fresh staircase first failure). If
+		// broken, it would be 30000 (continuation of cap).
+		//
+		// Filter to delays ≤ POLL_BACKOFF_MAX_MS so the trap-
+		// deadline setTimeout(... POST_CANCEL_DEADLINE_MS = 240000)
+		// armed inside cancel() doesn't confuse the assertion.
+		const POLL_BACKOFF_MAX_MS = 30_000;
+		delays.length = 0;
+		await session.cancel();
+		// cancel resolves with in-flight-conflict; postCancelConflict
+		// becomes true and polling continues. Let the next tick fire.
+		for (let i = 0; i < 4; i++) await new Promise((r) => realSetTimeout(r, 0));
+
+		const firstPollDelay = delays.find((d) => d > 0 && d <= POLL_BACKOFF_MAX_MS);
+		expect(firstPollDelay).toBe(4000);
+
+		spy.mockRestore();
+	});
+});
+
 // ──────── (7) gen-guard: late getStatus does NOT overwrite cancel ─────────
 
 describe('R11-CORR-POLL-WRITES-AFTER-STOPPOLLING', () => {

--- a/src/lib/auth/dash/session.svelte.test.ts
+++ b/src/lib/auth/dash/session.svelte.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Round-10/11/12/13 audit follow-up — TEST-COV-NO-UNIT-TESTS-FOR-DASH-AUTH:
+ * 12 rounds of subtle race-guard fixes accumulated in createDashSession
+ * (gen counters, three AbortControllers, two deadline timers, three
+ * concurrency-guard flags) had been verified by static reading only.
+ * This harness pins the invariants those fixes promise:
+ *
+ *   (1) startSession malformed-body shape-check (R12-INFO-BEGIN-ORPHAN-...)
+ *   (2) Orphan-microrace cancel fires fire-and-forget /cancel when
+ *       destroyed flips during the microtask gap between fetch
+ *       resolution and the startResponse assignment (R11-CORR-ORPHAN-
+ *       FETCH-MICRORACE).
+ *   (3) stop() re-entry is idempotent — second stop() does NOT issue
+ *       a duplicate fire-and-forget cancel (R11-DESIGN-STOP-NO-REENTRY-GUARD).
+ *   (4) stop() aborts the in-flight startSession AbortController
+ *       (R10-CORR-ORPHAN-SESSION-01).
+ *   (5) cancel() success branch does NOT abort the pollAbort signal
+ *       (R12-DESIGN-CANCEL-DOES-NOT-ABORT-POLLABORT).
+ *   (6) cancel() 409 in-flight-conflict → phase stays 'waiting',
+ *       postCancelConflict=true (R5-002 / R10-CORR-02).
+ *   (7) Late getStatus resolution after stopPolling is gen-guarded —
+ *       does NOT overwrite phase=failed (R11-CORR-POLL-WRITES-AFTER-STOPPOLLING).
+ *   (8) pollErrCount reset on stopPolling + schedulePoll entry
+ *       (R12-CORR-POLLERRCOUNT-NOT-RESET-ACROSS-RETRY).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock IsServiceClient before importing session.svelte.ts. The factory
+// uses `new IsServiceClient(opts.baseUrl)` directly; vi.mock is hoisted
+// so this swap lands before createDashSession imports the symbol.
+//
+// We hold the per-test mock object via globalThis so the factory hands
+// each new session the same instance and tests can drive it.
+type MockClient = {
+	startSession: ReturnType<typeof vi.fn>;
+	getStatus: ReturnType<typeof vi.fn>;
+	cancel: ReturnType<typeof vi.fn>;
+};
+
+declare global {
+	// eslint-disable-next-line no-var
+	var __dashTestClient: MockClient;
+}
+
+vi.mock('./isClient', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('./isClient')>();
+	// Constructible shim — session.svelte.ts does `new IsServiceClient(baseUrl)`.
+	// Each construction returns the test's current per-test mock.
+	class TestIsServiceClient {
+		startSession: MockClient['startSession'];
+		getStatus: MockClient['getStatus'];
+		cancel: MockClient['cancel'];
+		constructor(_baseUrl: string) {
+			const m = globalThis.__dashTestClient;
+			this.startSession = m.startSession;
+			this.getStatus = m.getStatus;
+			this.cancel = m.cancel;
+		}
+	}
+	return {
+		...actual,
+		IsServiceClient: TestIsServiceClient
+	};
+});
+
+import { createDashSession, type DashSession } from './session.svelte';
+import { IsServiceError, type SessionStartResponse } from './isClient';
+
+const PARITY_DEPOSIT_ADDRESS = 'tdash1qexamplemockaddressxxxxxxxxxxxxxxxx';
+
+function makeStartResponse(over: Partial<SessionStartResponse> = {}): SessionStartResponse {
+	return {
+		sid: 'sid-test',
+		depositAddress: PARITY_DEPOSIT_ADDRESS,
+		depositInstructionHex: '6f703d617574683b7369643d7369642d74657374',
+		addressSignature: 'addr-sig-test-base64',
+		requiredAmountDuffs: 10_000_000,
+		expiresAt: new Date(Date.now() + 30 * 60_000).toISOString(),
+		statusUrl: '/session/sid-test/status',
+		...over
+	};
+}
+
+/**
+ * A controllable Promise — resolves/rejects on demand so tests can
+ * drive the stop()-during-startSession race deterministically.
+ */
+function deferred<T>(): {
+	promise: Promise<T>;
+	resolve: (v: T) => void;
+	reject: (e: unknown) => void;
+} {
+	let resolve!: (v: T) => void;
+	let reject!: (e: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+let session: DashSession;
+
+beforeEach(() => {
+	globalThis.__dashTestClient = {
+		startSession: vi.fn(),
+		getStatus: vi.fn(),
+		cancel: vi.fn()
+	};
+});
+
+afterEach(() => {
+	// Best-effort: tear down whatever session the test created so
+	// timers/aborts don't leak between cases.
+	if (session) session.stop();
+	vi.useRealTimers();
+});
+
+// ───────────────────────────── (1) shape-check ─────────────────────────────
+
+describe('startSession malformed-response shape-check (R12-INFO-...)', () => {
+	it('phase flips to failed when startSession throws IsServiceError(200, malformed)', async () => {
+		globalThis.__dashTestClient.startSession.mockRejectedValueOnce(
+			new IsServiceError(200, 'malformed /session/start response')
+		);
+		session = createDashSession({ baseUrl: 'https://is.test', op: 'auth' });
+		await session.begin();
+		expect(session.phase).toBe('failed');
+		expect(session.error).toContain('malformed');
+	});
+
+	// Round-13 audit R13-INFO-SHAPECHECK-ASYMMETRIC-FIELDS captured the
+	// known gap: a server returning {sid:'', addressSignature:''}
+	// passes the typeof===string gate. We pin the CURRENT behaviour so
+	// a future tightening flip (empty-string reject) shows up
+	// explicitly in the diff rather than as a silent change.
+	it('CURRENT behaviour: empty sid+addressSignature pass the shape-check', async () => {
+		globalThis.__dashTestClient.startSession.mockResolvedValueOnce(
+			makeStartResponse({ sid: '', addressSignature: '' })
+		);
+		globalThis.__dashTestClient.getStatus.mockResolvedValue({
+			sid: '',
+			state: 'WAITING_FOR_IS',
+			expiresAt: new Date(Date.now() + 30 * 60_000).toISOString()
+		});
+		session = createDashSession({ baseUrl: 'https://is.test', op: 'auth' });
+		await session.begin();
+		expect(session.phase).toBe('waiting');
+		// R13-INFO-...: the orphan-microrace fire-and-forget cancel
+		// in stop() would skip on empty strings because of the
+		// `if (sr.sid && sr.addressSignature)` guard. Documented gap.
+	});
+});
+
+// ─────── (2) orphan-microrace cancel + (4) stop aborts startSession ────────
+
+describe('R11-CORR-ORPHAN-FETCH-MICRORACE + R10-CORR-ORPHAN-SESSION-01', () => {
+	it('stop() during in-flight startSession aborts the AbortController', async () => {
+		const d = deferred<SessionStartResponse>();
+		let capturedSignal: AbortSignal | undefined;
+		globalThis.__dashTestClient.startSession.mockImplementationOnce(
+			(_body: unknown, signal?: AbortSignal) => {
+				capturedSignal = signal;
+				return d.promise;
+			}
+		);
+
+		session = createDashSession({ baseUrl: 'https://is.test', op: 'auth' });
+		const beginPromise = session.begin();
+		// Yield once so begin() has had a chance to call client.startSession.
+		await Promise.resolve();
+		expect(capturedSignal).toBeDefined();
+		expect(capturedSignal!.aborted).toBe(false);
+
+		session.stop();
+		expect(capturedSignal!.aborted).toBe(true);
+
+		// Cleanly resolve the deferred so begin()'s try doesn't dangle.
+		d.reject(new DOMException('aborted', 'AbortError'));
+		await beginPromise;
+		expect(session.phase).not.toBe('waiting');
+	});
+
+	it('orphan microrace: stop() between fetch resolve and startResponse assignment → fire-and-forget cancel', async () => {
+		const d = deferred<SessionStartResponse>();
+		globalThis.__dashTestClient.startSession.mockReturnValueOnce(d.promise);
+		globalThis.__dashTestClient.cancel.mockResolvedValue('cancelled');
+
+		session = createDashSession({ baseUrl: 'https://is.test', op: 'auth' });
+		const beginPromise = session.begin();
+		await Promise.resolve(); // let begin reach the await
+
+		// Sequence: call stop() FIRST (sets destroyed=true), THEN
+		// resolve the startSession promise. begin()'s post-await branch
+		// observes destroyed=true and fires fire-and-forget /cancel.
+		session.stop();
+		d.resolve(makeStartResponse({ sid: 'orphan-sid', addressSignature: 'orphan-token' }));
+		await beginPromise;
+
+		expect(globalThis.__dashTestClient.cancel).toHaveBeenCalledTimes(1);
+		expect(globalThis.__dashTestClient.cancel).toHaveBeenCalledWith('orphan-sid', 'orphan-token');
+		// And destroyed-guard prevents state writes.
+		expect(session.startResponse).toBeUndefined();
+		expect(session.phase).not.toBe('waiting');
+	});
+});
+
+// ────────── (3) stop() re-entry idempotency (R11-DESIGN-STOP-...) ──────────
+
+describe('R11-DESIGN-STOP-NO-REENTRY-GUARD', () => {
+	it('two back-to-back stop() calls invoke client.cancel at most once', async () => {
+		globalThis.__dashTestClient.startSession.mockResolvedValue(
+			makeStartResponse({ sid: 'sid-reentry', addressSignature: 'token-reentry' })
+		);
+		globalThis.__dashTestClient.getStatus.mockResolvedValue({
+			sid: 'sid-reentry',
+			state: 'WAITING_FOR_IS',
+			expiresAt: new Date(Date.now() + 30 * 60_000).toISOString()
+		});
+		globalThis.__dashTestClient.cancel.mockResolvedValue('cancelled');
+
+		session = createDashSession({ baseUrl: 'https://is.test', op: 'auth' });
+		await session.begin();
+		// Drop the immediate poll() microtask but don't advance the 2s
+		// poll interval timer.
+		await Promise.resolve();
+
+		session.stop();
+		session.stop();
+		expect(globalThis.__dashTestClient.cancel).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ────────── (5) cancel() does NOT abort pollAbort (R12-DESIGN-...) ─────────
+
+describe('R12-DESIGN-CANCEL-DOES-NOT-ABORT-POLLABORT', () => {
+	it('cancel() success branch leaves an in-flight /status fetch running', async () => {
+		// Use real timers — the poll tick at delay=0 still has to run,
+		// but vi.useFakeTimers would freeze the microtask that resolves
+		// startSession before schedulePoll arms its setTimeout(tick,0).
+		globalThis.__dashTestClient.startSession.mockResolvedValue(makeStartResponse());
+
+		// Make getStatus return a never-resolving promise but capture
+		// its signal so the test can check `aborted` after cancel().
+		const statusDeferred = deferred<unknown>();
+		let capturedSignal: AbortSignal | undefined;
+		globalThis.__dashTestClient.getStatus.mockImplementation(
+			(_sid: string, signal?: AbortSignal) => {
+				capturedSignal = signal;
+				return statusDeferred.promise as Promise<never>;
+			}
+		);
+		globalThis.__dashTestClient.cancel.mockResolvedValue('cancelled');
+
+		session = createDashSession({ baseUrl: 'https://is.test', op: 'auth' });
+		await session.begin();
+		// Let the immediate first poll setTimeout(tick, 0) fire and
+		// reach the getStatus await.
+		await new Promise((r) => setTimeout(r, 0));
+		expect(capturedSignal).toBeDefined();
+		expect(capturedSignal!.aborted).toBe(false);
+
+		await session.cancel();
+		// The pollAbort signal must NOT have been aborted by cancel()
+		// — R12 documented intent is to let the in-flight /status
+		// resolve on its own and rely on the gen-guard to make any
+		// late write benign.
+		expect(capturedSignal!.aborted).toBe(false);
+	});
+});
+
+// ────────── (6) cancel 409 → postCancelConflict + keep polling ───────────
+
+describe('R5-002 / R10-CORR-02 cancel 409 in-flight-conflict branch', () => {
+	it('phase stays "waiting" and postCancelConflict=true on 409', async () => {
+		globalThis.__dashTestClient.startSession.mockResolvedValue(makeStartResponse());
+		globalThis.__dashTestClient.getStatus.mockResolvedValue({
+			sid: 'sid-test',
+			state: 'ATTESTING',
+			expiresAt: new Date(Date.now() + 30 * 60_000).toISOString()
+		});
+		globalThis.__dashTestClient.cancel.mockResolvedValue('in-flight-conflict');
+
+		session = createDashSession({ baseUrl: 'https://is.test', op: 'auth' });
+		await session.begin();
+		// Let the first poll land.
+		await new Promise((r) => setTimeout(r, 0));
+		await session.cancel();
+
+		expect(session.phase).toBe('waiting');
+		expect(session.postCancelConflict).toBe(true);
+	});
+});
+
+// ──────── stop() aborts in-flight /status (R11-INFO-GETSTATUS-...) ────────
+
+describe('R11-INFO-GETSTATUS-NO-EXTERNAL-SIGNAL', () => {
+	it('stop() aborts the in-flight getStatus AbortController', async () => {
+		globalThis.__dashTestClient.startSession.mockResolvedValue(makeStartResponse());
+		const statusD = deferred<unknown>();
+		let capturedSignal: AbortSignal | undefined;
+		globalThis.__dashTestClient.getStatus.mockImplementation(
+			(_sid: string, signal?: AbortSignal) => {
+				capturedSignal = signal;
+				return statusD.promise as Promise<never>;
+			}
+		);
+		globalThis.__dashTestClient.cancel.mockResolvedValue('cancelled');
+
+		session = createDashSession({ baseUrl: 'https://is.test', op: 'auth' });
+		await session.begin();
+		await new Promise((r) => setTimeout(r, 0));
+		expect(capturedSignal).toBeDefined();
+		expect(capturedSignal!.aborted).toBe(false);
+
+		session.stop();
+		expect(capturedSignal!.aborted).toBe(true);
+		// Let the deferred resolve so the awaiting promise chain clears.
+		statusD.reject(new DOMException('aborted', 'AbortError'));
+	});
+});
+
+// ──────── pollErrCount backoff resets on schedulePoll (R12-...) ──────────
+
+describe('R12-CORR-POLLERRCOUNT-NOT-RESET-ACROSS-RETRY', () => {
+	it('schedulePoll entry resets pollErrCount so the staircase restarts from 2s on retry', async () => {
+		// Two begin() cycles on the same session instance. Attempt 1
+		// errors three times → pollErrCount=3 by end. Attempt 2 must
+		// start fresh (delay=2s on first failure, NOT 16s).
+		//
+		// We observe the cadence through the schedulePoll setTimeout
+		// argument by spying on globalThis.setTimeout. Inside
+		// schedulePoll the very first tick is `setTimeout(tick, 0)`;
+		// subsequent ticks call `setTimeout(tick, nextDelay)`. We
+		// count the second-and-later delays per attempt to verify
+		// the staircase.
+		globalThis.__dashTestClient.startSession.mockResolvedValue(makeStartResponse());
+		globalThis.__dashTestClient.getStatus.mockRejectedValue(new Error('network'));
+		globalThis.__dashTestClient.cancel.mockResolvedValue('cancelled');
+
+		const delays: number[] = [];
+		const realSetTimeout = globalThis.setTimeout;
+		const spy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(
+			((fn: () => void, ms?: number) => {
+				if (typeof ms === 'number' && ms > 0) delays.push(ms);
+				return realSetTimeout(fn, 0); // collapse delays to immediate
+			}) as typeof globalThis.setTimeout
+		);
+
+		session = createDashSession({ baseUrl: 'https://is.test', op: 'auth' });
+		await session.begin();
+		// Let multiple immediate ticks fire so the backoff staircase
+		// has at least 3 entries on this attempt.
+		for (let i = 0; i < 6; i++) await new Promise((r) => realSetTimeout(r, 0));
+		const attempt1Delays = [...delays];
+		expect(attempt1Delays.length).toBeGreaterThan(0);
+
+		// Cancel + retry — should reset.
+		await session.cancel();
+		delays.length = 0;
+		await session.begin();
+		for (let i = 0; i < 4; i++) await new Promise((r) => realSetTimeout(r, 0));
+
+		// Attempt 2's first non-zero delay must be the FRESH staircase
+		// step (POLL_INTERVAL_MS * 2^1 = 4000 — pollErrCount is
+		// incremented BEFORE the delay is computed in tick's catch),
+		// NOT a continuation of attempt 1's last value (which would
+		// be the 30000 cap since attempt 1 ran ≥6 failing ticks).
+		const attempt2First = delays.find((d) => d > 0);
+		expect(attempt2First).toBe(4000);
+
+		// Sanity: attempt 1's tail had to reach the cap so the
+		// not-reset failure mode would be observably different.
+		expect(attempt1Delays).toContain(30_000);
+
+		spy.mockRestore();
+	});
+});
+
+// ──────── (7) gen-guard: late getStatus does NOT overwrite cancel ─────────
+
+describe('R11-CORR-POLL-WRITES-AFTER-STOPPOLLING', () => {
+	it('getStatus that resolves after stopPolling/cancel does not flip phase to done', async () => {
+		globalThis.__dashTestClient.startSession.mockResolvedValue(makeStartResponse());
+		const statusD = deferred<{
+			sid: string;
+			state: string;
+			sessionToken?: string;
+			expiresAt: string;
+		}>();
+		globalThis.__dashTestClient.getStatus.mockReturnValue(statusD.promise);
+		globalThis.__dashTestClient.cancel.mockResolvedValue('cancelled');
+
+		session = createDashSession({ baseUrl: 'https://is.test', op: 'auth' });
+		await session.begin();
+		// Let schedulePoll arm + the first tick reach the getStatus await.
+		await new Promise((r) => setTimeout(r, 0));
+
+		// User cancels while getStatus is pending. stopPolling bumps
+		// pollGen; phase becomes 'failed' / 'cancelled'.
+		await session.cancel();
+		expect(session.phase).toBe('failed');
+
+		// NOW resolve the late getStatus with a terminal ON_CHAIN.
+		// The gen-guard in poll() must drop this write — phase must
+		// stay 'failed', NOT silently flip to 'done'.
+		statusD.resolve({
+			sid: 'sid-test',
+			state: 'ON_CHAIN',
+			sessionToken: 'late-token',
+			expiresAt: new Date(Date.now() + 30 * 60_000).toISOString()
+		});
+		// Flush the microtask queue.
+		await new Promise((r) => setTimeout(r, 0));
+		expect(session.phase).toBe('failed');
+	});
+});

--- a/src/lib/auth/dash/session.svelte.ts
+++ b/src/lib/auth/dash/session.svelte.ts
@@ -147,6 +147,11 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 	// TTL — the R9-DESIGN-STOP-NOCANCEL-01 fire-and-forget /cancel
 	// couldn't fire because we had no sid yet.
 	let startAbort: AbortController | undefined
+	// Round-11 audit R11-INFO-GETSTATUS-NO-EXTERNAL-SIGNAL: same
+	// pattern for in-flight /status fetches. stop() aborts any
+	// pending getStatus so the per-host socket frees immediately
+	// instead of holding for up to 30s.
+	let pollAbort: AbortController | undefined
 
 	const terminal = $derived(status ? isTerminal(status.state) : false);
 
@@ -175,28 +180,59 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 	// so we never have more than one /status fetch in flight. The
 	// pollGen check inside tick guarantees a stopPolling that lands
 	// between tick start and tick end cancels the re-arm.
+	//
+	// Round-11 audit R11-CORR-POLL-WRITES-AFTER-STOPPOLLING /
+	// R11-CORR-POLL-LATE-WRITE-MILD: the gen value is now threaded
+	// into poll() so a late getStatus resolution after stopPolling
+	// can't overwrite phase/status (was a cancel-after-paid →
+	// logged-in-anyway race on tight RTT).
+	//
+	// Round-11 audit R11-OPS-POLL-NO-BACKOFF-01: a fast-failing
+	// /status (ECONNREFUSED, DNS error) used to re-fire every 2s
+	// steady-state. We now track pollErrCount and exponential-back
+	// off the next interval; reset on first success.
+	let pollErrCount = 0;
+	const POLL_BACKOFF_MAX_MS = 30_000;
 	function schedulePoll() {
 		if (destroyed || !startResponse) return;
 		const sid = startResponse.sid;
 		const gen = ++pollGen;
 		const tick = async () => {
 			if (destroyed || gen !== pollGen) return;
-			await poll(sid);
+			const ok = await poll(sid, gen);
 			if (destroyed || gen !== pollGen) return;
-			pollTimer = setTimeout(tick, POLL_INTERVAL_MS);
+			let nextDelay = POLL_INTERVAL_MS;
+			if (!ok) {
+				nextDelay = Math.min(
+					POLL_INTERVAL_MS * Math.pow(2, pollErrCount),
+					POLL_BACKOFF_MAX_MS
+				);
+			}
+			pollTimer = setTimeout(tick, nextDelay);
 		};
+		// R11-INFO-SCHEDULEPOLL-NO-CLEARTIMEOUT: defensive cleanup
+		// of any stale timer before arming. pollGen already
+		// invalidates an old tick's re-arm decision; this clears
+		// the not-yet-fired one too.
+		if (pollTimer !== undefined) clearTimeout(pollTimer);
 		// Immediate first poll so phase=='waiting' flips quickly
-		// when the user paid before the modal opened (rare but
-		// possible — pre-cached deposit address).
+		// when the user paid before the modal opened.
 		pollTimer = setTimeout(tick, 0);
 	}
 
-	async function poll(sid: string) {
-		if (destroyed) return;
+	// poll returns true on success (so the caller can reset the
+	// backoff) and false on caught error. Round-11 audit
+	// R11-CORR-POLL-WRITES-AFTER-STOPPOLLING: gen-gated post-await
+	// writes so a stopPolling that bumped pollGen during the
+	// in-flight fetch invalidates this tick's writes too.
+	async function poll(sid: string, gen: number): Promise<boolean> {
+		if (destroyed || gen !== pollGen) return true;
+		pollAbort = new AbortController();
 		try {
-			const next = await client.getStatus(sid);
-			if (destroyed) return;
+			const next = await client.getStatus(sid, pollAbort.signal);
+			if (destroyed || gen !== pollGen) return true;
 			status = next;
+			pollErrCount = 0;
 			if (isTerminal(next.state)) {
 				stopPolling();
 				if (next.state === 'ON_CHAIN' && next.sessionToken) {
@@ -215,12 +251,11 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 					error = readableFailure(next.state);
 				}
 			}
+			return true;
 		} catch (e) {
-			// Round-9 audit R9-CORR-01a: respect the destroyed gate
-			// here too. Without this guard a /status fetch that
-			// rejects (e.g. 404 after stop() races a Prune) would
-			// write to $state on an unmounted component.
-			if (destroyed) return;
+			// Round-9 audit R9-CORR-01a + round-11 R11-CORR-POLL-WRITES-AFTER-STOPPOLLING:
+			// respect both gates here too.
+			if (destroyed || gen !== pollGen) return false;
 			// Network blip is non-fatal — server's own TTL bounds the
 			// session. Only escalate on a hard 4xx that says the session
 			// is gone.
@@ -228,7 +263,12 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 				stopPolling();
 				phase = 'failed';
 				error = 'session no longer available on the server';
+				return true; // terminal — no backoff needed
 			}
+			pollErrCount++;
+			return false;
+		} finally {
+			pollAbort = undefined;
 		}
 	}
 
@@ -246,11 +286,22 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 			const body: { op: IsOp; args?: CallArgs } = { op: opts.op };
 			if (opts.op === 'call' && opts.args) body.args = opts.args;
 			const sr = await client.startSession(body, startAbort.signal);
-			// Round-8 audit R8-CORR-02: stop() may have run while the
-			// fetch was in flight. If so, bail before arming pollTimer
-			// (which would otherwise write to $state for the full
-			// server TTL on a destroyed component).
-			if (destroyed) return;
+			// Round-8 audit R8-CORR-02 + round-11 audit
+			// R11-CORR-ORPHAN-FETCH-MICRORACE: stop() may have run
+			// while the fetch was in flight OR in the microtask gap
+			// between fetch resolution and this assignment. If the
+			// server already minted the session, abort() is a no-op
+			// against an already-resolved fetch — so emit a
+			// fire-and-forget /cancel here so the server-side record
+			// is released promptly rather than waiting 30 minutes.
+			if (destroyed) {
+				if (sr.sid && sr.addressSignature) {
+					void client.cancel(sr.sid, sr.addressSignature).catch((e) => {
+						console.debug('Dash session orphan-microrace cancel rejected:', e);
+					});
+				}
+				return;
+			}
 			startResponse = sr;
 			phase = 'waiting';
 			schedulePoll();
@@ -359,6 +410,13 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 	}
 
 	function stop(): void {
+		// Round-11 audit R11-DESIGN-STOP-NO-REENTRY-GUARD: short-circuit
+		// repeat calls. Without this, a parent component that wires
+		// stop() to both an onDestroy AND a user-initiated 'close'
+		// button fires duplicate fire-and-forget /cancel + spurious
+		// 401 log noise on the second invocation. Mirrors the guard
+		// shape in begin()/cancel()/poll().
+		if (destroyed) return;
 		// Round-8 audit R8-CORR-02: synchronous teardown for Svelte's
 		// onDestroy. Mark destroyed first so any in-flight begin() /
 		// poll() / cancel() resolves with a no-op tail. Then clear
@@ -382,6 +440,12 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 		stopPolling();
 		if (startAbort !== undefined) {
 			startAbort.abort();
+		}
+		// Round-11 audit R11-INFO-GETSTATUS-NO-EXTERNAL-SIGNAL: also
+		// abort any in-flight /status fetch so the socket frees
+		// immediately rather than holding for up to 30s after stop().
+		if (pollAbort !== undefined) {
+			pollAbort.abort();
 		}
 		if (sid && token) {
 			// Round-10 audit R10-INFO-01: client.cancel never throws,

--- a/src/lib/auth/dash/session.svelte.ts
+++ b/src/lib/auth/dash/session.svelte.ts
@@ -24,12 +24,16 @@
  *                                          // fire-and-forgets a
  *                                          // server-side /cancel
  *
- * Polling cadence is 2s (matches the IS service's dashd-watcher);
- * once the state becomes terminal the loop self-stops. cancel() and
+ * Polling cadence is 2s on the happy path; on /status errors we
+ * exponentially back off (4s → 8s → … → 30s cap, resets on first
+ * success) so a fast-failing endpoint doesn't get hammered. Once
+ * the state becomes terminal the loop self-stops. cancel() and
  * begin() are no-ops after stop(); the `destroyed` flag is private.
  *
  * Cross-references: R6-SEC-01 trap-deadline (240s); R8-CORR-02
- * stop/cancel split; R9-SEC-01 AbortController timeouts in isClient.
+ * stop/cancel split; R9-SEC-01 AbortController timeouts in isClient;
+ * R11-OPS-POLL-NO-BACKOFF-01 exponential backoff; R12-CORR-POLLERRCOUNT-
+ * NOT-RESET-ACROSS-RETRY reset on schedulePoll entry.
  */
 import {
 	IsServiceClient,
@@ -172,6 +176,12 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 		// true whenever the poll loop reached a real terminal state
 		// before the deadline fired.
 		postCancelConflict = false;
+		// Round-12 audit R12-CORR-POLLERRCOUNT-NOT-RESET-ACROSS-RETRY:
+		// reset the backoff counter so the invariant 'no polling →
+		// no error history' holds uniformly. Without this, a session
+		// instance reused across retry cycles inherits the previous
+		// attempt's backoff inflation.
+		pollErrCount = 0;
 	}
 
 	// schedulePoll: recursive setTimeout that runs one poll, then
@@ -195,6 +205,13 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 	const POLL_BACKOFF_MAX_MS = 30_000;
 	function schedulePoll() {
 		if (destroyed || !startResponse) return;
+		// Round-12 audit R12-CORR-POLLERRCOUNT-NOT-RESET-ACROSS-RETRY:
+		// fresh schedule = fresh backoff. Without this reset, a
+		// retry()→begin() cycle inherits the previous attempt's
+		// pollErrCount and the first failure on the new sid jumps
+		// straight to a longer delay instead of the documented
+		// 2s→4s→8s staircase.
+		pollErrCount = 0;
 		const sid = startResponse.sid;
 		const gen = ++pollGen;
 		const tick = async () => {
@@ -232,6 +249,17 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 			const next = await client.getStatus(sid, pollAbort.signal);
 			if (destroyed || gen !== pollGen) return true;
 			status = next;
+			// Round-12 audit R12-OPS-BACKOFF-NO-VISIBILITY-01: log
+			// recovery once when we transition out of backoff so an
+			// operator scanning console can confirm a previously-
+			// stuck session resumed.
+			if (pollErrCount > 0) {
+				console.debug(
+					'Dash session: /status backoff recovered after',
+					pollErrCount,
+					'consecutive failures'
+				);
+			}
 			pollErrCount = 0;
 			if (isTerminal(next.state)) {
 				stopPolling();
@@ -266,6 +294,20 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 				return true; // terminal — no backoff needed
 			}
 			pollErrCount++;
+			// Round-12 audit R12-OPS-BACKOFF-NO-VISIBILITY-01: log
+			// the transition into backoff (first failure) and at the
+			// cap so operators have a devtools-greppable signal when
+			// a session is stuck at the slow cadence.
+			const cappedDelay = Math.min(
+				POLL_INTERVAL_MS * Math.pow(2, pollErrCount),
+				POLL_BACKOFF_MAX_MS
+			);
+			if (pollErrCount === 1 || cappedDelay === POLL_BACKOFF_MAX_MS) {
+				console.debug(
+					'Dash session: /status backoff',
+					{ consecutiveFails: pollErrCount, nextDelayMs: cappedDelay }
+				);
+			}
 			return false;
 		} finally {
 			pollAbort = undefined;
@@ -395,6 +437,13 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 					return;
 				}
 			}
+			// Round-12 audit R12-DESIGN-CANCEL-DOES-NOT-ABORT-POLLABORT:
+			// we intentionally do NOT abort pollAbort here. The
+			// gen-guard inside poll() already invalidates any
+			// post-await write, and the in-flight socket frees on
+			// its own 30s timeout. Aborting here would cancel a
+			// /status request that might be landing terminal at
+			// the very same instant.
 			stopPolling();
 			// Round-10 audit R10-CORR-CANCEL-NO-STATUS-01: same as
 			// above — the 'cancelled' message is valid regardless

--- a/src/lib/auth/dash/session.svelte.ts
+++ b/src/lib/auth/dash/session.svelte.ts
@@ -25,15 +25,27 @@
  *                                          // server-side /cancel
  *
  * Polling cadence is 2s on the happy path; on /status errors we
- * exponentially back off (4s → 8s → … → 30s cap, resets on first
- * success) so a fast-failing endpoint doesn't get hammered. Once
- * the state becomes terminal the loop self-stops. cancel() and
+ * exponentially back off (4s → 8s → … → 30s cap) so a fast-failing
+ * endpoint doesn't get hammered. The backoff counter resets on
+ * THREE triggers so the staircase always restarts from the fresh
+ * step after a lifecycle transition:
+ *   - any successful /status that lands while pollErrCount > 0
+ *   - stopPolling() (any teardown — clean cancel, terminal-state
+ *     reach, stop())
+ *   - schedulePoll() entry (any fresh schedule, e.g. retry → begin)
+ *   - cancel()'s 409 in-flight-conflict / error branches that
+ *     return early without stopPolling (R13-CORR-BACKOFF-PERSISTS-
+ *     ACROSS-IN-FLIGHT-CONFLICT-RETRY)
+ * Once the state becomes terminal the loop self-stops. cancel() and
  * begin() are no-ops after stop(); the `destroyed` flag is private.
  *
  * Cross-references: R6-SEC-01 trap-deadline (240s); R8-CORR-02
  * stop/cancel split; R9-SEC-01 AbortController timeouts in isClient;
  * R11-OPS-POLL-NO-BACKOFF-01 exponential backoff; R12-CORR-POLLERRCOUNT-
- * NOT-RESET-ACROSS-RETRY reset on schedulePoll entry.
+ * NOT-RESET-ACROSS-RETRY reset on schedulePoll entry; R13-CORR-BACKOFF-
+ * PERSISTS-ACROSS-IN-FLIGHT-CONFLICT-RETRY reset on cancel-conflict;
+ * R13-OPS-CONSOLE-DEBUG-SUPPRESSED-BY-DEFAULT backoff log promoted to
+ * console.warn so operators see it at default DevTools Console levels.
  */
 import {
 	IsServiceClient,
@@ -294,19 +306,23 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 				return true; // terminal — no backoff needed
 			}
 			pollErrCount++;
-			// Round-12 audit R12-OPS-BACKOFF-NO-VISIBILITY-01: log
+			// Round-12 audit R12-OPS-BACKOFF-NO-VISIBILITY-01 + round-13
+			// audit R13-OPS-CONSOLE-DEBUG-SUPPRESSED-BY-DEFAULT: log
 			// the transition into backoff (first failure) and at the
 			// cap so operators have a devtools-greppable signal when
-			// a session is stuck at the slow cadence.
+			// a session is stuck at the slow cadence. R13 promoted
+			// this from console.debug → console.warn so it surfaces
+			// at default Console levels (Chromium/Firefox hide Debug
+			// by default — defeated R12's visibility intent).
 			const cappedDelay = Math.min(
 				POLL_INTERVAL_MS * Math.pow(2, pollErrCount),
 				POLL_BACKOFF_MAX_MS
 			);
 			if (pollErrCount === 1 || cappedDelay === POLL_BACKOFF_MAX_MS) {
-				console.debug(
-					'Dash session: /status backoff',
-					{ consecutiveFails: pollErrCount, nextDelayMs: cappedDelay }
-				);
+				console.warn('Dash session: /status backoff', {
+					consecutiveFails: pollErrCount,
+					nextDelayMs: cappedDelay
+				});
 			}
 			return false;
 		} finally {
@@ -417,6 +433,15 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 					// progressing. Round-6 R6-SEC-01: arm the
 					// trap-deadline so a misbehaving server can't keep
 					// /status in non-terminal forever.
+					//
+					// Round-13 audit R13-CORR-BACKOFF-PERSISTS-ACROSS-
+					// IN-FLIGHT-CONFLICT-RETRY: reset the pollErrCount
+					// staircase here too. R12 only reset on stopPolling
+					// and on schedulePoll entry; the 409 branch returns
+					// early without either, so a retry that hit 409
+					// inherited the previous attempt's backoff
+					// inflation (cadence stuck at the 30s cap).
+					pollErrCount = 0;
 					postCancelConflict = true;
 					if (postCancelDeadlineTimer === undefined) {
 						postCancelDeadlineTimer = setTimeout(() => {

--- a/src/lib/auth/dash/session.svelte.ts
+++ b/src/lib/auth/dash/session.svelte.ts
@@ -18,6 +18,7 @@ import {
 	IsServiceError,
 	isTerminal,
 	type CallArgs,
+	type CancelResult,
 	type IsOp,
 	type IsSessionState,
 	type SessionStartResponse,
@@ -156,26 +157,17 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 	async function cancel(): Promise<void> {
 		const sid = startResponse?.sid;
 		const cancelToken = startResponse?.addressSignature;
-		// Round-5 audit R5-002: don't pre-set phase='failed' before we
-		// know whether the server can honour the cancel. If it returns
-		// 409 (R4-003 in-flight refusal), the session is still
-		// progressing toward a real terminal state and we keep polling
-		// — destroying that flow here would lose a legitimate login.
-		//
-		// Round-6 audit R6-CORR-04: a transient network/5xx error on
-		// the cancel request shape this code as outcome='error'. The
-		// pre-R6 implementation had an empty branch that fell through
-		// to stopPolling()+phase='failed' — re-introducing R5-002 by
-		// a different door. Treat 'error' the same as
-		// 'in-flight-conflict': keep polling and let the next /status
-		// poll reach the real terminal state on its own.
+		// Round-7 audit R7-CORR-02: reset the conflict banner on
+		// every call so a later clean cancel clears the previous
+		// 'finishing server-side step' state.
+		postCancelConflict = false;
+		// Round-5 audit R5-002 + round-6 R6-CORR-04 + round-7 R7-DRIFT-02:
+		// the client's CancelResult discriminator now covers all three
+		// outcomes (clean cancel, server 409 in-flight refusal, transient
+		// network/5xx error). 'in-flight-conflict' and 'error' both
+		// keep polling so the user reaches a real terminal state.
 		if (sid && cancelToken) {
-			let outcome: 'cancelled' | 'in-flight-conflict' | 'error' = 'cancelled';
-			try {
-				outcome = await client.cancel(sid, cancelToken);
-			} catch {
-				outcome = 'error';
-			}
+			const outcome: CancelResult = await client.cancel(sid, cancelToken);
 			if (outcome === 'in-flight-conflict' || outcome === 'error') {
 				// Server is mid-attestation OR the cancel request
 				// couldn't be confirmed. Keep polling so the user
@@ -187,6 +179,7 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 				postCancelConflict = true;
 				if (postCancelDeadlineTimer === undefined) {
 					postCancelDeadlineTimer = setTimeout(() => {
+						postCancelConflict = false;
 						stopPolling();
 						if (status && !isTerminal(status.state)) {
 							phase = 'failed';

--- a/src/lib/auth/dash/session.svelte.ts
+++ b/src/lib/auth/dash/session.svelte.ts
@@ -118,15 +118,20 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 	async function cancel(): Promise<void> {
 		stopPolling();
 		const sid = startResponse?.sid;
+		const cancelToken = startResponse?.addressSignature;
 		// Mark UI cancelled immediately so a slow network doesn't leave
 		// the modal stuck on "waiting".
 		if (status && !isTerminal(status.state)) {
 			phase = 'failed';
 			error = 'cancelled';
 		}
-		if (sid) {
+		// Need both sid AND the cancelToken — server rejects 401
+		// without the header (audit TC2-01). If the user clicked Cancel
+		// before /session/start returned, there's nothing to cancel
+		// server-side yet.
+		if (sid && cancelToken) {
 			try {
-				await client.cancel(sid);
+				await client.cancel(sid, cancelToken);
 			} catch {
 				/* server may already have GC'd — fine */
 			}

--- a/src/lib/auth/dash/session.svelte.ts
+++ b/src/lib/auth/dash/session.svelte.ts
@@ -25,6 +25,15 @@ import {
 } from './isClient';
 
 const POLL_INTERVAL_MS = 2000;
+// Round-6 audit R6-SEC-01: bound how long we keep polling after a
+// user-initiated cancel hit a 409 / network-error. A compromised IS
+// service could respond with 409 to every cancel AND keep /status in
+// non-terminal forever, trapping the user's modal. After this
+// deadline the client force-fails the modal regardless of server
+// state. The window covers the server's own reconcile budget
+// (~180s) with margin so legitimate in-flight L2 reconciles still
+// land before the trap-deadline kicks in.
+const POST_CANCEL_DEADLINE_MS = 240_000;
 
 export type DashSessionOpts = {
 	baseUrl: string;
@@ -43,6 +52,14 @@ export type DashSessionState = {
 	readonly error: string | undefined;
 	/** True when state machine reached a terminal state. */
 	readonly terminal: boolean;
+	/**
+	 * True after the user clicked cancel and the server refused with
+	 * 409 (R4-003 in-flight) OR the cancel request errored. While
+	 * this flag is set we keep polling until a real terminal state
+	 * (or the R6-SEC-01 deadline). Useful for surfacing a 'finishing
+	 * server-side step' banner in the modal.
+	 */
+	readonly postCancelConflict: boolean;
 };
 
 export type DashSession = DashSessionState & {
@@ -58,6 +75,14 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 	let phase = $state<DashSessionState['phase']>('idle');
 	let error = $state<string | undefined>(undefined);
 	let pollTimer: ReturnType<typeof setInterval> | undefined;
+	// Round-6 audit R6-SEC-01: trap-deadline timer for post-cancel
+	// polling. Set when the user clicks cancel and the server
+	// refuses (409) or the cancel request errors; if the next
+	// terminal state doesn't arrive within POST_CANCEL_DEADLINE_MS
+	// the modal is force-failed so a misbehaving IS service can't
+	// trap the user indefinitely.
+	let postCancelDeadlineTimer: ReturnType<typeof setTimeout> | undefined;
+	let postCancelConflict = $state(false);
 
 	const terminal = $derived(status ? isTerminal(status.state) : false);
 
@@ -65,6 +90,10 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 		if (pollTimer !== undefined) {
 			clearInterval(pollTimer);
 			pollTimer = undefined;
+		}
+		if (postCancelDeadlineTimer !== undefined) {
+			clearTimeout(postCancelDeadlineTimer);
+			postCancelDeadlineTimer = undefined;
 		}
 	}
 
@@ -132,6 +161,14 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 		// 409 (R4-003 in-flight refusal), the session is still
 		// progressing toward a real terminal state and we keep polling
 		// — destroying that flow here would lose a legitimate login.
+		//
+		// Round-6 audit R6-CORR-04: a transient network/5xx error on
+		// the cancel request shape this code as outcome='error'. The
+		// pre-R6 implementation had an empty branch that fell through
+		// to stopPolling()+phase='failed' — re-introducing R5-002 by
+		// a different door. Treat 'error' the same as
+		// 'in-flight-conflict': keep polling and let the next /status
+		// poll reach the real terminal state on its own.
 		if (sid && cancelToken) {
 			let outcome: 'cancelled' | 'in-flight-conflict' | 'error' = 'cancelled';
 			try {
@@ -139,14 +176,25 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 			} catch {
 				outcome = 'error';
 			}
-			if (outcome === 'in-flight-conflict') {
-				// Server is mid-attestation or mid-L2-submit; keep
-				// polling so the user reaches a real terminal state.
+			if (outcome === 'in-flight-conflict' || outcome === 'error') {
+				// Server is mid-attestation OR the cancel request
+				// couldn't be confirmed. Keep polling so the user
+				// reaches a real terminal state instead of seeing a
+				// spurious 'failed' for a session that may still be
+				// progressing. Round-6 R6-SEC-01: arm the
+				// trap-deadline so a misbehaving server can't keep
+				// /status in non-terminal forever.
+				postCancelConflict = true;
+				if (postCancelDeadlineTimer === undefined) {
+					postCancelDeadlineTimer = setTimeout(() => {
+						stopPolling();
+						if (status && !isTerminal(status.state)) {
+							phase = 'failed';
+							error = 'cancel acknowledged but session did not finish on the server in time';
+						}
+					}, POST_CANCEL_DEADLINE_MS);
+				}
 				return;
-			}
-			if (outcome === 'error') {
-				// Server may already have GC'd — surface the cancel
-				// in the UI but don't poison the modal with an error.
 			}
 		}
 		stopPolling();
@@ -171,6 +219,9 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 		},
 		get terminal() {
 			return terminal;
+		},
+		get postCancelConflict() {
+			return postCancelConflict;
 		},
 		begin,
 		cancel

--- a/src/lib/auth/dash/session.svelte.ts
+++ b/src/lib/auth/dash/session.svelte.ts
@@ -78,7 +78,16 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 					phase = 'done';
 				} else {
 					phase = 'failed';
-					error = next.forwardError || readableFailure(next.state);
+					// Round-3 audit R3-CSM-10: the server's forwardError
+					// contains operator-language ('L2 reconcile timed
+					// out — inspect chain state to recover' with a raw
+					// l2TxId) — useless to a non-technical user. Prefer
+					// the localized readableFailure mapping; surface the
+					// raw forwardError only as a console.warn for ops.
+					if (next.forwardError) {
+						console.warn('IS session failed with operator detail:', next.forwardError);
+					}
+					error = readableFailure(next.state);
 				}
 			}
 		} catch (e) {
@@ -159,15 +168,25 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 	};
 }
 
+// readableFailure converts a server-side IS session state into a
+// user-facing message. Round-3 audit R3-CSM-10 split the reconcile-
+// related ForwardError variants out of the generic FORWARD_FAILED
+// bucket because the server text is operator language (e.g. "L2
+// reconcile timed out — inspect chain state to recover (l2TxId=...)").
+//
+// New states from D2-DESIGN-06 (L2_SUBMITTED + reconcile result) get
+// mapped here so non-technical users see actionable copy.
 function readableFailure(state: IsSessionState): string {
 	switch (state) {
 		case 'ATTESTATION_TIMEOUT':
-			return 'validator quorum not reached in time';
+			return 'Validator quorum was not reached in time. Please try again — if this persists, contact support.';
 		case 'FORWARD_FAILED':
-			return 'on-chain forward failed';
+			return 'The on-chain step failed. Your Dash deposit will be available via the slow path; contact support to recover.';
 		case 'EXPIRED':
-			return 'session expired before payment was observed';
+			return 'The session expired before your InstantSend payment was observed.';
+		case 'SLOW_PATH_PENDING':
+			return 'Your payment is being processed via the slow path. This may take a few minutes.';
 		default:
-			return `session failed in state ${state}`;
+			return 'Sign-in failed. Please try again — if this persists, contact support.';
 	}
 }

--- a/src/lib/auth/dash/session.svelte.ts
+++ b/src/lib/auth/dash/session.svelte.ts
@@ -1,0 +1,168 @@
+/**
+ * Reactive session wrapper around IsServiceClient. Owns the polling loop,
+ * lifecycle, and Svelte 5 $state so consumers can bind to status text /
+ * QR data without managing intervals themselves.
+ *
+ * Usage:
+ *
+ *   const session = createDashSession({ baseUrl, op: 'auth' });
+ *   session.start();                       // returns when start() resolves
+ *   // ... UI binds to session.state, session.start_response, etc.
+ *   session.cancel();                      // tears down poll + tells server
+ *
+ * Polling is 2s, matching the IS service's dashd-watcher cadence; once
+ * the state becomes terminal the loop self-stops.
+ */
+import {
+	IsServiceClient,
+	IsServiceError,
+	isTerminal,
+	type CallArgs,
+	type IsOp,
+	type IsSessionState,
+	type SessionStartResponse,
+	type SessionStatusResponse
+} from './isClient';
+
+const POLL_INTERVAL_MS = 2000;
+
+export type DashSessionOpts = {
+	baseUrl: string;
+	op: IsOp;
+	args?: CallArgs;
+};
+
+export type DashSessionState = {
+	/** Last status the server reported. `undefined` until first poll lands. */
+	readonly status: SessionStatusResponse | undefined;
+	/** Response from session/start. Includes deposit address + QR data. */
+	readonly startResponse: SessionStartResponse | undefined;
+	/** Loading / error UI hook. */
+	readonly phase: 'idle' | 'starting' | 'waiting' | 'done' | 'failed';
+	/** Human-facing error message — populated alongside phase=failed. */
+	readonly error: string | undefined;
+	/** True when state machine reached a terminal state. */
+	readonly terminal: boolean;
+};
+
+export type DashSession = DashSessionState & {
+	begin(): Promise<void>;
+	cancel(): Promise<void>;
+};
+
+export function createDashSession(opts: DashSessionOpts): DashSession {
+	const client = new IsServiceClient(opts.baseUrl);
+
+	let startResponse = $state<SessionStartResponse | undefined>(undefined);
+	let status = $state<SessionStatusResponse | undefined>(undefined);
+	let phase = $state<DashSessionState['phase']>('idle');
+	let error = $state<string | undefined>(undefined);
+	let pollTimer: ReturnType<typeof setInterval> | undefined;
+
+	const terminal = $derived(status ? isTerminal(status.state) : false);
+
+	function stopPolling() {
+		if (pollTimer !== undefined) {
+			clearInterval(pollTimer);
+			pollTimer = undefined;
+		}
+	}
+
+	async function poll(sid: string) {
+		try {
+			const next = await client.getStatus(sid);
+			status = next;
+			if (isTerminal(next.state)) {
+				stopPolling();
+				if (next.state === 'ON_CHAIN' && next.sessionToken) {
+					phase = 'done';
+				} else {
+					phase = 'failed';
+					error = next.forwardError || readableFailure(next.state);
+				}
+			}
+		} catch (e) {
+			// Network blip is non-fatal — server's own TTL bounds the
+			// session. Only escalate on a hard 4xx that says the session
+			// is gone.
+			if (e instanceof IsServiceError && (e.status === 404 || e.status === 410)) {
+				stopPolling();
+				phase = 'failed';
+				error = 'session no longer available on the server';
+			}
+		}
+	}
+
+	async function begin(): Promise<void> {
+		if (phase !== 'idle' && phase !== 'failed') return;
+		phase = 'starting';
+		error = undefined;
+		try {
+			const body: { op: IsOp; args?: CallArgs } = { op: opts.op };
+			if (opts.op === 'call' && opts.args) body.args = opts.args;
+			startResponse = await client.startSession(body);
+			phase = 'waiting';
+			pollTimer = setInterval(() => {
+				if (startResponse) void poll(startResponse.sid);
+			}, POLL_INTERVAL_MS);
+			// Immediate first poll so the UI surfaces ATTESTING quickly
+			// when the user paid before the modal even opened (rare but
+			// possible — pre-cached deposit address).
+			void poll(startResponse.sid);
+		} catch (e) {
+			phase = 'failed';
+			error = e instanceof Error ? e.message : 'failed to start session';
+		}
+	}
+
+	async function cancel(): Promise<void> {
+		stopPolling();
+		const sid = startResponse?.sid;
+		// Mark UI cancelled immediately so a slow network doesn't leave
+		// the modal stuck on "waiting".
+		if (status && !isTerminal(status.state)) {
+			phase = 'failed';
+			error = 'cancelled';
+		}
+		if (sid) {
+			try {
+				await client.cancel(sid);
+			} catch {
+				/* server may already have GC'd — fine */
+			}
+		}
+	}
+
+	return {
+		get status() {
+			return status;
+		},
+		get startResponse() {
+			return startResponse;
+		},
+		get phase() {
+			return phase;
+		},
+		get error() {
+			return error;
+		},
+		get terminal() {
+			return terminal;
+		},
+		begin,
+		cancel
+	};
+}
+
+function readableFailure(state: IsSessionState): string {
+	switch (state) {
+		case 'ATTESTATION_TIMEOUT':
+			return 'validator quorum not reached in time';
+		case 'FORWARD_FAILED':
+			return 'on-chain forward failed';
+		case 'EXPIRED':
+			return 'session expired before payment was observed';
+		default:
+			return `session failed in state ${state}`;
+	}
+}

--- a/src/lib/auth/dash/session.svelte.ts
+++ b/src/lib/auth/dash/session.svelte.ts
@@ -66,6 +66,17 @@ export type DashSessionState = {
 export type DashSession = DashSessionState & {
 	begin(): Promise<void>;
 	cancel(): Promise<void>;
+	/**
+	 * Synchronous teardown — clears the poll interval and the R6-SEC-01
+	 * trap-deadline timer immediately, marks the session destroyed,
+	 * and (if a sid is known) issues a best-effort fire-and-forget
+	 * server-side cancel so the server's session record is released.
+	 * Safe to call from Svelte's onDestroy hook. Round-8 audit
+	 * R8-CORR-02: the previous onDestroy(() => cancel()) path leaked
+	 * pollTimer + 240s deadline on the 409/error branches because
+	 * cancel() intentionally skipped stopPolling in those cases.
+	 */
+	stop(): void;
 };
 
 export function createDashSession(opts: DashSessionOpts): DashSession {
@@ -84,6 +95,20 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 	// trap the user indefinitely.
 	let postCancelDeadlineTimer: ReturnType<typeof setTimeout> | undefined;
 	let postCancelConflict = $state(false);
+	// Round-8 audit R8-CORR-02: destroyed gate. Once stop() runs,
+	// poll() / cancel() / begin() must NOT re-arm any timer or write
+	// to $state cells. Solves the begin()/onDestroy race (start was
+	// in-flight at unmount → resolves after with a fresh
+	// setInterval) and the 409/error-branch leak (cancel returned
+	// early without stopPolling).
+	let destroyed = false
+	// Round-8 audit R8-INFO-02 + R8-DESIGN-02: concurrency guard for
+	// cancel(). The modal has three cancel call-sites (onDestroy,
+	// $effect open=false, retry()). Without this flag, a 409 from
+	// the first cancel can cascade into a second cancel arming a
+	// fresh 240s timer after the first stopPolling has already
+	// cleared it.
+	let cancelling = false
 
 	const terminal = $derived(status ? isTerminal(status.state) : false);
 
@@ -96,11 +121,18 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 			clearTimeout(postCancelDeadlineTimer);
 			postCancelDeadlineTimer = undefined;
 		}
+		// Round-8 audit R8-CORR-01: clearing the post-cancel timer
+		// without resetting the banner left postCancelConflict stuck
+		// true whenever the poll loop reached a real terminal state
+		// before the deadline fired.
+		postCancelConflict = false;
 	}
 
 	async function poll(sid: string) {
+		if (destroyed) return;
 		try {
 			const next = await client.getStatus(sid);
+			if (destroyed) return;
 			status = next;
 			if (isTerminal(next.state)) {
 				stopPolling();
@@ -133,13 +165,20 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 	}
 
 	async function begin(): Promise<void> {
+		if (destroyed) return;
 		if (phase !== 'idle' && phase !== 'failed') return;
 		phase = 'starting';
 		error = undefined;
 		try {
 			const body: { op: IsOp; args?: CallArgs } = { op: opts.op };
 			if (opts.op === 'call' && opts.args) body.args = opts.args;
-			startResponse = await client.startSession(body);
+			const sr = await client.startSession(body);
+			// Round-8 audit R8-CORR-02: stop() may have run while the
+			// fetch was in flight. If so, bail before arming pollTimer
+			// (which would otherwise write to $state for the full
+			// server TTL on a destroyed component).
+			if (destroyed) return;
+			startResponse = sr;
 			phase = 'waiting';
 			pollTimer = setInterval(() => {
 				if (startResponse) void poll(startResponse.sid);
@@ -149,52 +188,76 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 			// possible — pre-cached deposit address).
 			void poll(startResponse.sid);
 		} catch (e) {
+			if (destroyed) return;
 			phase = 'failed';
 			error = e instanceof Error ? e.message : 'failed to start session';
 		}
 	}
 
 	async function cancel(): Promise<void> {
-		const sid = startResponse?.sid;
-		const cancelToken = startResponse?.addressSignature;
-		// Round-7 audit R7-CORR-02: reset the conflict banner on
-		// every call so a later clean cancel clears the previous
-		// 'finishing server-side step' state.
-		postCancelConflict = false;
-		// Round-5 audit R5-002 + round-6 R6-CORR-04 + round-7 R7-DRIFT-02:
-		// the client's CancelResult discriminator now covers all three
-		// outcomes (clean cancel, server 409 in-flight refusal, transient
-		// network/5xx error). 'in-flight-conflict' and 'error' both
-		// keep polling so the user reaches a real terminal state.
-		if (sid && cancelToken) {
-			const outcome: CancelResult = await client.cancel(sid, cancelToken);
-			if (outcome === 'in-flight-conflict' || outcome === 'error') {
-				// Server is mid-attestation OR the cancel request
-				// couldn't be confirmed. Keep polling so the user
-				// reaches a real terminal state instead of seeing a
-				// spurious 'failed' for a session that may still be
-				// progressing. Round-6 R6-SEC-01: arm the
-				// trap-deadline so a misbehaving server can't keep
-				// /status in non-terminal forever.
-				postCancelConflict = true;
-				if (postCancelDeadlineTimer === undefined) {
-					postCancelDeadlineTimer = setTimeout(() => {
-						postCancelConflict = false;
-						stopPolling();
-						if (status && !isTerminal(status.state)) {
-							phase = 'failed';
-							error = 'cancel acknowledged but session did not finish on the server in time';
-						}
-					}, POST_CANCEL_DEADLINE_MS);
+		// Round-8 audit R8-INFO-02 + R8-DESIGN-02: reject re-entry.
+		// DashLogin has 3 cancel call-sites (onDestroy, $effect on
+		// close, retry()); back-to-back invocations used to fire
+		// duplicate POST /cancel + re-arm the trap-deadline.
+		if (destroyed || cancelling) return;
+		cancelling = true;
+		try {
+			const sid = startResponse?.sid;
+			const cancelToken = startResponse?.addressSignature;
+			// Round-7 audit R7-CORR-02: reset the conflict banner on
+			// every call so a later clean cancel clears the previous
+			// 'finishing server-side step' state.
+			postCancelConflict = false;
+			// Round-5 audit R5-002 + round-6 R6-CORR-04 + round-7 R7-DRIFT-02:
+			// the client's CancelResult discriminator now covers all three
+			// outcomes (clean cancel, server 409 in-flight refusal, transient
+			// network/5xx error). 'in-flight-conflict' and 'error' both
+			// keep polling so the user reaches a real terminal state.
+			if (sid && cancelToken) {
+				const outcome: CancelResult = await client.cancel(sid, cancelToken);
+				if (destroyed) return;
+				if (outcome === 'in-flight-conflict' || outcome === 'error') {
+					// Server is mid-attestation OR the cancel request
+					// couldn't be confirmed. Keep polling so the user
+					// reaches a real terminal state instead of seeing a
+					// spurious 'failed' for a session that may still be
+					// progressing. Round-6 R6-SEC-01: arm the
+					// trap-deadline so a misbehaving server can't keep
+					// /status in non-terminal forever.
+					postCancelConflict = true;
+					if (postCancelDeadlineTimer === undefined) {
+						postCancelDeadlineTimer = setTimeout(() => {
+							if (destroyed) return;
+							postCancelConflict = false;
+							stopPolling();
+							if (status && !isTerminal(status.state)) {
+								phase = 'failed';
+								error = 'cancel acknowledged but session did not finish on the server in time';
+							}
+						}, POST_CANCEL_DEADLINE_MS);
+					}
+					return;
 				}
-				return;
 			}
+			stopPolling();
+			if (status && !isTerminal(status.state)) {
+				phase = 'failed';
+				error = 'cancelled';
+			}
+		} finally {
+			cancelling = false;
 		}
+	}
+
+	function stop(): void {
+		// Round-8 audit R8-CORR-02: synchronous teardown for Svelte's
+		// onDestroy. Mark destroyed first so any in-flight begin() /
+		// poll() / cancel() resolves with a no-op tail. Then clear
+		// timers. We do NOT fire a server-side /cancel here — the
+		// component is going away and the server's own TTL bounds the
+		// session.
+		destroyed = true;
 		stopPolling();
-		if (status && !isTerminal(status.state)) {
-			phase = 'failed';
-			error = 'cancelled';
-		}
 	}
 
 	return {
@@ -217,7 +280,8 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 			return postCancelConflict;
 		},
 		begin,
-		cancel
+		cancel,
+		stop
 	};
 }
 

--- a/src/lib/auth/dash/session.svelte.ts
+++ b/src/lib/auth/dash/session.svelte.ts
@@ -176,7 +176,16 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 	// pattern for in-flight /status fetches. stop() aborts any
 	// pending getStatus so the per-host socket frees immediately
 	// instead of holding for up to 30s.
-	let pollAbort: AbortController | undefined
+	//
+	// Audit R15-CORR-poll-late-finally-clobbers-new-controller (LOW):
+	// pollAbort is GEN-tagged so an old tick whose finally runs AFTER
+	// a new tick already grabbed pollAbort can't blindly null it.
+	// The old finally checks `pollAbort.gen === gen` before clearing.
+	// Without this, a cancel-409's schedulePoll() re-arm could leave
+	// stop() unable to abort the new in-flight fetch — the per-host
+	// socket then stays held until the browser's ~30s default,
+	// defeating the R11 fix.
+	let pollAbort: { gen: number; ctrl: AbortController } | undefined
 
 	const terminal = $derived(status ? isTerminal(status.state) : false);
 
@@ -278,9 +287,10 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 	// in-flight fetch invalidates this tick's writes too.
 	async function poll(sid: string, gen: number): Promise<boolean> {
 		if (destroyed || gen !== pollGen) return true;
-		pollAbort = new AbortController();
+		const ctrl = new AbortController();
+		pollAbort = { gen, ctrl };
 		try {
-			const next = await client.getStatus(sid, pollAbort.signal);
+			const next = await client.getStatus(sid, ctrl.signal);
 			if (destroyed || gen !== pollGen) return true;
 			status = next;
 			// Round-12 audit R12-OPS-BACKOFF-NO-VISIBILITY-01: log
@@ -364,7 +374,15 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 			if (atCap) atBackoffCap = true;
 			return false;
 		} finally {
-			pollAbort = undefined;
+			// Audit R15-CORR-poll-late-finally-clobbers-new-controller:
+			// only clear pollAbort if it still references OUR tick. A
+			// stale tick whose await resolved AFTER a newer tick already
+			// installed a new controller must NOT clobber that newer
+			// reference — otherwise stop() can't abort the in-flight
+			// fetch and the socket stays held.
+			if (pollAbort?.gen === gen) {
+				pollAbort = undefined;
+			}
 		}
 	}
 
@@ -570,8 +588,11 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 		// Round-11 audit R11-INFO-GETSTATUS-NO-EXTERNAL-SIGNAL: also
 		// abort any in-flight /status fetch so the socket frees
 		// immediately rather than holding for up to 30s after stop().
+		// Audit R15-CORR-poll-late-finally-clobbers-new-controller:
+		// pollAbort is now { gen, ctrl } so the .abort() goes through
+		// the wrapper.
 		if (pollAbort !== undefined) {
-			pollAbort.abort();
+			pollAbort.ctrl.abort();
 		}
 		if (sid && token) {
 			// Round-10 audit R10-INFO-01: client.cancel never throws,

--- a/src/lib/auth/dash/session.svelte.ts
+++ b/src/lib/auth/dash/session.svelte.ts
@@ -27,8 +27,11 @@
  * Polling cadence is 2s on the happy path; on /status errors we
  * exponentially back off (4s → 8s → … → 30s cap) so a fast-failing
  * endpoint doesn't get hammered. The backoff counter resets on
- * THREE triggers so the staircase always restarts from the fresh
- * step after a lifecycle transition:
+ * multiple triggers so the staircase always restarts from the fresh
+ * step after a lifecycle transition (R14-DRIFT-DOCSTRING-THREE-VS-
+ * FOUR-TRIGGERS: dropped the prose count word — the R13 fix added
+ * a fourth bullet without bumping it, recreating the very drift it
+ * was meant to close; use the list as the authoritative source):
  *   - any successful /status that lands while pollErrCount > 0
  *   - stopPolling() (any teardown — clean cancel, terminal-state
  *     reach, stop())
@@ -41,11 +44,17 @@
  *
  * Cross-references: R6-SEC-01 trap-deadline (240s); R8-CORR-02
  * stop/cancel split; R9-SEC-01 AbortController timeouts in isClient;
- * R11-OPS-POLL-NO-BACKOFF-01 exponential backoff; R12-CORR-POLLERRCOUNT-
- * NOT-RESET-ACROSS-RETRY reset on schedulePoll entry; R13-CORR-BACKOFF-
- * PERSISTS-ACROSS-IN-FLIGHT-CONFLICT-RETRY reset on cancel-conflict;
- * R13-OPS-CONSOLE-DEBUG-SUPPRESSED-BY-DEFAULT backoff log promoted to
- * console.warn so operators see it at default DevTools Console levels.
+ * R10-OPS-POLL-OVERLAP-01 recursive-setTimeout single-in-flight
+ * /status; R10-CORR-ORPHAN-SESSION-01 startSession AbortController
+ * for unmount race; R11-OPS-POLL-NO-BACKOFF-01 exponential backoff;
+ * R12-CORR-POLLERRCOUNT-NOT-RESET-ACROSS-RETRY reset on schedulePoll
+ * entry; R13-CORR-BACKOFF-PERSISTS-ACROSS-IN-FLIGHT-CONFLICT-RETRY
+ * reset on cancel-conflict; R13-OPS-CONSOLE-DEBUG-SUPPRESSED-BY-
+ * DEFAULT backoff log promoted to console.warn so operators see it
+ * at default DevTools Console levels; R14-OPS-BACKOFF-WARN-FLOODS-
+ * AT-CAP cap-reached log is now edge-triggered (entry only) and
+ * recovery log promoted to console.warn so both lifecycle halves
+ * surface at the same level.
  */
 import {
 	IsServiceClient,
@@ -194,6 +203,7 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 		// instance reused across retry cycles inherits the previous
 		// attempt's backoff inflation.
 		pollErrCount = 0;
+		atBackoffCap = false;
 	}
 
 	// schedulePoll: recursive setTimeout that runs one poll, then
@@ -214,6 +224,15 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 	// steady-state. We now track pollErrCount and exponential-back
 	// off the next interval; reset on first success.
 	let pollErrCount = 0;
+	// Round-14 audit R14-OPS-BACKOFF-WARN-FLOODS-AT-CAP: edge-trigger
+	// the cap-reached warn. Without this flag a stuck poll loop fires
+	// console.warn on every failing tick once pollErrCount >= 4 — at
+	// the 30s steady cadence that's ~120 warns/hr/session, training
+	// operators to filter the prefix out and defeating R13's
+	// visibility promotion. We set it on entry into cap (warn once),
+	// keep it set while in cap (silent), and clear it on recovery
+	// (handled in poll() success branch).
+	let atBackoffCap = false;
 	const POLL_BACKOFF_MAX_MS = 30_000;
 	function schedulePoll() {
 		if (destroyed || !startResponse) return;
@@ -222,8 +241,11 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 		// retry()→begin() cycle inherits the previous attempt's
 		// pollErrCount and the first failure on the new sid jumps
 		// straight to a longer delay instead of the documented
-		// 2s→4s→8s staircase.
+		// 2s→4s→8s staircase. Round-14 R14-OPS-BACKOFF-WARN-FLOODS-
+		// AT-CAP: drop the cap-latch too so the first failing tick
+		// on the new schedule re-fires the entry warn.
 		pollErrCount = 0;
+		atBackoffCap = false;
 		const sid = startResponse.sid;
 		const gen = ++pollGen;
 		const tick = async () => {
@@ -264,13 +286,18 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 			// Round-12 audit R12-OPS-BACKOFF-NO-VISIBILITY-01: log
 			// recovery once when we transition out of backoff so an
 			// operator scanning console can confirm a previously-
-			// stuck session resumed.
+			// stuck session resumed. Round-14 R14-OPS-BACKOFF-WARN-
+			// FLOODS-AT-CAP promoted to console.warn so the entry
+			// log (warn) and recovery log surface at the same level
+			// — otherwise default DevTools Console levels hid the
+			// recovery half while the entry half was visible.
 			if (pollErrCount > 0) {
-				console.debug(
+				console.warn(
 					'Dash session: /status backoff recovered after',
 					pollErrCount,
 					'consecutive failures'
 				);
+				atBackoffCap = false;
 			}
 			pollErrCount = 0;
 			if (isTerminal(next.state)) {
@@ -318,12 +345,23 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 				POLL_INTERVAL_MS * Math.pow(2, pollErrCount),
 				POLL_BACKOFF_MAX_MS
 			);
-			if (pollErrCount === 1 || cappedDelay === POLL_BACKOFF_MAX_MS) {
+			// Round-14 audit R14-OPS-BACKOFF-WARN-FLOODS-AT-CAP: fire
+			// at the first failure (transition into backoff) and
+			// exactly once on transition INTO the cap, then go silent
+			// until either recovery or another lifecycle event. The
+			// previous "cappedDelay === POLL_BACKOFF_MAX_MS" guard
+			// fired on every tick once the cap latched, flooding the
+			// console.
+			const atCap = cappedDelay === POLL_BACKOFF_MAX_MS;
+			const enteringCap = atCap && !atBackoffCap;
+			if (pollErrCount === 1 || enteringCap) {
 				console.warn('Dash session: /status backoff', {
 					consecutiveFails: pollErrCount,
-					nextDelayMs: cappedDelay
+					nextDelayMs: cappedDelay,
+					atCap
 				});
 			}
+			if (atCap) atBackoffCap = true;
 			return false;
 		} finally {
 			pollAbort = undefined;
@@ -441,7 +479,11 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 					// early without either, so a retry that hit 409
 					// inherited the previous attempt's backoff
 					// inflation (cadence stuck at the 30s cap).
+					// Round-14 R14-OPS-BACKOFF-WARN-FLOODS-AT-CAP: also
+					// drop the cap-latch so the first post-409 failure
+					// re-fires the entry warn instead of going silent.
 					pollErrCount = 0;
+					atBackoffCap = false;
 					postCancelConflict = true;
 					if (postCancelDeadlineTimer === undefined) {
 						postCancelDeadlineTimer = setTimeout(() => {

--- a/src/lib/auth/dash/session.svelte.ts
+++ b/src/lib/auth/dash/session.svelte.ts
@@ -1,17 +1,35 @@
 /**
- * Reactive session wrapper around IsServiceClient. Owns the polling loop,
- * lifecycle, and Svelte 5 $state so consumers can bind to status text /
- * QR data without managing intervals themselves.
+ * Reactive session wrapper around IsServiceClient. Owns the polling
+ * loop, lifecycle, and Svelte 5 $state so consumers can bind to
+ * status text / QR data without managing intervals themselves.
  *
- * Usage:
+ * Usage (round-9 audit R9-DRIFT-DOC-USAGE-01 — pre-R9 the docstring
+ * referenced session.start() / session.state / session.start_response
+ * which do not exist; the real names are begin/phase/startResponse,
+ * and stop() is the synchronous-teardown path that onDestroy must
+ * call):
  *
  *   const session = createDashSession({ baseUrl, op: 'auth' });
- *   session.start();                       // returns when start() resolves
- *   // ... UI binds to session.state, session.start_response, etc.
- *   session.cancel();                      // tears down poll + tells server
+ *   await session.begin();                 // POST /session/start
+ *   // UI binds to session.phase / session.startResponse / session.status
  *
- * Polling is 2s, matching the IS service's dashd-watcher cadence; once
- * the state becomes terminal the loop self-stops.
+ *   await session.cancel();                // user-initiated; tells
+ *                                          // server; may keep polling
+ *                                          // on 409 in-flight refusal
+ *
+ *   onDestroy(() => session.stop());       // synchronous teardown —
+ *                                          // sets destroyed=true,
+ *                                          // clears poll + trap-
+ *                                          // deadline timers, and
+ *                                          // fire-and-forgets a
+ *                                          // server-side /cancel
+ *
+ * Polling cadence is 2s (matches the IS service's dashd-watcher);
+ * once the state becomes terminal the loop self-stops. cancel() and
+ * begin() are no-ops after stop(); the `destroyed` flag is private.
+ *
+ * Cross-references: R6-SEC-01 trap-deadline (240s); R8-CORR-02
+ * stop/cancel split; R9-SEC-01 AbortController timeouts in isClient.
  */
 import {
 	IsServiceClient,
@@ -153,6 +171,11 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 				}
 			}
 		} catch (e) {
+			// Round-9 audit R9-CORR-01a: respect the destroyed gate
+			// here too. Without this guard a /status fetch that
+			// rejects (e.g. 404 after stop() races a Prune) would
+			// write to $state on an unmounted component.
+			if (destroyed) return;
 			// Network blip is non-fatal — server's own TTL bounds the
 			// session. Only escalate on a hard 4xx that says the session
 			// is gone.
@@ -201,6 +224,23 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 		// duplicate POST /cancel + re-arm the trap-deadline.
 		if (destroyed || cancelling) return;
 		cancelling = true;
+		// Round-9 audit R9-SEC-01: arm the R6-SEC-01 trap-deadline
+		// BEFORE the await. Defense in depth — even if a future
+		// regression removes the isClient AbortController, the
+		// deadline still fires and force-fails the modal so a
+		// hostile server can't pin the user indefinitely. Cleared
+		// in the finally OR overwritten with the post-conflict
+		// timer below.
+		const cancelCallDeadline = setTimeout(() => {
+			if (destroyed) return;
+			cancelling = false;
+			postCancelConflict = false;
+			stopPolling();
+			if (status && !isTerminal(status.state)) {
+				phase = 'failed';
+				error = 'cancel did not complete in time';
+			}
+		}, POST_CANCEL_DEADLINE_MS);
 		try {
 			const sid = startResponse?.sid;
 			const cancelToken = startResponse?.addressSignature;
@@ -245,6 +285,7 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 				error = 'cancelled';
 			}
 		} finally {
+			clearTimeout(cancelCallDeadline);
 			cancelling = false;
 		}
 	}
@@ -253,11 +294,23 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 		// Round-8 audit R8-CORR-02: synchronous teardown for Svelte's
 		// onDestroy. Mark destroyed first so any in-flight begin() /
 		// poll() / cancel() resolves with a no-op tail. Then clear
-		// timers. We do NOT fire a server-side /cancel here — the
-		// component is going away and the server's own TTL bounds the
-		// session.
+		// timers.
+		//
+		// Round-9 audit R9-DESIGN-STOP-NOCANCEL-01: fire-and-forget
+		// a server-side /cancel if we have a sid + token, so the
+		// server's session and dashd-watcher entries get released
+		// promptly rather than waiting for the 30-min TTL. The
+		// fetch runs detached — we don't await it — and the
+		// AbortController timeout in isClient bounds the request.
+		const sid = startResponse?.sid;
+		const token = startResponse?.addressSignature;
 		destroyed = true;
 		stopPolling();
+		if (sid && token) {
+			void client.cancel(sid, token).catch(() => {
+				/* fire-and-forget; server TTL is the safety net */
+			});
+		}
 	}
 
 	return {

--- a/src/lib/auth/dash/session.svelte.ts
+++ b/src/lib/auth/dash/session.svelte.ts
@@ -482,9 +482,19 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 					// Round-14 R14-OPS-BACKOFF-WARN-FLOODS-AT-CAP: also
 					// drop the cap-latch so the first post-409 failure
 					// re-fires the entry warn instead of going silent.
+					// Round-14 R14-CANCEL-409-BACKOFF-RESET-WINDOW:
+					// schedule a fresh poll from here so any stale
+					// 30s-armed setTimeout from an in-flight tick's
+					// catch branch is replaced by a fresh 2s tick.
+					// Without the explicit re-schedule, a race
+					// between the in-flight tick's catch + this
+					// reset could leave the first post-409 retry
+					// waiting up to 30s instead of the documented
+					// 4s "restart from fresh step" cadence.
 					pollErrCount = 0;
 					atBackoffCap = false;
 					postCancelConflict = true;
+					schedulePoll();
 					if (postCancelDeadlineTimer === undefined) {
 						postCancelDeadlineTimer = setTimeout(() => {
 							if (destroyed) return;

--- a/src/lib/auth/dash/session.svelte.ts
+++ b/src/lib/auth/dash/session.svelte.ts
@@ -104,7 +104,19 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 	let status = $state<SessionStatusResponse | undefined>(undefined);
 	let phase = $state<DashSessionState['phase']>('idle');
 	let error = $state<string | undefined>(undefined);
-	let pollTimer: ReturnType<typeof setInterval> | undefined;
+	// Round-10 audit R10-OPS-POLL-OVERLAP-01: replaced the setInterval
+	// pattern with a recursive setTimeout that re-schedules ONLY after
+	// the previous poll resolves/aborts. Pre-R10 setInterval(2s) could
+	// stack ~15 concurrent /status fetches against a stalling server
+	// before the AbortController timeouts fired (browser per-host
+	// limit gates further). The new shape naturally bounds in-flight
+	// /status to 1, freeing other sockets for cancel/start.
+	let pollTimer: ReturnType<typeof setTimeout> | undefined;
+	// pollGen bumps on each stopPolling so an in-flight tick whose
+	// re-schedule would otherwise race past clearTimeout cancels itself
+	// after its await resolves. Solves the schedulePoll-vs-stopPolling
+	// re-arm race.
+	let pollGen = 0;
 	// Round-6 audit R6-SEC-01: trap-deadline timer for post-cancel
 	// polling. Set when the user clicks cancel and the server
 	// refuses (409) or the cancel request errors; if the next
@@ -127,12 +139,23 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 	// fresh 240s timer after the first stopPolling has already
 	// cleared it.
 	let cancelling = false
+	// Round-10 audit R10-CORR-ORPHAN-SESSION-01: track the
+	// AbortController for an in-flight POST /session/start so stop()
+	// can cancel the request itself. Without this, a user who
+	// unmounts the modal between session/start being submitted and
+	// resolved leaks the server-side session for the full 30-min
+	// TTL — the R9-DESIGN-STOP-NOCANCEL-01 fire-and-forget /cancel
+	// couldn't fire because we had no sid yet.
+	let startAbort: AbortController | undefined
 
 	const terminal = $derived(status ? isTerminal(status.state) : false);
 
 	function stopPolling() {
+		// Bump the generation so any in-flight tick declines to
+		// re-arm itself after its await resolves.
+		pollGen++;
 		if (pollTimer !== undefined) {
-			clearInterval(pollTimer);
+			clearTimeout(pollTimer);
 			pollTimer = undefined;
 		}
 		if (postCancelDeadlineTimer !== undefined) {
@@ -144,6 +167,28 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 		// true whenever the poll loop reached a real terminal state
 		// before the deadline fired.
 		postCancelConflict = false;
+	}
+
+	// schedulePoll: recursive setTimeout that runs one poll, then
+	// schedules the next AFTER it resolves/aborts. Round-10 audit
+	// R10-OPS-POLL-OVERLAP-01 replaced setInterval with this shape
+	// so we never have more than one /status fetch in flight. The
+	// pollGen check inside tick guarantees a stopPolling that lands
+	// between tick start and tick end cancels the re-arm.
+	function schedulePoll() {
+		if (destroyed || !startResponse) return;
+		const sid = startResponse.sid;
+		const gen = ++pollGen;
+		const tick = async () => {
+			if (destroyed || gen !== pollGen) return;
+			await poll(sid);
+			if (destroyed || gen !== pollGen) return;
+			pollTimer = setTimeout(tick, POLL_INTERVAL_MS);
+		};
+		// Immediate first poll so phase=='waiting' flips quickly
+		// when the user paid before the modal opened (rare but
+		// possible — pre-cached deposit address).
+		pollTimer = setTimeout(tick, 0);
 	}
 
 	async function poll(sid: string) {
@@ -192,10 +237,15 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 		if (phase !== 'idle' && phase !== 'failed') return;
 		phase = 'starting';
 		error = undefined;
+		// Round-10 audit R10-CORR-ORPHAN-SESSION-01: hand stop() a
+		// handle on the in-flight start so it can abort if the user
+		// unmounts before the server returns. Cleared in the
+		// finally branch below.
+		startAbort = new AbortController();
 		try {
 			const body: { op: IsOp; args?: CallArgs } = { op: opts.op };
 			if (opts.op === 'call' && opts.args) body.args = opts.args;
-			const sr = await client.startSession(body);
+			const sr = await client.startSession(body, startAbort.signal);
 			// Round-8 audit R8-CORR-02: stop() may have run while the
 			// fetch was in flight. If so, bail before arming pollTimer
 			// (which would otherwise write to $state for the full
@@ -203,17 +253,13 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 			if (destroyed) return;
 			startResponse = sr;
 			phase = 'waiting';
-			pollTimer = setInterval(() => {
-				if (startResponse) void poll(startResponse.sid);
-			}, POLL_INTERVAL_MS);
-			// Immediate first poll so the UI surfaces ATTESTING quickly
-			// when the user paid before the modal even opened (rare but
-			// possible — pre-cached deposit address).
-			void poll(startResponse.sid);
+			schedulePoll();
 		} catch (e) {
 			if (destroyed) return;
 			phase = 'failed';
 			error = e instanceof Error ? e.message : 'failed to start session';
+		} finally {
+			startAbort = undefined;
 		}
 	}
 
@@ -231,12 +277,21 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 		// hostile server can't pin the user indefinitely. Cleared
 		// in the finally OR overwritten with the post-conflict
 		// timer below.
+		//
+		// Round-10 audit R10-CORR-03 + R10-DRIFT-CANCEL-PRE-AWAIT-...
+		// outerExpired flag signals 'deadline already fired' so a
+		// late await that resolves AFTER the timer doesn't re-arm
+		// the conflict banner or write phase. Belt-and-braces with
+		// the `cancelling` flag which the deadline callback already
+		// resets.
+		let outerExpired = false;
 		const cancelCallDeadline = setTimeout(() => {
 			if (destroyed) return;
+			outerExpired = true;
 			cancelling = false;
 			postCancelConflict = false;
 			stopPolling();
-			if (status && !isTerminal(status.state)) {
+			if (!status || !isTerminal(status.state)) {
 				phase = 'failed';
 				error = 'cancel did not complete in time';
 			}
@@ -255,7 +310,12 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 			// keep polling so the user reaches a real terminal state.
 			if (sid && cancelToken) {
 				const outcome: CancelResult = await client.cancel(sid, cancelToken);
-				if (destroyed) return;
+				// Round-10 audit R10-CORR-03: bail if the outer
+				// trap-deadline already fired while the await was
+				// pending; otherwise we'd reset the banner and
+				// re-arm a fresh deadline against a session that's
+				// already been force-failed.
+				if (destroyed || outerExpired) return;
 				if (outcome === 'in-flight-conflict' || outcome === 'error') {
 					// Server is mid-attestation OR the cancel request
 					// couldn't be confirmed. Keep polling so the user
@@ -270,7 +330,12 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 							if (destroyed) return;
 							postCancelConflict = false;
 							stopPolling();
-							if (status && !isTerminal(status.state)) {
+							// Round-10 audit R10-CORR-CANCEL-NO-STATUS-01:
+							// the 'cancel acknowledged...' message is
+							// valid even when /status never landed
+							// (user paid before first poll, server
+							// rejected, etc). Don't gate it on status.
+							if (!status || !isTerminal(status.state)) {
 								phase = 'failed';
 								error = 'cancel acknowledged but session did not finish on the server in time';
 							}
@@ -280,7 +345,10 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 				}
 			}
 			stopPolling();
-			if (status && !isTerminal(status.state)) {
+			// Round-10 audit R10-CORR-CANCEL-NO-STATUS-01: same as
+			// above — the 'cancelled' message is valid regardless
+			// of whether /status has reported anything yet.
+			if (!status || !isTerminal(status.state)) {
 				phase = 'failed';
 				error = 'cancelled';
 			}
@@ -299,16 +367,29 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 		// Round-9 audit R9-DESIGN-STOP-NOCANCEL-01: fire-and-forget
 		// a server-side /cancel if we have a sid + token, so the
 		// server's session and dashd-watcher entries get released
-		// promptly rather than waiting for the 30-min TTL. The
-		// fetch runs detached — we don't await it — and the
-		// AbortController timeout in isClient bounds the request.
+		// promptly rather than waiting for the 30-min TTL.
+		//
+		// Round-10 audit R10-CORR-ORPHAN-SESSION-01: if the user
+		// unmounts BEFORE /session/start resolves, we have no sid
+		// yet — but we DO have an AbortController on the in-flight
+		// fetch. Abort it so the server either (a) sees the
+		// connection drop before PutNew (no leak) or (b) finishes
+		// after — same as today's worst case, but no
+		// indefinite-orphan window.
 		const sid = startResponse?.sid;
 		const token = startResponse?.addressSignature;
 		destroyed = true;
 		stopPolling();
+		if (startAbort !== undefined) {
+			startAbort.abort();
+		}
 		if (sid && token) {
-			void client.cancel(sid, token).catch(() => {
-				/* fire-and-forget; server TTL is the safety net */
+			// Round-10 audit R10-INFO-01: client.cancel never throws,
+			// but keep a defensive catch with a debug-level log so a
+			// future refactor making it throw surfaces in browser
+			// devtools instead of as an unhandled rejection.
+			void client.cancel(sid, token).catch((e) => {
+				console.debug('Dash session stop() fire-and-forget cancel rejected:', e);
 			});
 		}
 	}

--- a/src/lib/auth/dash/session.svelte.ts
+++ b/src/lib/auth/dash/session.svelte.ts
@@ -125,25 +125,34 @@ export function createDashSession(opts: DashSessionOpts): DashSession {
 	}
 
 	async function cancel(): Promise<void> {
-		stopPolling();
 		const sid = startResponse?.sid;
 		const cancelToken = startResponse?.addressSignature;
-		// Mark UI cancelled immediately so a slow network doesn't leave
-		// the modal stuck on "waiting".
+		// Round-5 audit R5-002: don't pre-set phase='failed' before we
+		// know whether the server can honour the cancel. If it returns
+		// 409 (R4-003 in-flight refusal), the session is still
+		// progressing toward a real terminal state and we keep polling
+		// — destroying that flow here would lose a legitimate login.
+		if (sid && cancelToken) {
+			let outcome: 'cancelled' | 'in-flight-conflict' | 'error' = 'cancelled';
+			try {
+				outcome = await client.cancel(sid, cancelToken);
+			} catch {
+				outcome = 'error';
+			}
+			if (outcome === 'in-flight-conflict') {
+				// Server is mid-attestation or mid-L2-submit; keep
+				// polling so the user reaches a real terminal state.
+				return;
+			}
+			if (outcome === 'error') {
+				// Server may already have GC'd — surface the cancel
+				// in the UI but don't poison the modal with an error.
+			}
+		}
+		stopPolling();
 		if (status && !isTerminal(status.state)) {
 			phase = 'failed';
 			error = 'cancelled';
-		}
-		// Need both sid AND the cancelToken — server rejects 401
-		// without the header (audit TC2-01). If the user clicked Cancel
-		// before /session/start returned, there's nothing to cancel
-		// server-side yet.
-		if (sid && cancelToken) {
-			try {
-				await client.cancel(sid, cancelToken);
-			} catch {
-				/* server may already have GC'd — fine */
-			}
 		}
 	}
 

--- a/src/lib/auth/dash/signature.ts
+++ b/src/lib/auth/dash/signature.ts
@@ -1,0 +1,140 @@
+/**
+ * Address-signature verification.
+ *
+ * The IS service signs (depositAddress || 0x00 || instruction) with a
+ * pinned key whose public half is configured via
+ * PUBLIC_IS_SERVICE_SIGNER_PUBKEY (see config.ts).
+ *
+ * v1 ships with no pubkey by default — the IS service uses an HMAC-SHA256
+ * stub which the frontend can't verify without sharing the symmetric
+ * secret (spec §5.7 explicitly calls this out as dev-only). When no
+ * pubkey is configured, the verifier returns 'unconfigured' so the UI
+ * can fall back to the address-fingerprint visual check.
+ *
+ * Production wiring (TODO):
+ *   1. Move the IS service to an HSM/KMS asymmetric signer (Ed25519 or
+ *      BLS).
+ *   2. Publish the public half via PUBLIC_IS_SERVICE_SIGNER_PUBKEY.
+ *   3. Pick the matching verify-* helper below and wire it into
+ *      verifyAddressSignature.
+ *
+ * The seam below — verifyAddressSignature returning a tagged union — is
+ * what the rest of the app binds to, so the upgrade is local once a
+ * scheme is picked.
+ */
+
+export type SignatureVerdict =
+	| { kind: 'valid' }
+	| { kind: 'invalid' }
+	| { kind: 'unconfigured' } // no pubkey set — frontend should fall back to fingerprint check
+	| { kind: 'unsupported'; reason: string };
+
+/**
+ * Verify (depositAddress || \0 || instruction) signed by the IS service.
+ *
+ * Returns 'unconfigured' when no pubkey is pinned. Returns 'unsupported'
+ * for the v1 HMAC stub (the frontend can't verify HMAC without sharing
+ * the secret). Returns 'valid' / 'invalid' once an asymmetric signer is
+ * wired.
+ */
+export async function verifyAddressSignature(opts: {
+	depositAddress: string;
+	instruction: string;
+	signatureB64: string;
+	pinnedPubkey: string;
+}): Promise<SignatureVerdict> {
+	const { pinnedPubkey, depositAddress, instruction, signatureB64 } = opts;
+	if (!pinnedPubkey) return { kind: 'unconfigured' };
+
+	// The Ed25519/BLS pubkey format detection — pick by length once we
+	// publish a real key. Until then, refuse to verify and ask the UI
+	// to fall back to fingerprint check.
+	if (pinnedPubkey.startsWith('hmac:')) {
+		return {
+			kind: 'unsupported',
+			reason: 'HMAC stub cannot be verified client-side (spec §5.7 dev mode)'
+		};
+	}
+
+	if (pinnedPubkey.startsWith('ed25519:')) {
+		try {
+			const ok = await verifyEd25519(
+				pinnedPubkey.slice('ed25519:'.length),
+				depositAddress,
+				instruction,
+				signatureB64
+			);
+			return { kind: ok ? 'valid' : 'invalid' };
+		} catch (e) {
+			return {
+				kind: 'unsupported',
+				reason: 'ed25519 verifier failed: ' + (e instanceof Error ? e.message : 'unknown')
+			};
+		}
+	}
+
+	return {
+		kind: 'unsupported',
+		reason: 'unknown pubkey scheme; expected hmac:/ed25519:/bls: prefix'
+	};
+}
+
+/**
+ * Build the message bytes the IS service signs: `addr || 0x00 || instruction`.
+ * Exposed for tests; mirrors handlers.go's AddressSignerHMAC.Sign.
+ */
+export function addressSignatureMessage(depositAddress: string, instruction: string): Uint8Array {
+	const enc = new TextEncoder();
+	const a = enc.encode(depositAddress);
+	const i = enc.encode(instruction);
+	const out = new Uint8Array(a.length + 1 + i.length);
+	out.set(a, 0);
+	out[a.length] = 0;
+	out.set(i, a.length + 1);
+	return out;
+}
+
+/**
+ * Ed25519 verifier via WebCrypto. WebCrypto's Ed25519 support landed in
+ * Chrome 137 / Safari 18 / Firefox 130 — falls back to throwing on older
+ * browsers, which verifyAddressSignature catches as 'unsupported'.
+ */
+async function verifyEd25519(
+	pubkeyHex: string,
+	depositAddress: string,
+	instruction: string,
+	signatureB64: string
+): Promise<boolean> {
+	const pubBytes = hexToBytes(pubkeyHex);
+	const sigBytes = base64ToBytes(signatureB64);
+	const msgBytes = addressSignatureMessage(depositAddress, instruction);
+	const key = await crypto.subtle.importKey(
+		'raw',
+		pubBytes as unknown as ArrayBuffer,
+		{ name: 'Ed25519' },
+		false,
+		['verify']
+	);
+	return await crypto.subtle.verify(
+		{ name: 'Ed25519' },
+		key,
+		sigBytes as unknown as ArrayBuffer,
+		msgBytes as unknown as ArrayBuffer
+	);
+}
+
+function hexToBytes(hex: string): Uint8Array {
+	if (hex.length % 2 !== 0) throw new Error('hex string must have even length');
+	const out = new Uint8Array(hex.length / 2);
+	for (let i = 0; i < out.length; i++) {
+		out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+	}
+	return out;
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+	const bin = atob(b64);
+	const out = new Uint8Array(bin.length);
+	for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+	return out;
+}

--- a/src/lib/auth/dash/signature.ts
+++ b/src/lib/auth/dash/signature.ts
@@ -8,8 +8,13 @@
  * v1 ships with no pubkey by default — the IS service uses an HMAC-SHA256
  * stub which the frontend can't verify without sharing the symmetric
  * secret (spec §5.7 explicitly calls this out as dev-only). When no
- * pubkey is configured, the verifier returns 'unconfigured' so the UI
- * can fall back to the address-fingerprint visual check.
+ * pubkey is configured, the verifier returns 'unconfigured' and DashLogin
+ * surfaces a yellow "Verification not configured" warn-panel telling the
+ * user crypto-verification was unavailable for this session. There is NO
+ * fingerprint to fall back to — the on-screen address fingerprint is per-
+ * session-internal (regenerated every session) and no canonical operator-
+ * published value exists to compare it against (audit R19-SEC-fingerprint-
+ * warn-panel-no-canonical-source-exists).
  *
  * Production wiring (TODO):
  *   1. Move the IS service to an HSM/KMS asymmetric signer (Ed25519 or
@@ -26,7 +31,7 @@
 export type SignatureVerdict =
 	| { kind: 'valid' }
 	| { kind: 'invalid' }
-	| { kind: 'unconfigured' } // no pubkey set — frontend should fall back to fingerprint check
+	| { kind: 'unconfigured' } // no pubkey pinned — DashLogin renders the yellow "Verification not configured" warn-panel; NO fingerprint comparison is possible (audit R19-SEC-fingerprint-warn-panel-no-canonical-source-exists)
 	| { kind: 'unsupported'; reason: string };
 
 /**
@@ -47,8 +52,10 @@ export async function verifyAddressSignature(opts: {
 	if (!pinnedPubkey) return { kind: 'unconfigured' };
 
 	// The Ed25519/BLS pubkey format detection — pick by length once we
-	// publish a real key. Until then, refuse to verify and ask the UI
-	// to fall back to fingerprint check.
+	// publish a real key. Until then, refuse to verify and surface the
+	// 'unsupported' verdict so DashLogin renders its yellow warn-panel
+	// (no fingerprint comparison; audit R19-SEC-fingerprint-warn-panel-
+	// no-canonical-source-exists).
 	if (pinnedPubkey.startsWith('hmac:')) {
 		return {
 			kind: 'unsupported',

--- a/src/lib/auth/dashCaip.ts
+++ b/src/lib/auth/dashCaip.ts
@@ -1,0 +1,26 @@
+/**
+ * CAIP-2 chain identifiers for Dash networks.
+ *
+ * A CAIP-2 chain ID is the first 32 hex characters of the chain's genesis
+ * block hash. These constants MUST match go-vsc-node's lib/dids/dash.go
+ * (DashDIDPrefix / DashTestnetDIDPrefix) and the dash-mapping-contract's
+ * dashGenesisCAIP2Hex helper — drift breaks the cross-layer identity
+ * binding (round-2 audit D2-DESIGN-01).
+ *
+ * The contract derives DashDID as
+ *   did:pkh:bip122:<chain-genesis-hex>:<addr>
+ * The literal token "dash" (which an earlier altera draft used) does
+ * NOT match; every contract-state lookup by that malformed DID returns
+ * empty.
+ */
+export const DASH_MAINNET_CAIP = '00000ffd590b1485b3caadc19b22e637';
+export const DASH_TESTNET_CAIP = '00000bafbc94add76cb75e2ec9289483';
+
+/**
+ * Build the canonical DashDID for an L1 address on the given network.
+ * Returns the same string the contract's ResolveSenderDashDID produces.
+ */
+export function buildDashDID(network: 'mainnet' | 'testnet', address: string): string {
+	const caip = network === 'mainnet' ? DASH_MAINNET_CAIP : DASH_TESTNET_CAIP;
+	return `did:pkh:bip122:${caip}:${address}`;
+}

--- a/src/lib/auth/hive/index.ts
+++ b/src/lib/auth/hive/index.ts
@@ -33,7 +33,11 @@ let aioha: Aioha;
 
 if (browser) {
 	_hiveAuthStore.subscribe((value) => {
-		if (value.value) {
+		// Round-4 audit R4-CSM-03: gate on provider so a Dash session
+		// written into the (now-separate) _dashAuthStore can never
+		// drive a dhive lookup here even if subscribers ever get
+		// re-routed.
+		if (value.value && value.value.provider === 'aioha') {
 			getProfilePicUrl(value.value.address).then((pp) => {
 				if (value.value != undefined && pp && value.value.profilePicUrl == undefined) {
 					value.value.profilePicUrl = pp;

--- a/src/lib/auth/store.ts
+++ b/src/lib/auth/store.ts
@@ -37,16 +37,28 @@ export const getAuth = () => {
 };
 export const _hiveAuthStore = writable<Auth>({ status: 'pending' });
 export const _reownAuthStore = writable<Auth>({ status: 'none' });
+// Round-4 audit R4-CSM-03: Dash sessions have their own store so a
+// Hive account_changed event, hiveLogout, or init {status:'none'} write
+// cannot clobber a logged-in Dash session, and Hive-side subscribers
+// (e.g. getProfilePicUrl) never dispatch dhive lookups against a
+// did:pkh:bip122:... payload.
+export const _dashAuthStore = writable<Auth>({ status: 'none' });
 
-export const authStore = derived([_hiveAuthStore, _reownAuthStore], ([$hive, $reown]) => {
-	if ($hive.status !== 'none') {
-		return $hive;
-	} else if ($reown.status !== 'none') {
-		return $reown;
-	} else {
-		const noneAuth = { status: 'none' as const };
-		return noneAuth as Auth;
+export const authStore = derived(
+	[_hiveAuthStore, _reownAuthStore, _dashAuthStore],
+	([$hive, $reown, $dash]) => {
+		if ($dash.status === 'authenticated') {
+			return $dash;
+		}
+		if ($hive.status !== 'none') {
+			return $hive;
+		} else if ($reown.status !== 'none') {
+			return $reown;
+		} else {
+			const noneAuth = { status: 'none' as const };
+			return noneAuth as Auth;
+		}
 	}
-});
+);
 
 export const loginRetry = writable<'idle' | 'retry' | 'cooldown' | 'logout'>('idle');

--- a/src/lib/auth/store.ts
+++ b/src/lib/auth/store.ts
@@ -13,7 +13,7 @@ export type Auth = {
 		address: string;
 		did: string;
 		logout: () => Promise<void>;
-		provider: 'aioha' | 'reown';
+		provider: 'aioha' | 'reown' | 'dash-instantsend';
 		openSettings: () => void;
 		profilePicUrl?: string | undefined;
 		aioha?: Aioha;

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import AppKitLogin from '$lib/auth/AppKitLogin.svelte';
 	import HiveLogin from '$lib/auth/HiveLogin.svelte';
+	import DashLogin from '$lib/auth/DashLogin.svelte';
 	import { goto } from '$app/navigation';
 	import { getAuth } from '$lib/auth/store';
 	import { browser } from '$app/environment';
@@ -241,6 +242,9 @@
 					<div class="option-button" onclick={() => setTimeout(() => loginOpen = false, 100)}>
 						<AppKitLogin namespace="bip122" />
 					</div>
+				</div>
+				<div class="dash-login-wrap">
+					<DashLogin />
 				</div>
 				<div class="login-divider">
 					<span>or</span>

--- a/static/dash/dash-logo.svg
+++ b/static/dash/dash-logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="none">
+  <!-- Dash logomark, simplified two-bar mark. Trademark of Dash Core Group;
+       used here under brand-asset terms for app-integration UIs. -->
+  <path d="M165 64H86l-10 36h79c20 0 32 8 32 24 0 12-7 36-26 36H82l-10 36h79c41 0 70-23 70-72 0-37-26-60-56-60z"
+        fill="#008CE7" />
+  <path d="M60 100H8l-6 24h52z" fill="#008CE7" />
+  <path d="M52 136H0l-6 24h52z" fill="#008CE7" transform="translate(8 0)" />
+</svg>


### PR DESCRIPTION
## Summary

Adds the client-side "Sign in with DashPay" surface for the
[Dash IS-Login lazy-attestation v1](https://github.com/vsc-eco/go-vsc-node/blob/feat/dash-is-login/docs/dash-is-login/0-scoping-spike-decision.md)
flow: user clicks **Sign in with DashPay** on `/login`, scans a QR code with
any Dash wallet, the wallet sends an InstantSend deposit, the modal polls
the IS-service `/session/:sid/status` endpoint, and on `ON_CHAIN` the
DashDID is written into a new `_dashAuthStore` and the user is logged in.

The runtime + IS-service ship in [`vsc-eco/go-vsc-node#feat/dash-is-login`](https://github.com/vsc-eco/go-vsc-node/tree/feat/dash-is-login).
The on-chain contracts ship in [`vsc-eco/utxo-mapping#feat/dash-is-login`](https://github.com/vsc-eco/utxo-mapping/tree/feat/dash-is-login).

## What's new

All new code lives under `src/lib/auth/dash/` + a single `DashLogin.svelte`
that consumes it. Net additions:

### [`src/lib/auth/DashLogin.svelte`](./src/lib/auth/DashLogin.svelte) (+555)

The user-facing modal. Renders the QR code + dash: URI, polls the
IS-service status, shows progress through `WAITING_FOR_IS →
IS_OBSERVED → ATTESTING → L2_SUBMITTED → ON_CHAIN` with human-readable
copy, displays the address-signature verdict (shield-check / shield-
question / shield-alert) and surfaces the per-session address
fingerprint. On `ON_CHAIN` writes the DashDID into `_dashAuthStore` and
closes the dialog.

### [`src/lib/auth/dash/session.svelte.ts`](./src/lib/auth/dash/session.svelte.ts) (+654)

The reactive session state machine wrapped around `IsServiceClient`.
Owns the polling loop, lifecycle, and Svelte 5 `$state` so consumers
bind to `phase` / `startResponse` / `status` without managing intervals
themselves.

Polling cadence is 2s on the happy path; on `/status` errors it
exponentially backs off (4s → 8s → … → 30s cap) with edge-triggered
warn logs (entry + recovery) so operators see stuck sessions without
flooding the console. Backoff resets on multiple lifecycle triggers
documented as a single source-of-truth list in the file header.

Highlights of the concurrency model:
- Recursive `setTimeout` (not `setInterval`) so we never have more
  than one `/status` fetch in flight (R10-OPS-POLL-OVERLAP-01).
- `pollGen` generation tagging on every async path — late
  resolutions decline to write `$state` if a newer tick has started
  (R11-CORR-POLL-WRITES-AFTER-STOPPOLLING + R15-CORR-poll-late-
  finally-clobbers-new-controller).
- `destroyed` flag so `begin()` / `cancel()` after `onDestroy` are
  no-ops (R8-CORR-02).
- `stop()` synchronous teardown for `onDestroy` — clears the
  poll timer, the 240s trap-deadline, aborts in-flight `/start` and
  `/status` fetches, and fire-and-forgets a server-side `/cancel`.
- 240s `POST_CANCEL_DEADLINE_MS` trap-deadline (R6-SEC-01) — a
  hostile IS-service that responds 409 to every `/cancel` AND keeps
  `/status` non-terminal forever can't pin the user indefinitely.
- Orphan-microrace cancel (R11-CORR-ORPHAN-FETCH-MICRORACE) — if
  `stop()` runs between the server minting a session and the client
  assigning the response, the session module fire-and-forgets a
  `/cancel` so the server-side record is released promptly rather
  than waiting the 30-min TTL.

### [`src/lib/auth/dash/isClient.ts`](./src/lib/auth/dash/isClient.ts) (+389)

Typed HTTP client for the IS-service API.
`startSession` / `getStatus` / `cancel`. All three accept an optional
`externalSignal` so `session.svelte.ts` can abort in-flight requests
on unmount.

`fetchAndParse` wraps every request in an `AbortController` whose
timer covers BOTH the `fetch()` promise and the body-parse step —
fixes the R9 / R10-CORR-01 body-stream-stall slow-loris hole. The
external-signal composition uses a manual `addEventListener('abort')`
forwarder (rather than `AbortSignal.any()` so the API works in
slightly older browsers) with paired cleanup in the `finally` block.

Defensive shape check on `/session/start` responses: a 200 with body
`null` / `{}` / missing `sid` / missing `addressSignature` is thrown as
`IsServiceError(200, 'malformed /session/start response')` so the
orphan-microrace cancel handle (R12-INFO) doesn't silently slip past.

Includes `addressFingerprint()` (hex truncate + checksum for QR-side
display) and `buildDashUri()` (BIP21 dash: URI builder).

### [`src/lib/auth/dash/signature.ts`](./src/lib/auth/dash/signature.ts) (+147)

Address-signature verifier. Returns a tagged union:
- `'valid'` / `'invalid'` — once an Ed25519 (or BLS) pubkey is pinned.
- `'unconfigured'` — no pubkey set; DashLogin renders the yellow
  "Verification not configured" warn-panel.
- `'unsupported'` — HMAC stub (the IS-service's dev-mode signer; the
  frontend can't verify HMAC without sharing the secret per spec
  §5.7) OR an older browser without WebCrypto Ed25519.

Production wiring is documented as a 3-step TODO in the file header:
move the IS-service to an HSM/KMS asymmetric signer, publish the
public half via `PUBLIC_IS_SERVICE_SIGNER_PUBKEY`, swap the helper.
The seam — `verifyAddressSignature` returning a tagged union — is
what the rest of the app binds to, so the upgrade is local once a
scheme is picked.

### [`src/lib/auth/dash/config.ts`](./src/lib/auth/dash/config.ts) (+138)

Env wiring + cross-check:
- `PUBLIC_IS_SERVICE_URL` (defaults to testnet host).
- `PUBLIC_IS_SERVICE_SIGNER_PUBKEY` (empty default → 'unconfigured' verdict).
- `PUBLIC_DASH_NETWORK` (`mainnet` / `testnet`; **no silent default** — a
  missing value throws on first DashLogin render, so a mainnet deploy
  can't silently fall back to testnet and authenticate users into the
  wrong-DID namespace).

The network resolver also cross-checks `PUBLIC_DASH_NETWORK` against a
hard-coded list of known testnet / mainnet host suffixes on
`PUBLIC_IS_SERVICE_URL` and throws on mismatch (R4-CSM-08). Lazy-
resolved so an unrelated route doesn't blow up at module load if env
is wrong (R5-OP-01 / R6-OP-02 — error isn't cached, so a hot-reload
+ fix recovers without a tab reload).

### [`src/lib/auth/dashCaip.ts`](./src/lib/auth/dashCaip.ts) (+26)

CAIP-2 chain hex constants + `buildDashDID(network, address)`. Pinned
to match `go-vsc-node/lib/dids/dash.go` + `dash-mapping-contract`'s
`dashGenesisCAIP2Hex` — drift here would break every contract-state
lookup keyed by DashDID.

### [`src/lib/auth/store.ts`](./src/lib/auth/store.ts) (changes)

Adds `_dashAuthStore` separate from `_hiveAuthStore` (R4-CSM-03) so a
Hive `account_changed` event, `hiveLogout`, or init `{status:'none'}`
write can't clobber a logged-in Dash session. The combined `authStore`
precedence is now `dash > hive > reown`.

Adds `provider: 'dash-instantsend'` to the `Auth.value.provider` union
so downstream consumers (QuickSwap, balance fetchers, transactions
store, the `(authed)/+layout`) can branch on provider instead of
silently treating Dash users as Hive users.

### [`src/routes/login/+page.svelte`](./src/routes/login/+page.svelte) (+4)

Mounts the `<DashLogin />` modal alongside the existing Hive +
AppKit-bip122 buttons.

### [`src/lib/auth/dash/session.svelte.test.ts`](./src/lib/auth/dash/session.svelte.test.ts) (+477)

11 vitest cases covering the audit-found races + invariants:

- Malformed `/start` response → `phase='failed'`.
- `stop()` during in-flight `startSession` aborts the controller.
- Orphan-microrace: `stop()` between fetch resolve and assignment →
  fire-and-forget `/cancel`.
- Two back-to-back `stop()`s invoke `client.cancel` at most once.
- `cancel()` 409 in-flight-conflict keeps `/status` polling +
  `postCancelConflict=true`.
- `stop()` aborts in-flight `getStatus`.
- `schedulePoll` entry resets `pollErrCount` (R12 backoff reset on retry).
- `cancel()` 409 path also resets `pollErrCount` (R13 reset on conflict).
- Late `getStatus` resolution after `stopPolling` does NOT flip
  `phase='done'` (R11 post-stop write guard).

All pass in ~72ms locally (`pnpm test src/lib/auth/dash/`).

## Behaviour for existing flows

- The new button on `/login` is additive. Removing the
  `<DashLogin />` mount restores the previous page exactly.
- `authStore` precedence change (`dash > hive > reown`): only relevant
  if a user is simultaneously logged into Dash AND Hive in the same
  browser session. Until this PR ships there's no way to be in that
  state, so existing single-provider users see no behaviour change.
- New `provider: 'dash-instantsend'` value: downstream consumers that
  don't case-match `provider` continue to work — the union widens, no
  existing branch narrows.
- No existing component, route, store, or query was modified.

## Configuration

A `.env.local` template ships under [`.env.example`](./.env.example):

```bash
PUBLIC_IS_SERVICE_URL=https://is-service-testnet.okinoko.io
PUBLIC_DASH_NETWORK=testnet
# PUBLIC_IS_SERVICE_SIGNER_PUBKEY=ed25519:<hex>    # unset → yellow warn-panel
```

For mainnet (when the witness fleet finishes the consensus-version
flip + the IS-service publishes its asymmetric signer's public half):

```bash
PUBLIC_IS_SERVICE_URL=https://is-service.okinoko.io
PUBLIC_DASH_NETWORK=mainnet
PUBLIC_IS_SERVICE_SIGNER_PUBKEY=ed25519:<published hex>
```

## Known follow-ups

- **Signer pubkey pinning.** Ships with no pinned pubkey. Verdict
  falls through to the `'unconfigured'` yellow warn-panel — the IS-
  service can be replaced and the modal will still render, but the
  user only gets the "verified" green badge after the IS-service
  publishes a real signer pubkey and `PUBLIC_IS_SERVICE_SIGNER_PUBKEY`
  is set. Tracked in [`signature.ts`](./src/lib/auth/dash/signature.ts).
- **Mainnet host suffix list.** The current allow-list in
  [`config.ts`](./src/lib/auth/dash/config.ts) covers
  `is-service.okinoko.io` + `.mainnet.okinoko.io`. If production picks
  a different hostname (e.g. behind a CDN like `is.magi.eco`), update
  the list AT THE SAME TIME as flipping the env's
  `PUBLIC_IS_SERVICE_URL` — the network resolver throws on mismatch.
- **`op=call` deep-link surface.** This PR only wires `op=auth`
  (login-only). The contract-call flavour (`op=call` with target
  contract / method / args) is a separate UI surface — used inside
  the swap flow once the DEX router consumes forwarder-mediated
  calls. The protocol-level support is already in `IsServiceClient`
  + `createDashSession({ op: 'call', args: { contract, method, args
  }})`; only a wrapper component is missing.

## Test plan (for reviewers)

```bash
# Unit (vitest)
pnpm test src/lib/auth/dash/

# Type-check + lint
pnpm check
pnpm lint

# Local dev server against testnet IS-service (no env required —
# defaults to is-service-testnet.okinoko.io)
PUBLIC_DASH_NETWORK=testnet pnpm dev
# → visit http://localhost:5173/login, click "Sign in with DashPay",
#   scan with any Dash wallet, send the deposit (the QR's dash: URI
#   includes the amount), watch the modal progress through
#   WAITING_FOR_IS → IS_OBSERVED → ATTESTING → L2_SUBMITTED → ON_CHAIN.
```

## Companion PRs

- [`vsc-eco/go-vsc-node#feat/dash-is-login`](https://github.com/vsc-eco/go-vsc-node/tree/feat/dash-is-login)
  — magi runtime + IS-service binary + devnet tests (+22,086 / −55).
  Provides the HTTP API this PR consumes.
- [`vsc-eco/utxo-mapping#feat/dash-is-login`](https://github.com/vsc-eco/utxo-mapping/tree/feat/dash-is-login)
  — `dash-mapping-contract` + `dash-forwarder-contract` (+7,566 / −544).
- [`vsc-eco/dex-contracts#feat/dash-is-effectivecaller`](https://github.com/vsc-eco/dex-contracts/tree/feat/dash-is-effectivecaller)
  — router `EffectiveCallerOrCaller` switch + DASH swap test (+395 / −4).

This PR can land independently of the others — the IS-service it
points at (`is-service-testnet.okinoko.io`) is already running. The
op=call deep-link surface above is what blocks on the runtime PR.
