### PR TITLE
fix(transactions): swap "confirmed amount" shows settled value, not slippage floor (0.3.21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to Altera are documented here.
 > CI / build-banner / release-script use, and so a glance at `package.json`
 > matches reality.
 
+## [0.3.21] — 2026-06-16
+
+### Fixes
+
+- **A confirmed swap could show two different output amounts minutes apart.** The transaction-detail popup reads the settled `amount_out` from the indexer, which ingests a swap a few seconds _after_ it confirms; in that gap it fell back to the swap payload's `min_amount_out` (the slippage floor) and showed it as the received amount — so the same confirmed tx displayed the floor, then the real fill once the indexer caught up. `ContractTr` now polls the indexer (~15s, backing off) for the settled amount instead of giving up after one read, and never shows the floor on a confirmed swap: while the real figure loads it shows a small loading indicator plus the guaranteed minimum ("you'll receive at least X"), then snaps to the settled amount. It also matches both indexer key formats — the bare `<hash>` and the chain-native `<hash>-<opIndex>` bundle suffix — so bundled swaps (deposit+swap, BTC-allowance+swap) resolve too. The confirmed _status_ is unchanged (the tx really is final on-chain); only the amount display was corrected. Swap-payload parsing and the settle-state decision are extracted to `swapDisplay.ts` with 12 unit tests
+
 ## [0.3.20] — 2026-06-16
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.3.20",
+	"version": "0.3.21",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {

--- a/src/routes/(authed)/transactions/Table/tds/Amount.svelte
+++ b/src/routes/(authed)/transactions/Table/tds/Amount.svelte
@@ -2,15 +2,32 @@
 	import type { UnkCoinAmount } from '$lib/currency/CoinAmount';
 	import { Coin } from '$lib/sendswap/utils/sendOptions';
 	import { getHiveAssetName, getHbdAssetName } from '../../../../../client';
+	import WaveLoading from '$lib/components/WaveLoading.svelte';
 
 	type Props = {
 		amount: UnkCoinAmount;
-		direction?: 'incoming' | 'outgoing' | 'swap' | 'contract' | 'add-liquidity' | 'remove-liquidity';
+		direction?:
+			| 'incoming'
+			| 'outgoing'
+			| 'swap'
+			| 'contract'
+			| 'add-liquidity'
+			| 'remove-liquidity';
 		fromAmount?: UnkCoinAmount | null;
 		secondAmount?: UnkCoinAmount | null;
 		lpInfo?: string | null;
+		// Confirmed swap whose settled output isn't known yet — show a placeholder
+		// instead of the slippage floor (which would mis-state what was received).
+		pendingAmount?: boolean;
 	};
-	let { amount, direction = 'incoming', fromAmount = null, secondAmount = null, lpInfo = null }: Props = $props();
+	let {
+		amount,
+		direction = 'incoming',
+		fromAmount = null,
+		secondAmount = null,
+		lpInfo = null,
+		pendingAmount = false
+	}: Props = $props();
 
 	function unitFor(coin: UnkCoinAmount['coin']): string {
 		if (coin.value === Coin.hive.value) return getHiveAssetName();
@@ -26,8 +43,12 @@
 		<span class="amount outgoing">{fromAmount.toPrettyAmountString()}</span>
 		<span class="token outgoing">{unitFor(fromAmount.coin)}</span>
 		<span class="swap-arrow">→</span>
-		<span class="amount green">{amount.toPrettyAmountString()}</span>
-		<span class="token green">{displayUnit}</span>
+		{#if pendingAmount}
+			<span class="amount settling"><WaveLoading size={18} /></span>
+		{:else}
+			<span class="amount green">{amount.toPrettyAmountString()}</span>
+			<span class="token green">{displayUnit}</span>
+		{/if}
 	{:else if direction === 'add-liquidity' && secondAmount}
 		<span class="amount">{amount.toPrettyAmountString()}</span>
 		<span class="token">{displayUnit}</span>
@@ -91,5 +112,11 @@
 	}
 	.outgoing {
 		color: var(--dash-text-secondary);
+	}
+	.amount.settling {
+		display: inline-flex;
+		align-items: center;
+		vertical-align: middle;
+		color: var(--dash-text-muted);
 	}
 </style>

--- a/src/routes/(authed)/transactions/Table/tr/ContractTr.svelte
+++ b/src/routes/(authed)/transactions/Table/tr/ContractTr.svelte
@@ -15,7 +15,13 @@
 	import { Coin, Network } from '$lib/sendswap/utils/sendOptions';
 	import ContractId from '../tds/ContractId.svelte';
 	import PopupTitleRow from './PopupTitleRow.svelte';
+	import WaveLoading from '$lib/components/WaveLoading.svelte';
 	import { hasuraQuery } from '$lib/indexer/query';
+	import {
+		classifyContractOp,
+		isAwaitingSettledAmount,
+		swapEventHashCandidates
+	} from './swapDisplay';
 
 	type Props = {
 		tx: TransactionInter;
@@ -45,99 +51,102 @@
 	});
 
 	// ── Operation classification ────────────────────────────────────────────
-	// Classify this contract call into one of: swap | add-liquidity | remove-liquidity | generic.
-	// The classification drives which amount/label/direction is used for both the
-	// table row and the side-popup detail view.
-	type OpKind = 'swap' | 'add-liquidity' | 'remove-liquidity' | 'generic';
-
-	const opKind: OpKind = $derived.by(() => {
-		if (op.data.action !== 'execute' || !parsedPayload) return 'generic';
-		const p = parsedPayload;
-
-		// Add liquidity: payload type="deposit" + 2 intents (both assets sent in)
-		if (
-			p.type === 'deposit' &&
-			p.asset0 && p.asset1 && p.amount0 != null && p.amount1 != null &&
-			(op.data.intents?.length ?? 0) >= 2
-		) return 'add-liquidity';
-
-		// Remove liquidity: payload type="withdrawal" + lp_amount present
-		if (p.type === 'withdrawal' && p.lp_amount != null) return 'remove-liquidity';
-
-		return 'generic';
-	});
-
-	// ── Swap detection ──────────────────────────────────────────────────────
-	// Two swap formats:
-	//   New router (Altera):  { type:"swap", asset_in, asset_out, amount_in, min_amount_out }
-	//   Old pool (legacy):    { type:"deposit", asset0, asset1, amount0, amount1 } (0-1 intents)
-	// Both normalised to { asset0, amount0, asset1, amount1 } for display.
-	const swapPayload = $derived.by(() => {
-		if (opKind !== 'generic' || op.data.action !== 'execute' || !parsedPayload) return null;
-		const p = parsedPayload;
-
-		// New router format
-		if (
-			p.type === 'swap' &&
-			p.asset_in && p.asset_out && p.amount_in != null
-		) {
-			return {
-				asset0: String(p.asset_in).toLowerCase(),
-				amount0: String(p.amount_in),
-				asset1: String(p.asset_out).toLowerCase(),
-				amount1: String(p.min_amount_out ?? '0'),
-				isNewRouter: true
-			};
-		}
-		// Old pool format — amount1 is the settled value. Only match when intent
-		// count ≤ 1 (add-liquidity has ≥ 2 intents and is already classified above).
-		if (
-			p.asset0 && p.asset1 && p.amount0 != null && p.amount1 != null &&
-			(!p.type || p.type === 'swap' || p.type === 'deposit')
-		) {
-			return { ...p, isNewRouter: false } as {
-				asset0: string; amount0: string; asset1: string; amount1: string; isNewRouter: false
-			};
-		}
-		return null;
-	});
+	// Classify this contract call into one of: swap | add-liquidity | remove-liquidity | generic,
+	// and normalise both swap payload formats. The pure logic lives in
+	// swapDisplay.ts so the swap-amount decision (min_amount_out vs settled) is
+	// unit-tested. The classification drives which amount/label/direction is used
+	// for both the table row and the side-popup detail view.
+	const classified = $derived(
+		classifyContractOp(parsedPayload, op.data.action, op.data.intents?.length ?? 0)
+	);
+	const opKind = $derived(classified.opKind);
+	const swapPayload = $derived(classified.swapPayload);
 
 	const isSwap = $derived(swapPayload !== null);
 
-	// For confirmed new-router swaps, fetch the actual settled amount_out from the indexer.
+	// For confirmed new-router swaps the only trustworthy output is the settled
+	// `amount_out` from the indexer. The swap payload's `amount1` is just
+	// `min_amount_out` (the slippage floor) — showing it as the received amount
+	// under-reports the real fill, which is what caused "same tx, different
+	// numbers minutes apart". The indexer can lag a few seconds behind
+	// confirmation, so we POLL a handful of times instead of giving up after one
+	// empty response, and we never display the floor in the meantime (see
+	// `awaitingSettledAmount` / the loading copy below).
 	let indexerAmountOut = $state.raw<{ amount_out: number; asset_out: string } | null>(null);
-	let lastFetchedTxId = '';
+	// Acts as the current-tx token: stale polls (component reused for a new tx)
+	// detect the change and bail without writing. A fresh mount (e.g. reopening
+	// the popup later) resets this and re-polls, so a transient indexer miss
+	// self-heals on the next open.
+	let startedFetchTxId = '';
 	$effect(() => {
-		if (!isSwap || !swapPayload?.isNewRouter || tx.isPending || tx.id === lastFetchedTxId) return;
-		lastFetchedTxId = tx.id;
-		hasuraQuery<{ dex_pool_swap_events: Array<{ amount_out: number; asset_out: string }> }>(
-			`query GetSwapActualOutput($txHash: String!) {
-				dex_pool_swap_events(where: {indexer_tx_hash: {_eq: $txHash}}, limit: 1) {
-					amount_out
-					asset_out
+		if (!isSwap || !swapPayload?.isNewRouter || tx.isPending) return;
+		const thisTxId = tx.id;
+		if (thisTxId === startedFetchTxId) return;
+		startedFetchTxId = thisTxId;
+		indexerAmountOut = null;
+
+		const hashCandidates = swapEventHashCandidates(thisTxId, op.index);
+
+		// ~15s of polling, backing off, before we conclude the indexer has no row.
+		const delaysMs = [0, 1000, 2000, 4000, 8000];
+		(async () => {
+			for (const delay of delaysMs) {
+				if (delay) await new Promise((r) => setTimeout(r, delay));
+				if (startedFetchTxId !== thisTxId) return; // superseded by a newer tx
+				const data = await hasuraQuery<{
+					dex_pool_swap_events: Array<{ amount_out: number; asset_out: string }>;
+				}>(
+					`query GetSwapActualOutput($hashes: [String!]!) {
+						dex_pool_swap_events(where: {indexer_tx_hash: {_in: $hashes}}, limit: 1) {
+							amount_out
+							asset_out
+						}
+					}`,
+					{ hashes: hashCandidates }
+				);
+				if (startedFetchTxId !== thisTxId) return;
+				const event = data?.dex_pool_swap_events?.[0];
+				if (event) {
+					indexerAmountOut = event;
+					break;
 				}
-			}`,
-			{ txHash: tx.id }
-		).then((data) => {
-			const event = data?.dex_pool_swap_events?.[0];
-			if (event) indexerAmountOut = event;
-		});
+			}
+		})();
 	});
 
+	// True while a confirmed new-router swap's real output is still unknown — the
+	// window in which we must NOT show min_amount_out. Drives the loading copy.
+	const awaitingSettledAmount = $derived(
+		isAwaitingSettledAmount({
+			isSwap,
+			isNewRouter: !!swapPayload?.isNewRouter,
+			isPending: tx.isPending,
+			hasIndexerAmount: !!indexerAmountOut
+		})
+	);
+
 	// ── Liquidity amounts ───────────────────────────────────────────────────
-	function coinFromAsset(asset: string): typeof Coin[keyof typeof Coin] {
+	function coinFromAsset(asset: string): (typeof Coin)[keyof typeof Coin] {
 		return Coin[asset.split('_')[0] as keyof typeof Coin] || Coin.unk;
 	}
 
 	// Add-liquidity: both token amounts the user deposited into the pool.
 	const liqAmount0 = $derived(
 		opKind === 'add-liquidity' && parsedPayload
-			? new CoinAmount(String(parsedPayload.amount0), coinFromAsset(String(parsedPayload.asset0)), true)
+			? new CoinAmount(
+					String(parsedPayload.amount0),
+					coinFromAsset(String(parsedPayload.asset0)),
+					true
+				)
 			: null
 	);
 	const liqAmount1 = $derived(
 		opKind === 'add-liquidity' && parsedPayload
-			? new CoinAmount(String(parsedPayload.amount1), coinFromAsset(String(parsedPayload.asset1)), true)
+			? new CoinAmount(
+					String(parsedPayload.amount1),
+					coinFromAsset(String(parsedPayload.asset1)),
+					true
+				)
 			: null
 	);
 
@@ -156,9 +165,7 @@
 		return null;
 	});
 	const lpAmount = $derived(
-		opKind === 'remove-liquidity' && parsedPayload
-			? String(parsedPayload.lp_amount)
-			: null
+		opKind === 'remove-liquidity' && parsedPayload ? String(parsedPayload.lp_amount) : null
 	);
 
 	// ── Swap amounts ────────────────────────────────────────────────────────
@@ -189,8 +196,21 @@
 		return new CoinAmount(amt, Coin[coinVal.split('_')[0] as keyof typeof Coin] || Coin.hive, true);
 	});
 
+	// The slippage floor (min_amount_out) for a new-router swap — a meaningful
+	// GUARANTEED MINIMUM to reassure the user while the exact settled amount is
+	// still being fetched ("you'll receive at least X"). Null when there's no
+	// protective floor (min_amount_out "0"), so we don't show "at least 0".
+	const minReceived = $derived.by(() => {
+		if (!isSwap || !swapPayload?.isNewRouter) return null;
+		const floor = new CoinAmount(swapPayload.amount1, coinFromAsset(swapPayload.asset1), true);
+		return floor.toNumber() > 0 ? floor : null;
+	});
+
 	let inUsd = $state(0);
 	$effect(() => {
+		// Don't price the slippage floor while the settled amount is still pending —
+		// it would show a misleading USD value that then jumps once it resolves.
+		if (awaitingSettledAmount) return;
 		amount.convertTo(Coin.usd, Network.lightning).then((a) => {
 			inUsd = a.toNumber();
 		});
@@ -233,6 +253,7 @@
 		{amount}
 		{fromAmount}
 		{direction}
+		pendingAmount={awaitingSettledAmount}
 		secondAmount={opKind === 'add-liquidity' ? liqAmount1 : removeLiqAmount1}
 		lpInfo={lpAmount}
 	/>
@@ -243,12 +264,18 @@
 	<PopupTitleRow title={popupTitle} status={tx.status} />
 	<p class="popup-subtitle">
 		{moment(getTimestamp(tx)).format('MMM DD, YYYY [at] H:mm')}
-		{#if op.data.from} · {op.data.from}{/if}
+		{#if op.data.from}
+			· {op.data.from}{/if}
 	</p>
 	<div class="sections">
 		<div class="amount">
 			{#if isSwap && fromAmount}
-				{fromAmount.toPrettyString()} → {amount.toPrettyString()}
+				{fromAmount.toPrettyString()} →
+				{#if awaitingSettledAmount}
+					<span class="settling"><WaveLoading size={28} /></span>
+				{:else}
+					{amount.toPrettyString()}
+				{/if}
 			{:else if opKind === 'add-liquidity' && liqAmount0 && liqAmount1}
 				{liqAmount0.toPrettyString()} + {liqAmount1.toPrettyString()}
 			{:else if opKind === 'remove-liquidity' && removeLiqAmount0 && removeLiqAmount1}
@@ -262,7 +289,15 @@
 				{amount.toPrettyString()}
 			{/if}
 			<span class="approx-usd">
-				Approx. {formatUsd(inUsd)}
+				{#if awaitingSettledAmount}
+					Waiting for the network to report the settled amount…
+					{#if minReceived}
+						<span class="settle-floor">You'll receive at least {minReceived.toPrettyString()}.</span
+						>
+					{/if}
+				{:else}
+					Approx. {formatUsd(inUsd)}
+				{/if}
 			</span>
 		</div>
 		<div class="tx-id section">
@@ -302,6 +337,17 @@
 		color: var(--dash-text-muted);
 		font-size: var(--text-sm);
 		margin-top: 0.25rem;
+	}
+	.settling {
+		display: inline-flex;
+		align-items: center;
+		vertical-align: middle;
+		color: var(--dash-text-muted);
+	}
+	.settle-floor {
+		display: block;
+		margin-top: 0.2rem;
+		color: var(--dash-text-secondary);
 	}
 	.date {
 		color: var(--dash-text-secondary);

--- a/src/routes/(authed)/transactions/Table/tr/swapDisplay.test.ts
+++ b/src/routes/(authed)/transactions/Table/tr/swapDisplay.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Pins the swap-amount display contract that fixes the "same confirmed tx,
+ * different numbers minutes apart" bug:
+ *
+ *   - A new-router swap normalises amount1 to min_amount_out (the slippage
+ *     FLOOR) — so the consumer must NOT show amount1 as the received amount; it
+ *     waits for the indexer's settled value.
+ *   - isAwaitingSettledAmount marks exactly the window where the floor would
+ *     otherwise leak into the UI (confirmed new-router swap, no indexer value
+ *     yet) — and is false for old-pool swaps, pending swaps, and once settled.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+	classifyContractOp,
+	isAwaitingSettledAmount,
+	swapEventHashCandidates
+} from './swapDisplay';
+
+describe('classifyContractOp — swap normalisation', () => {
+	it('new-router swap: amount1 is min_amount_out (the floor, NOT the settled output)', () => {
+		const { opKind, swapPayload } = classifyContractOp(
+			{
+				type: 'swap',
+				asset_in: 'HBD',
+				asset_out: 'HIVE',
+				amount_in: 5320,
+				min_amount_out: 99797 // the floor — real fill was 100311
+			},
+			'execute',
+			0
+		);
+		expect(opKind).toBe('generic');
+		expect(swapPayload).not.toBeNull();
+		expect(swapPayload?.isNewRouter).toBe(true);
+		expect(swapPayload?.asset0).toBe('hbd');
+		expect(swapPayload?.amount0).toBe('5320');
+		expect(swapPayload?.asset1).toBe('hive');
+		// amount1 is the FLOOR — the consumer must not display it for a confirmed swap.
+		expect(swapPayload?.amount1).toBe('99797');
+	});
+
+	it('new-router swap missing min_amount_out → floor defaults to "0"', () => {
+		const { swapPayload } = classifyContractOp(
+			{ type: 'swap', asset_in: 'HBD', asset_out: 'HIVE', amount_in: 5320 },
+			'execute',
+			0
+		);
+		expect(swapPayload?.isNewRouter).toBe(true);
+		expect(swapPayload?.amount1).toBe('0');
+	});
+
+	it('old-pool swap: amount1 is the settled value (isNewRouter false, no indexer needed)', () => {
+		const { swapPayload } = classifyContractOp(
+			{ asset0: 'hbd', amount0: '5320', asset1: 'hive', amount1: '100311' },
+			'execute',
+			0
+		);
+		expect(swapPayload?.isNewRouter).toBe(false);
+		expect(swapPayload?.amount1).toBe('100311');
+	});
+
+	it('add-liquidity (deposit + ≥2 intents) is not a swap', () => {
+		const { opKind, swapPayload } = classifyContractOp(
+			{ type: 'deposit', asset0: 'hive', amount0: '1', asset1: 'hbd', amount1: '2' },
+			'execute',
+			2
+		);
+		expect(opKind).toBe('add-liquidity');
+		expect(swapPayload).toBeNull();
+	});
+
+	it('remove-liquidity (withdrawal + lp_amount) is not a swap', () => {
+		const { opKind, swapPayload } = classifyContractOp(
+			{ type: 'withdrawal', lp_amount: '42' },
+			'execute',
+			0
+		);
+		expect(opKind).toBe('remove-liquidity');
+		expect(swapPayload).toBeNull();
+	});
+
+	it('non-execute action or unparsable payload → generic, no swap', () => {
+		expect(classifyContractOp({ type: 'swap' }, 'register', 0)).toEqual({
+			opKind: 'generic',
+			swapPayload: null
+		});
+		expect(classifyContractOp(null, 'execute', 0)).toEqual({
+			opKind: 'generic',
+			swapPayload: null
+		});
+	});
+});
+
+describe('swapEventHashCandidates — bare hash + op-index-suffixed key', () => {
+	it('returns both the bare hash and `<hash>-<opIndex>`', () => {
+		// Standalone swap (op 0): the indexer stores the bare hash.
+		expect(swapEventHashCandidates('0d9538', 0)).toEqual(['0d9538', '0d9538-0']);
+		// Bundled swap (op 1, e.g. deposit+swap): indexer suffixes with -1.
+		expect(swapEventHashCandidates('666309', 1)).toEqual(['666309', '666309-1']);
+	});
+});
+
+describe('isAwaitingSettledAmount — when the floor must be hidden', () => {
+	const base = { isSwap: true, isNewRouter: true, isPending: false, hasIndexerAmount: false };
+
+	it('confirmed new-router swap with no indexer value yet → awaiting (hide floor)', () => {
+		expect(isAwaitingSettledAmount(base)).toBe(true);
+	});
+
+	it('once the settled amount arrives → not awaiting', () => {
+		expect(isAwaitingSettledAmount({ ...base, hasIndexerAmount: true })).toBe(false);
+	});
+
+	it('pending swap → not awaiting (min-out is a legitimate expected-minimum here)', () => {
+		expect(isAwaitingSettledAmount({ ...base, isPending: true })).toBe(false);
+	});
+
+	it('old-pool swap → not awaiting (settled amount is already in the payload)', () => {
+		expect(isAwaitingSettledAmount({ ...base, isNewRouter: false })).toBe(false);
+	});
+
+	it('non-swap contract call → not awaiting', () => {
+		expect(isAwaitingSettledAmount({ ...base, isSwap: false })).toBe(false);
+	});
+});

--- a/src/routes/(authed)/transactions/Table/tr/swapDisplay.ts
+++ b/src/routes/(authed)/transactions/Table/tr/swapDisplay.ts
@@ -1,0 +1,123 @@
+/**
+ * Pure display helpers for contract-call transactions (swaps / liquidity).
+ *
+ * Extracted from ContractTr.svelte so the swap-amount decision logic can be
+ * unit-tested without rendering the component. The crux pinned here:
+ *
+ *   For a NEW-ROUTER swap, `amount1` is `min_amount_out` — the slippage FLOOR,
+ *   not the executed output. It must never be shown as the received amount on a
+ *   confirmed swap; the real value comes from the indexer's settled
+ *   `amount_out`. `isAwaitingSettledAmount` marks the window where the floor
+ *   would otherwise leak into the UI (the "same tx, different numbers minutes
+ *   apart" bug).
+ *
+ *   Old-pool swaps carry the settled value directly in `amount1`, so they need
+ *   no indexer round-trip (isNewRouter: false).
+ */
+
+export type OpKind = 'swap' | 'add-liquidity' | 'remove-liquidity' | 'generic';
+
+export type NormalizedSwap = {
+	asset0: string;
+	amount0: string;
+	asset1: string;
+	amount1: string;
+	/** New router → amount1 is min_amount_out (floor). Old pool → amount1 is settled. */
+	isNewRouter: boolean;
+};
+
+/**
+ * Classify a contract op and, when it's a swap, normalise both payload formats
+ * to `{ asset0, amount0, asset1, amount1, isNewRouter }`.
+ *
+ * @param parsedPayload  JSON.parse of op.data.payload (or null on parse failure)
+ * @param action         op.data.action
+ * @param intentCount    op.data.intents?.length ?? 0
+ */
+export function classifyContractOp(
+	parsedPayload: Record<string, unknown> | null,
+	action: string | undefined,
+	intentCount: number
+): { opKind: OpKind; swapPayload: NormalizedSwap | null } {
+	if (action !== 'execute' || !parsedPayload) return { opKind: 'generic', swapPayload: null };
+	const p = parsedPayload;
+
+	// Add liquidity: payload type="deposit" + 2 intents (both assets sent in)
+	if (
+		p.type === 'deposit' &&
+		p.asset0 &&
+		p.asset1 &&
+		p.amount0 != null &&
+		p.amount1 != null &&
+		intentCount >= 2
+	) {
+		return { opKind: 'add-liquidity', swapPayload: null };
+	}
+
+	// Remove liquidity: payload type="withdrawal" + lp_amount present
+	if (p.type === 'withdrawal' && p.lp_amount != null) {
+		return { opKind: 'remove-liquidity', swapPayload: null };
+	}
+
+	// ── Swap detection (opKind stays 'generic'; swap is a sub-classification) ──
+	// New router format: { type:"swap", asset_in, asset_out, amount_in, min_amount_out }
+	if (p.type === 'swap' && p.asset_in && p.asset_out && p.amount_in != null) {
+		return {
+			opKind: 'generic',
+			swapPayload: {
+				asset0: String(p.asset_in).toLowerCase(),
+				amount0: String(p.amount_in),
+				asset1: String(p.asset_out).toLowerCase(),
+				amount1: String(p.min_amount_out ?? '0'),
+				isNewRouter: true
+			}
+		};
+	}
+	// Old pool format — amount1 is the settled value. Only match when intent
+	// count ≤ 1 (add-liquidity has ≥ 2 intents and is already classified above).
+	if (
+		p.asset0 &&
+		p.asset1 &&
+		p.amount0 != null &&
+		p.amount1 != null &&
+		(!p.type || p.type === 'swap' || p.type === 'deposit')
+	) {
+		return {
+			opKind: 'generic',
+			swapPayload: {
+				asset0: String(p.asset0),
+				amount0: String(p.amount0),
+				asset1: String(p.asset1),
+				amount1: String(p.amount1),
+				isNewRouter: false
+			}
+		};
+	}
+
+	return { opKind: 'generic', swapPayload: null };
+}
+
+/**
+ * The indexer keys a swap event by either the bare tx hash (standalone swap at
+ * op 0) OR `<hash>-<opIndex>` when the swap is bundled with another op in the
+ * same tx (deposit+swap, BTC increaseAllowance+swap, …). Query BOTH so bundled
+ * swaps resolve — matching only the bare hash leaves them stuck "confirming".
+ */
+export function swapEventHashCandidates(txId: string, opIndex: number): string[] {
+	return [txId, `${txId}-${opIndex}`];
+}
+
+/**
+ * True while a confirmed new-router swap's settled output is still unknown — the
+ * window in which the UI must show a loading placeholder instead of the
+ * min_amount_out floor. Old-pool swaps (settled amount in-payload) and pending
+ * swaps are never "awaiting".
+ */
+export function isAwaitingSettledAmount(args: {
+	isSwap: boolean;
+	isNewRouter: boolean;
+	isPending: boolean;
+	hasIndexerAmount: boolean;
+}): boolean {
+	return args.isSwap && args.isNewRouter && !args.isPending && !args.hasIndexerAmount;
+}


### PR DESCRIPTION
## What

A *confirmed* swap could show two different output amounts a few minutes apart (reported by Jux). Fixes the display so a confirmed swap never shows the wrong number.

## Why

The transaction-detail popup reads the settled `amount_out` from the **indexer**, which ingests a swap a few seconds *after* it confirms on-chain. In that gap, the popup fell back to the swap payload's `min_amount_out` — the **slippage floor** — and showed it as the received amount. Once the indexer caught up, it corrected to the real fill → "different results minutes apart."

The transaction **status** was always right (the swap *is* final on-chain). Only the displayed **amount** was wrong, so the fix targets the amount, not the status.

## Changes

- **Poll** the indexer (~15s, backing off) for the settled amount instead of giving up after one read; re-polls on reopen so a transient miss self-heals.
- **Never show the floor on a confirmed swap** — while the real figure loads, show a small loading indicator + the guaranteed minimum (`"you'll receive at least X"`), then snap to the settled amount.
- **Match both indexer key formats** — bare `<hash>` and the chain-native `<hash>-<opIndex>` bundle suffix (confirmed correct with tibfox) — so bundled swaps resolve too.
- Swap-payload parsing + the settle-state decision extracted to `swapDisplay.ts`.

## Testing

- 12 unit tests in `swapDisplay.test.ts`.
- `pnpm check` at baseline; full suite green (334 passing).