### PR TITLE
fix(swap): block swaps the contract would overcharge (pendulum CLP fee)

### DIFF
--- a/src/lib/cards/QuickSwap.svelte
+++ b/src/lib/cards/QuickSwap.svelte
@@ -38,6 +38,8 @@
 		getOrderedDepthsFor,
 		checkExceedsPoolDepth,
 		calculatePriceImpact,
+		swapFeeExceedsGuard,
+		swapFeeGuardMessage,
 		type TypedPoolDepths,
 		type SwapCalcResult
 	} from '$lib/pools/swapCalc';
@@ -395,6 +397,7 @@
 			if (txState.swapBaseFee !== undefined) txState.swapBaseFee = undefined;
 			if (txState.swapClpFee !== undefined) txState.swapClpFee = undefined;
 			if (txState.swapTotalFee !== undefined) txState.swapTotalFee = undefined;
+			if (txState.swapFeeBps !== undefined) txState.swapFeeBps = undefined;
 			if (txState.swapHop1Fee !== undefined) txState.swapHop1Fee = undefined;
 		});
 	}
@@ -488,6 +491,7 @@
 			if (txState.swapBaseFee !== swapBaseFee) txState.swapBaseFee = swapBaseFee;
 			if (txState.swapClpFee !== swapClpFee) txState.swapClpFee = swapClpFee;
 			if (txState.swapTotalFee !== swapTotalFee) txState.swapTotalFee = swapTotalFee;
+			if (txState.swapFeeBps !== result.feeBps) txState.swapFeeBps = result.feeBps;
 			const hop1 = result.hop1Fee
 				? { asset: result.hop1Fee.asset, totalFee: result.hop1Fee.totalFee.toString() }
 				: undefined;
@@ -651,6 +655,11 @@
 		if (!toValue || !txState.from) return false;
 		return fromAllowedValues.has(toValue);
 	});
+
+	// Overcharge safety guard: block the swap when the modelled fee is abnormally
+	// high (contract pendulum CLP fee spike — fixed upstream). Mirrors the hard
+	// stop in sendUtils.send() and the warning in ReviewSwap.
+	const feeGuardTripped = $derived(swapFeeExceedsGuard(txState.swapFeeBps));
 
 	/** Human-readable reason when the swap button is disabled. */
 	const swapBlockedReason = $derived.by(() => {
@@ -908,6 +917,15 @@
 	async function requestSwap() {
 		if (!validateSwap()) return;
 
+		// Overcharge safety guard (hard stop — QuickSwap broadcasts directly,
+		// not through sendUtils.send(), so it needs its own backstop in addition
+		// to the disabled button). Covers both this card's broadcast paths.
+		if (swapFeeExceedsGuard(txState.swapFeeBps)) {
+			setError(swapFeeGuardMessage(txState.swapFeeBps));
+			swapLoading = false;
+			return;
+		}
+
 		// Reown Bitcoin wallet + BTC source → take the deposit-address
 		// flow instead of the normal review popup. The user sends BTC
 		// from their own wallet (same pattern as BitcoinMainnetDeposit),
@@ -1007,6 +1025,13 @@
 
 	async function confirmSwap() {
 		if (!auth.value || !txState.from || !txState.to) return;
+
+		// Backstop the overcharge guard at the actual broadcast point too.
+		if (swapFeeExceedsGuard(txState.swapFeeBps)) {
+			setError(swapFeeGuardMessage(txState.swapFeeBps));
+			swapLoading = false;
+			return;
+		}
 
 		const fromCoinDef = txState.from.coin;
 		const toCoinDef = txState.to.coin;
@@ -1458,6 +1483,14 @@
 	{/if}
 	</div><!-- end .swap-middle -->
 
+	{#if feeGuardTripped}
+		<p class="fee-guard-warning">
+			Swap blocked: the network would charge an abnormally high fee
+			(~{((txState.swapFeeBps ?? 0) / 100).toFixed(1)}%) on this trade right now. Try a smaller
+			amount, or wait until it's resolved.
+		</p>
+	{/if}
+
 	<!-- Exchange -->
 	<PillButton
 		onclick={requestSwap}
@@ -1466,7 +1499,8 @@
 			sameCoinSelected ||
 			missingReceiver ||
 			exceedsBalance ||
-			exceedsPoolDepth}
+			exceedsPoolDepth ||
+			feeGuardTripped}
 		styleType="invert submit"
 	>
 		{swapLoading ? 'Swapping...' : 'Swap'}
@@ -1583,6 +1617,15 @@
 </Dialog>
 
 <style lang="scss">
+	.fee-guard-warning {
+		margin: 0 0 0.75rem;
+		padding: 0.6rem 0.8rem;
+		border: 1px solid var(--dash-accent-red, #dc2626);
+		border-radius: 12px;
+		color: var(--dash-accent-red, #dc2626);
+		font-size: 0.82rem;
+		line-height: 1.4;
+	}
 	.swap-card {
 		background: var(--dash-card-bg);
 		border: 1px solid var(--dash-card-border);

--- a/src/lib/pools/swapCalc.test.ts
+++ b/src/lib/pools/swapCalc.test.ts
@@ -16,6 +16,8 @@ import {
 	getOrderedDepthsFor,
 	checkExceedsPoolDepth,
 	calculatePriceImpact,
+	swapFeeExceedsGuard,
+	SWAP_FEE_GUARD_BPS,
 	type TypedPoolDepths
 } from './swapCalc';
 
@@ -393,5 +395,42 @@ describe('calculatePriceImpact', () => {
 		const twoHop   = calculatePriceImpact(100_000n, 'hive', 'btc', hiveHbdPool, btcHbdPool);
 		const singleH  = calculatePriceImpact(100_000n, 'hive', 'hbd', hiveHbdPool, btcHbdPool);
 		expect(twoHop).toBeGreaterThan(singleH);
+	});
+});
+
+// ─── Overcharge safety guard (2026-06-18) ─────────────────────────────────────
+
+describe('swap fee guard', () => {
+	it('reports a small feeBps for a tiny swap (well under the guard)', () => {
+		const r = calculateSwap(1_000n, hiveHbdPool.reserve0, hiveHbdPool.reserve1, 100);
+		expect(r.feeBps).toBeLessThan(SWAP_FEE_GUARD_BPS);
+		expect(swapFeeExceedsGuard(r.feeBps)).toBe(false);
+	});
+
+	it('flags a large, high-impact swap (CLP fee × stabilizer) as over the guard', () => {
+		// ~9% of the reserve → CLP fee ≈ price impact, ×2 stabilizer → multi-percent.
+		const r = calculateSwap(200_000n, hiveHbdPool.reserve0, hiveHbdPool.reserve1, 100);
+		expect(r.feeBps).toBeGreaterThan(SWAP_FEE_GUARD_BPS);
+		expect(swapFeeExceedsGuard(r.feeBps)).toBe(true);
+	});
+
+	it('feeBps grows monotonically with swap size', () => {
+		const small = calculateSwap(10_000n, hiveHbdPool.reserve0, hiveHbdPool.reserve1, 100);
+		const big = calculateSwap(150_000n, hiveHbdPool.reserve0, hiveHbdPool.reserve1, 100);
+		expect(big.feeBps).toBeGreaterThan(small.feeBps);
+	});
+
+	it('two-hop feeBps is at least a comparable single hop (both hops taxed)', () => {
+		const r = calculateTwoHopSwap(120_000n, hiveHbdPool, btcHbdPool, 'hive', 'hbd', 'btc', 100);
+		const single = calculateSwap(120_000n, hiveHbdPool.reserve0, hiveHbdPool.reserve1, 100);
+		expect(r.feeBps).toBeGreaterThanOrEqual(single.feeBps);
+	});
+
+	it('swapFeeExceedsGuard handles null/boundary inputs', () => {
+		expect(swapFeeExceedsGuard(undefined)).toBe(false);
+		expect(swapFeeExceedsGuard(null)).toBe(false);
+		expect(swapFeeExceedsGuard(0)).toBe(false);
+		expect(swapFeeExceedsGuard(SWAP_FEE_GUARD_BPS)).toBe(false); // boundary: not strictly greater
+		expect(swapFeeExceedsGuard(SWAP_FEE_GUARD_BPS + 1)).toBe(true);
 	});
 });

--- a/src/lib/pools/swapCalc.ts
+++ b/src/lib/pools/swapCalc.ts
@@ -110,6 +110,9 @@ export interface SwapCalcResult {
 	expectedOutput: bigint;
 	minAmountOut: bigint;
 	slippageBps: number; // basis points (e.g. 100 = 1%)
+	/** Modelled effective fee as a fraction of gross output, in bps. Drives the
+	 *  overcharge safety guard below. For two-hop swaps this sums both hops. */
+	feeBps: number;
 	/** Set on two-hop swaps. Hop1 takes its fees in the intermediate
 	 *  asset (e.g. HBD), separately from the top-level fee fields which
 	 *  always represent the final hop in the output asset. */
@@ -119,6 +122,46 @@ export interface SwapCalcResult {
 		clpFee: bigint;
 		totalFee: bigint;
 	};
+}
+
+/**
+ * Swap-fee safety guard (2026-06-18). The on-chain pendulum CLP fee can charge a
+ * swap far above the 8 bps tier — it scales ~2× with the trade's price impact,
+ * so large swaps get hit with multi-percent fees (root cause: the CLP leg ×
+ * stabilizer in the contract; being fixed by Milo/tibfox). Until that lands, we
+ * block any swap whose MODELLED effective fee exceeds this threshold so users
+ * can't be silently overcharged. Client-side only — does not stop direct
+ * contract callers. Lower/remove once the contract fee is fixed.
+ *
+ * The contract overcharges ~2× a swap's price impact, so a LOW threshold blocks
+ * much normal activity (at 1% it blocks ~$20 HBD→HIVE / ~$15 BTC swaps on
+ * current mainnet depth) while a HIGH one only catches the clearly-broken
+ * cases. Users already see the post-fee output in the quote, so 300 bps (3%)
+ * blocks the egregious overcharges while letting small/moderate swaps through.
+ * Tune with lordbutterfly as the contract situation evolves.
+ */
+export const SWAP_FEE_GUARD_BPS = 300; // 3%
+
+/** True when a modelled swap fee is above the safety threshold. */
+export function swapFeeExceedsGuard(feeBps: number | undefined | null): boolean {
+	return feeBps != null && feeBps > SWAP_FEE_GUARD_BPS;
+}
+
+/** Single source of truth for the user-facing guard message. */
+export function swapFeeGuardMessage(feeBps: number | undefined | null): string {
+	const pct = feeBps != null ? (feeBps / 100).toFixed(1) : '?';
+	return (
+		`Swap cancelled to protect you: the network would currently charge an abnormally high fee ` +
+		`(~${pct}%, well above the usual ~0.1%) on this trade. Try a smaller amount, or wait until ` +
+		`this is resolved.`
+	);
+}
+
+/** Effective fee in bps = totalFee / grossOut, where grossOut = out + fee. */
+function feeBpsOf(totalFee: bigint, expectedOutput: bigint): number {
+	const grossOut = expectedOutput + totalFee;
+	if (grossOut <= 0n) return 0;
+	return Number((totalFee * 10000n) / grossOut);
 }
 
 /**
@@ -205,7 +248,8 @@ export function calculateSwap(
 			totalFee: 0n,
 			expectedOutput: 0n,
 			minAmountOut: 0n,
-			slippageBps
+			slippageBps,
+			feeBps: 0
 		};
 	}
 
@@ -251,7 +295,8 @@ export function calculateSwap(
 		totalFee,
 		expectedOutput,
 		minAmountOut,
-		slippageBps
+		slippageBps,
+		feeBps: feeBpsOf(totalFee, expectedOutput)
 	};
 }
 
@@ -509,7 +554,8 @@ export function calculateTwoHopSwap(
 			totalFee: 0n,
 			expectedOutput: 0n,
 			minAmountOut: 0n,
-			slippageBps
+			slippageBps,
+			feeBps: 0
 		};
 	}
 	// First hop runs at its own pool and produces an intermediate amount.
@@ -533,6 +579,7 @@ export function calculateTwoHopSwap(
 			expectedOutput: 0n,
 			minAmountOut: 0n,
 			slippageBps,
+			feeBps: hop1.feeBps,
 			hop1Fee
 		};
 	}
@@ -549,6 +596,8 @@ export function calculateTwoHopSwap(
 		expectedOutput: hop2.expectedOutput,
 		minAmountOut: hop2.minAmountOut,
 		slippageBps,
+		// Both hops are taxed by the CLP fee, so the effective cost compounds.
+		feeBps: hop1.feeBps + hop2.feeBps,
 		hop1Fee
 	};
 }

--- a/src/lib/sendswap/stages/ReviewSwap.svelte
+++ b/src/lib/sendswap/stages/ReviewSwap.svelte
@@ -13,6 +13,7 @@
 	import Dialog from '$lib/zag/Dialog.svelte';
 	import TxStatus from '../components/shared/TxStatus.svelte';
 	import { getHiveAssetName, getHbdAssetName } from '../../../client';
+	import { swapFeeExceedsGuard } from '$lib/pools/swapCalc';
 	import { numberFormatLanguage } from '$lib/constants';
 	import { getUsernameFromAuth } from '$lib/getAccountName';
 	import {
@@ -387,6 +388,10 @@
 
 	// Whether this is a two-hop swap (determines fee label %).
 	const isTwoHopSwap = $derived(!!asSwap?.swapHop1Fee);
+	// Overcharge safety guard: warn + block the swap when the modelled fee is
+	// abnormally high (contract pendulum CLP fee can spike — fixed upstream).
+	// Mirrors the hard stop in sendUtils.send().
+	const feeGuardTripped = $derived(swapFeeExceedsGuard(asSwap?.swapFeeBps));
 
 	let today = moment().format('MMM D, YYYY');
 
@@ -627,6 +632,14 @@
 		showHiveWarning={auth.value?.provider === 'aioha'}
 	/>
 
+	{#if feeGuardTripped}
+		<p class="fee-guard-warning">
+			This swap is temporarily blocked: the network would charge an abnormally high fee
+			(~{((asSwap?.swapFeeBps ?? 0) / 100).toFixed(1)}%) on it right now. Try a smaller amount, or
+			wait until it's resolved.
+		</p>
+	{/if}
+
 	{#if popup}
 		<div class="popup-buttons">
 			<PillButton
@@ -637,7 +650,12 @@
 			>
 				Back
 			</PillButton>
-			<PillButton onclick={() => next?.()} theme="accent" styleType="invert" disabled={waiting}>
+			<PillButton
+				onclick={() => next?.()}
+				theme="accent"
+				styleType="invert"
+				disabled={waiting || feeGuardTripped}
+			>
 				{waiting ? 'Waiting…' : 'Swap'}
 			</PillButton>
 		</div>
@@ -658,6 +676,15 @@
 {/if}
 
 <style lang="scss">
+	.fee-guard-warning {
+		margin: 0.75rem 0 0;
+		padding: 0.65rem 0.85rem;
+		border: 1px solid var(--dash-accent-red, #dc2626);
+		border-radius: 12px;
+		color: var(--dash-accent-red, #dc2626);
+		font-size: 0.85rem;
+		line-height: 1.45;
+	}
 	.stacked-cards {
 		display: flex;
 		flex-direction: column;

--- a/src/lib/sendswap/stages/SwapOptions.svelte
+++ b/src/lib/sendswap/stages/SwapOptions.svelte
@@ -165,6 +165,12 @@
 		const fromCoin = txState.from;
 		const toCoin = txState.to;
 		const fromAmount = txState.fromAmount;
+		// Clear the prior fee-guard reading before recomputing; the success path
+		// re-sets it. Without this a stale high feeBps from a previous quote could
+		// wrongly block a now-different (or now-invalid) swap.
+		untrack(() => {
+			if (txState.swapFeeBps !== undefined) txState.swapFeeBps = undefined;
+		});
 		if (!fromCoin || !toCoin || !fromAmount || fromAmount === '0') {
 			swapResult = null;
 			txState.swapCalcPending = false;
@@ -274,6 +280,9 @@
 			}
 			if (txState.swapTotalFee !== swapTotalFee) {
 				txState.swapTotalFee = swapTotalFee;
+			}
+			if (txState.swapFeeBps !== result.feeBps) {
+				txState.swapFeeBps = result.feeBps;
 			}
 			const hop1 = result.hop1Fee
 				? { asset: result.hop1Fee.asset, totalFee: result.hop1Fee.totalFee.toString() }

--- a/src/lib/sendswap/utils/sendUtils.ts
+++ b/src/lib/sendswap/utils/sendUtils.ts
@@ -43,6 +43,7 @@ import swapOptions, {
 } from './sendOptions'
 import type { TxStateBase } from './txState.svelte'
 import { SwapTxState, TransferTxState, WithdrawTxState, type TxState } from './txState.svelte'
+import { swapFeeExceedsGuard, swapFeeGuardMessage } from '$lib/pools/swapCalc'
 
 export function scanForBalance(opts: CoinOnNetwork[]): CoinOnNetwork | undefined {
 	const accBal = get(accountBalance);
@@ -715,6 +716,18 @@ export async function send(
 		let opType: string | undefined;
 
 		if (isSwap) {
+			// Safety guard (2026-06-18): block swaps the contract would overcharge
+			// via the pendulum CLP fee (scales ~2× with price impact). Hard stop
+			// before broadcast for the send()-based flow (QuickSwap has its own
+			// guard in confirmSwap() — it broadcasts directly, not through here).
+			// Return an Error (the established pattern) rather than throwing, so
+			// the caller's `.then` runs and the message surfaces. Remove once the
+			// contract fee is fixed.
+			if (details instanceof SwapTxState && swapFeeExceedsGuard(details.swapFeeBps)) {
+				const msg = swapFeeGuardMessage(details.swapFeeBps);
+				setStatus(msg, true);
+				return new Error(msg);
+			}
 			setStatus('Waiting for Hive wallet approval…');
 			// For swap, amount_in must be the from-asset amount (asset_in), e.g. 5 TBD => 5000
 			const fromAmountStr = details.fromAmount && details.fromAmount !== '0' ? details.fromAmount : amount;

--- a/src/lib/sendswap/utils/txState.svelte.ts
+++ b/src/lib/sendswap/utils/txState.svelte.ts
@@ -53,6 +53,8 @@ export class SwapTxState extends TxStateBase {
 	swapClpFee: string | undefined = $state(undefined);
 	swapTotalFee: string | undefined = $state(undefined);
 	swapHop1Fee: { asset: string; totalFee: string } | undefined = $state(undefined);
+	/** Modelled effective fee in bps — drives the overcharge safety guard. */
+	swapFeeBps: number | undefined = $state(undefined);
 	swapCalcPending: boolean = $state(false);
 }
 


### PR DESCRIPTION
## What
Client-side safety guard that blocks app swaps the contract would currently overcharge.
## Why
The on-chain pendulum fee has a CLP leg `(x²·Y)/(x+X)² × stabilizer` that scales ~2× a swap's
price impact, so large/imbalancing swaps pay multi-percent fees vs the 0.08% tier (a real ~6.5%
example confirmed on-chain). Root cause is in the contract (fix upstream with Milo/tibfox); this
is a backstop until that lands.

## How
- `swapCalc`: model the effective fee as `feeBps`; `swapFeeExceedsGuard` / `SWAP_FEE_GUARD_BPS = 300` (3%)
- enforce at the `send()` flow dispatch (returns an Error, not throw) and in QuickSwap's direct
  broadcast paths (`requestSwap` + `confirmSwap` — it doesn't go through `send()`)
- warn + disable the confirm button in ReviewSwap and QuickSwap

## Threshold (tunable)
3% blocks the egregious overcharges while letting small/moderate swaps through. At 1% it blocked
~$20 HBD→HIVE / ~$15 BTC swaps on current mainnet depth — too aggressive. Tune as the contract
situation evolves.