### PR TITLE
fix(swap): match CLP fee to milo's contract fix (unblocks legit swaps)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to Altera are documented here.
 > CI / build-banner / release-script use, and so a glance at `package.json`
 > matches reality.
 
+## [0.3.22] — 2026-06-19
+
+### Fixes
+
+- **Legitimate swaps were being rejected with "abnormally high fee".** A client-side guard (added after the swap-overcharge incident) blocks swaps whose _modelled_ fee exceeds 3%. After milo's 2026-06-19 contract fix re-tuned the on-chain fee — it took the pendulum stabilizer **off** the CLP fee leg and scaled that leg by a constant `CLPScaleBps` (625 = 1/16) instead, so a swap is no longer charged ≈2× its own price impact — the client model in `swapCalc.ts` still computed the _pre-fix_ formula (CLP leg × the 2× stabilizer cap). It therefore over-estimated the fee ~10×, so a ~$28 BTC→HBD swap modelled at ~4% and was rejected (reported by Bradley / lordbutterfly). The CLP leg now scales by the constant `CLP_SCALE_BPS = 625` instead of `STABILIZER_CAP_BPS` (20000), matching `go-vsc-node/modules/incentive-pendulum/wasm/applier.go`. This corrects both the guard and the (previously over-pessimistic) quote. Verified against live indexer data: the model fee is a strict **floor** of the real on-chain fee for every pendulum `m ∈ [1, 2]` (so users are never under-delivered and `min_amount_out` never reverts a swap), the guard cannot trip for any pool-allowed swap (49% of reserve ≈ 221 bps, under the 300 bps threshold), and real fees are now ~0.2% vs the pre-fix ~12.6% overcharge. The fee-model unit tests were updated to pin the new composition
+
 ## [0.3.21] — 2026-06-16
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.3.21",
+	"version": "0.3.22",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {

--- a/src/lib/pools/swapCalc.test.ts
+++ b/src/lib/pools/swapCalc.test.ts
@@ -91,13 +91,14 @@ describe('calculateSwap', () => {
 		expect(r.expectedOutput).toBeLessThan(9_955n); // strictly below grossOut
 	});
 
-	it('large trade near 50% cap has very high CLP fee', () => {
+	it('large trade near 50% cap has a much worse rate (AMM slippage)', () => {
 		// 1,110 HIVE (1,110,000 units) = exactly 50% of reserve
 		const r50pct = calculateSwap(1_110_000n, 2_221_000n, 2_221_000n, 100);
 		// 10 HIVE trade for reference
 		const rSmall = calculateSwap(10_000n, 2_221_000n, 2_221_000n, 100);
 
-		// At 50%, CLP fee should dominate — effective rate much worse
+		// At 50%, the constant-product slippage dominates the effective rate
+		// (independent of the now-small CLP fee).
 		const rate50 = Number(r50pct.expectedOutput) / 1_110_000;
 		const rateSmall = Number(rSmall.expectedOutput) / 10_000;
 		expect(rate50).toBeLessThan(rateSmall * 0.7); // at least 30% worse rate
@@ -114,45 +115,33 @@ describe('calculateSwap', () => {
 		expect(r.minAmountOut).toBeLessThanOrEqual(r.expectedOutput);
 	});
 
-	// ─── Stabilizer worst-case guarantees ─────────────────────────────────
-	// These pin the contract our quote makes with users: "you will receive
-	// AT LEAST `expectedOutput`". If anyone ever weakens the stabilizer
-	// floor (e.g. drops the ×2 multiplier without a matching backend
-	// guarantee), these tests turn red — and BTC swaps start reverting in
-	// production the same way they did before this fix.
+	// ─── Fee-model floor (post-2026-06-19 fix) ─────────────────────────────
+	// Pin the quote contract ("you receive AT LEAST expectedOutput") AND the
+	// post-fix composition: protocol leg × worst-case 2.0, CLP leg × the 1/16
+	// constant (no stabilizer). If anyone re-applies the stabilizer to the CLP
+	// leg, these turn red — that's the overcharge bug.
 
-	it('expectedOutput equals the on-chain floor at the m=2.0 stabilizer cap', () => {
-		// Worked figures from the 2026-06-06 incident report (§5):
-		//   hop-1 BTC→HBD, 150,000 sats into 2,313,898 : 1,426,458
-		//   grossOut    ≈ 86,842
-		//   baseCLP     ≈ 5,286
-		//   baseProtocol ≈ 69
-		//   userOutput at m=2.0  ≈ 76,132
-		// Our worst-case quote MUST equal that floor (within BigInt floor
-		// rounding) — otherwise the 110%-reliable property is broken.
-		const r = calculateSwap(150_000n, 2_313_898n, 1_426_458n, 100);
-		// Allow ±5 units for floor-rounding differences across the
-		// independent base-fee calculations.
-		const ON_CHAIN_FLOOR = 76_132n;
-		const diff = r.expectedOutput - ON_CHAIN_FLOOR;
-		const absDiff = diff < 0n ? -diff : diff;
-		expect(absDiff).toBeLessThanOrEqual(5n);
-	});
-
-	it('expectedOutput is strictly less than grossOut (stabilizer is applied)', () => {
-		// If someone accidentally drops the ×2 multiplier this becomes
-		// equal to the m=1 quote which on-chain reality exceeds — and
-		// BTC swaps start reverting again.
+	it('expectedOutput = grossOut − 2×protocol − (1/16)×CLP (exact)', () => {
 		const r = calculateSwap(150_000n, 2_313_898n, 1_426_458n, 100);
 		const newX = 2_313_898n + 150_000n;
 		const grossOut = 1_426_458n - (2_313_898n * 1_426_458n) / newX;
-		const m1Quote = grossOut - (grossOut * 8n) / 10000n - (150_000n * 150_000n * 1_426_458n) / (newX * newX);
-		// Worst-case must be strictly LESS than the m=1 quote — by roughly
-		// the size of one fee leg (the surplus). Sanity-check the gap is at
-		// least 5% of the m=1 quote on this very shallow pool.
-		expect(r.expectedOutput).toBeLessThan(m1Quote);
-		const gap = m1Quote - r.expectedOutput;
-		expect(Number(gap) / Number(m1Quote)).toBeGreaterThan(0.05);
+		let baseProtocol = (grossOut * 8n) / 10000n;
+		if (baseProtocol === 0n) baseProtocol = 1n;
+		let baseCLP = (150_000n * 150_000n * 1_426_458n) / (newX * newX);
+		if (baseCLP === 0n) baseCLP = 1n;
+		const totalFee = (baseProtocol * 20000n) / 10000n + (baseCLP * 625n) / 10000n;
+		expect(r.expectedOutput).toBe(grossOut - totalFee);
+		expect(r.expectedOutput).toBeLessThan(grossOut); // fees are still applied
+	});
+
+	it('CLP leg is scaled to 1/16 with no stabilizer (the overcharge fix)', () => {
+		const r = calculateSwap(150_000n, 2_313_898n, 1_426_458n, 100);
+		const newX = 2_313_898n + 150_000n;
+		let baseCLP = (150_000n * 150_000n * 1_426_458n) / (newX * newX);
+		if (baseCLP === 0n) baseCLP = 1n;
+		// charged CLP is exactly baseCLP × 625/10000 — NOT baseCLP × 2 (pre-fix).
+		expect(r.clpFee).toBe((baseCLP * 625n) / 10000n);
+		expect(r.clpFee).toBeLessThan(baseCLP); // strictly reduced, never amplified
 	});
 });
 
@@ -407,11 +396,13 @@ describe('swap fee guard', () => {
 		expect(swapFeeExceedsGuard(r.feeBps)).toBe(false);
 	});
 
-	it('flags a large, high-impact swap (CLP fee × stabilizer) as over the guard', () => {
-		// ~9% of the reserve → CLP fee ≈ price impact, ×2 stabilizer → multi-percent.
+	it('a large swap that pre-fix exceeded the guard now stays under it (fee fix)', () => {
+		// 200,000 units ≈ 9% of reserve. Pre-2026-06-19 (CLP × 2× stabilizer) this
+		// modelled at ~4% and was wrongly blocked; post-fix (CLP × 1/16) it's well
+		// under the 3% guard, so it goes through.
 		const r = calculateSwap(200_000n, hiveHbdPool.reserve0, hiveHbdPool.reserve1, 100);
-		expect(r.feeBps).toBeGreaterThan(SWAP_FEE_GUARD_BPS);
-		expect(swapFeeExceedsGuard(r.feeBps)).toBe(true);
+		expect(r.feeBps).toBeLessThan(SWAP_FEE_GUARD_BPS);
+		expect(swapFeeExceedsGuard(r.feeBps)).toBe(false);
 	});
 
 	it('feeBps grows monotonically with swap size', () => {

--- a/src/lib/pools/swapCalc.ts
+++ b/src/lib/pools/swapCalc.ts
@@ -13,44 +13,33 @@
  *   base protocol fee = grossOut * feeBps / 10000        (output units, floor 1)
  *   base CLP fee      = (x^2 * Y) / (x + X)^2            (output units, floor 1)
  *
- *   ─── STABILIZER WORST-CASE (m = 2.0 cap) ───
+ *   ─── FEE COMPOSITION (post-2026-06-19 contract fix) ───
  *
- *   The on-chain consensus code applies a pendulum stabilizer
- *   multiplier `m` to BOTH fee legs at execution
- *   (`incentive-pendulum/wasm/applier.go:200-221`,
- *   `incentive-pendulum/fees_int.go:68-124`). `m` is bounded:
- *   `m ∈ [1.0, 2.0]` where 2.0 is the hard cap set by
- *   `DefaultStabilizerParamsBps.Cap` (`fees_int.go:59-66`).
+ *   The on-chain code (`incentive-pendulum/wasm/applier.go`) charges the two
+ *   legs differently:
+ *     • protocol (8 bps) leg × pendulum stabilizer `m` (m ∈ [1, 2], cap 2.0)
+ *     • CLP leg × a CONSTANT scale `CLPScaleBps` (default 625 = 1/16), NO `m`
  *
- *   We don't know the live `m` from the frontend — fetching pendulum
- *   V/E geometry would re-implement consensus math, exactly the drift
- *   class this codebase was bitten by. Instead we use the bound:
- *   compute `expectedOutput` as if `m = 2.0` (the worst case).
+ *   We don't know the live `m` from the frontend, so we quote the protocol
+ *   leg at the worst case (m = 2.0) and the CLP leg at the exact constant:
  *
- *     expectedOutput = grossOut - 2 × (baseProtocol + baseCLP)
+ *     expectedOutput = grossOut - 2 × baseProtocol - (1/16) × baseCLP
  *     min_amount_out = expectedOutput * (10000 - slippageBps) / 10000
  *
- *   Guarantees this gives us:
- *     • For any real on-chain m ∈ [1, 2], actualOutput ≥ expectedOutput
- *     • The slippage gate on-chain (`actualOutput ≥ min_amount_out`)
- *       always passes for the stabilizer portion — slippage only
- *       needs to absorb normal reserve drift between sign and execute
- *     • User receives at least what they were quoted; sometimes more
+ *   Guarantees: for any real on-chain m ∈ [1, 2], actualOutput ≥ expectedOutput
+ *   (the protocol leg is the only `m`-dependent part and we took its worst
+ *   case), so the on-chain `actualOutput ≥ min_amount_out` gate passes and the
+ *   user is never under-delivered.
  *
- *   Trade-off: the quote is pessimistic. On deep HIVE/HBD pools the
- *   surplus is ~0.06% so the difference is invisible. On the shallow
- *   BTC/HBD pool it can be 6.6% — users see a lower number than a
- *   naive `m = 1` quote, but they will never be under-delivered.
+ *   HISTORY: before milo's 2026-06-19 fix the stabilizer was ALSO applied to
+ *   the CLP leg, so a swap was charged ≈2× its own price impact — large swaps
+ *   paid multi-percent fees (the overcharge incident). The fix moved `m` off
+ *   the CLP leg and scaled it by the constant instead.
  *
- *   ⚠️ MAINTENANCE TRIPWIRE: this depends on the on-chain cap staying
- *   at 2.0. If `fees_int.go:DefaultStabilizerParamsBps.Cap` is ever
- *   raised, update `STABILIZER_CAP_BPS` below in lockstep — otherwise
- *   we silently regress to the same class of bug.
- *
- *   The proper long-term fix is still a backend `simulateSwap` that
- *   returns the actual `userOutput` from the live `ApplySwapFees`.
- *   Tracking: incident report "Altera Swap Quote ↔ On-Chain Pendulum
- *   Divergence (Stabilizer Omission)" dated 2026-06-06.
+ *   ⚠️ MAINTENANCE TRIPWIRE: `STABILIZER_CAP_BPS` must track the on-chain cap
+ *   and `CLP_SCALE_BPS` must track `Config.CLPScaleBps`. If either on-chain
+ *   value changes, update the constant below in lockstep. The proper long-term
+ *   fix is still a backend `simulateSwap` returning the actual `userOutput`.
  */
 
 /**
@@ -61,6 +50,16 @@
  */
 const STABILIZER_CAP_BPS = 20000n;
 const BPS_SCALE = 10000n;
+
+/**
+ * Constant scale applied to the CLP fee leg (no stabilizer), in basis points.
+ * 625 bps = 1/16. Mirrors `Config.CLPScaleBps` (default 625) in
+ * `go-vsc-node/modules/incentive-pendulum/wasm/applier.go`. Added by milo's
+ * 2026-06-19 fee fix: the pendulum multiplier was taken OFF the CLP leg and a
+ * constant scale put on it instead, so large swaps are no longer charged ≈2×
+ * their price impact. If the on-chain default changes, update this in lockstep.
+ */
+const CLP_SCALE_BPS = 625n;
 
 import { GetStateByKeysStore } from '$houdini';
 import { fetchPoolRegistry, fetchPoolLiquiditySnapshot } from './poolsData';
@@ -266,13 +265,14 @@ export function calculateSwap(
 	let baseClpFee = (x * x * Y) / (newX * newX);
 	if (baseClpFee === 0n) baseClpFee = 1n;
 
-	// Apply the worst-case stabilizer multiplier (m = 2.0 at the cap).
-	// On-chain the multiplier is `charged = floor(base * m_bps / BpsScale)`
-	// — matches `incentive-pendulum/fees_int.go:128-133 ApplyMultiplierBps`.
-	// We use m_bps = STABILIZER_CAP_BPS so the resulting `expectedOutput`
-	// is a guaranteed FLOOR over any real on-chain m ∈ [1, 2].
+	// Post-2026-06-19 contract fix (`incentive-pendulum/wasm/applier.go`):
+	//   • protocol leg × stabilizer `m` — we use the worst case (m = 2.0 at the
+	//     cap) so `expectedOutput` is a guaranteed FLOOR over any real m ∈ [1,2].
+	//   • CLP leg × the CONSTANT `CLP_SCALE_BPS` (625 = 1/16), NO stabilizer.
+	//     (Pre-fix this also got `m`, charging ≈2× price impact — the bug milo
+	//     fixed.) `charged = floor(base * bps / BpsScale)`.
 	const chargedProtocolFee = (baseProtocolFee * STABILIZER_CAP_BPS) / BPS_SCALE;
-	const chargedClpFee = (baseClpFee * STABILIZER_CAP_BPS) / BPS_SCALE;
+	const chargedClpFee = (baseClpFee * CLP_SCALE_BPS) / BPS_SCALE;
 	const totalFee = chargedProtocolFee + chargedClpFee;
 
 	// expectedOutput is the worst-case net delivery (m = 2.0).


### PR DESCRIPTION
## What
Match the client-side swap fee model to milo's 2026-06-19 contract fix so the
fee guard stops blocking legitimate swaps.

## Why
milo moved the pendulum stabilizer OFF the CLP fee leg and scaled it by a
constant (CLPScaleBps = 625 = 1/16). Our model still applied CLP × 2× stabilizer,
over-estimating fees ~10× — so the guard rejected legit swaps (a ~$28 BTC→HBD
swap modelled at 4.05%, reported by Bradley/lordbutterfly).

## Change
CLP fee leg now × 625 bps (1/16) instead of × 20000 (2×), matching
go-vsc-node incentive-pendulum/wasm/applier.go.

## Verified (live data)
- Strict floor: model fee ≥ real on-chain fee for every pendulum m ∈ [1,2].
- Guard can't trip for any executable swap (49% of reserve = 221 bps < 300).
- Real fees now ~0.2% vs the pre-fix 12.6% overcharge. Reported swap: feeBps 405 → 27.
- type-check baseline, 339 tests pass, lint clean.