### PR TITLE
audit(dash): frontend M3/M4 — refuse mainnet without pinned signer pu…

### DIFF
--- a/src/lib/auth/dash/config.ts
+++ b/src/lib/auth/dash/config.ts
@@ -110,6 +110,25 @@ function resolveDashNetwork(): 'mainnet' | 'testnet' {
 				`matches a known mainnet host suffix. Fix one of the two.`
 		);
 	}
+	// Audit M3 (5.9) + M4 (6.0): mainnet deploys must NOT be allowed to
+	// run with the verifier in 'unconfigured' fail-open mode. If the
+	// IS-service is on a mainnet host AND the frontend has no pinned
+	// signer pubkey, the modal shows the yellow "Verification not
+	// configured" warn-panel and accepts the deposit-address binding
+	// on faith. On mainnet that means real Dash deposits trust the
+	// network identity. Refuse to render until the operator wires a
+	// real Ed25519 pubkey via PUBLIC_IS_SERVICE_SIGNER_PUBKEY (which
+	// also disables the HMAC dev-stub path in signature.ts).
+	if (network === 'mainnet' && (!isServiceSignerPubkey || isServiceSignerPubkey.startsWith('hmac:'))) {
+		throw new Error(
+			`PUBLIC_DASH_NETWORK=mainnet but PUBLIC_IS_SERVICE_SIGNER_PUBKEY is ` +
+				`${isServiceSignerPubkey ? 'an HMAC dev-stub' : 'unset'}. ` +
+				`Production mainnet deploys MUST publish the IS-service's asymmetric ` +
+				`signer pubkey (ed25519:<hex>) so the client can verify the address ` +
+				`signature — without it, the yellow 'Verification not configured' ` +
+				`warn-panel accepts the deposit-address binding on faith.`
+		);
+	}
 	return network;
 }
 


### PR DESCRIPTION
## Summary

Audit M3 + M4 (frontend half): `resolveDashNetwork()` now throws on
mainnet without a pinned Ed25519 signer pubkey. Pairs with the
IS-service mainnet-refuse on the go-vsc-node side.

## What changed

- `src/lib/auth/dash/` — `resolveDashNetwork()` enforces that a mainnet
  session config carries a non-empty pinned signer pubkey. Throws an
  explicit error at config-resolution time rather than silently
  accepting a forged IS-service address.

## Why

A compromised or substituted IS-service URL on mainnet could forge
signatures against an attacker-controlled signer key if the frontend
trusted any returned pubkey. Pinning the expected pubkey at config
time + refusing mainnet without it closes the trust gap. Devnet /
testnet remain permissive for iteration.

## Cross-repo dependencies

- **PAIRED WITH** `vsc-eco/go-vsc-node#<PR id>` (M4 IS-service-side
  mainnet refuse). Either side alone is incomplete.

## Test plan

- [x] `pnpm vitest run src/lib/auth/dash/` — 11/11 PASS

## Reference

`DASH-AUDIT-HANDOVER-2026-06-19.md` §3 for the full frontend-side scope.
