### PR TITLE
fix(witness): lock consensus stake/unstake to the signed-in account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to Altera are documented here.
 > CI / build-banner / release-script use, and so a glance at `package.json`
 > matches reality.
 
+## [0.3.23] — 2026-06-20
+
+### Fixes
+
+- **Consensus staking could silently send your HIVE to another account.** The witness "Consensus Staking" / "Consensus Unstaking" modals had an _editable_ "Witness Account" field. It defaulted to your logged-in account, but you could type any account — and that value becomes the `to` of the on-chain op (`vsc.consensus_stake`: `from: hive:<you>`, `to: hive:<typed>`). Because there is **no delegation feature**, staking to an account that isn't yours doesn't delegate — it _transfers_ the HIVE to that account and stakes it there, recoverable only with that account's keys (reported by lordbutterfly, who staked to `magi-team-node` from the witness page without realising it was also a transfer). Both modals now **lock the account to the signed-in user**: the field is a read-only display and the value is `$derived(username)`, so `to` always equals `from` and no input can change it — locked at the data layer, not just hidden in the UI. The consensus stake/unstake ops have no other callers, so this fully closes the path. The stake modal also picked up the same EVM-wallet guard the unstake modal already had. Delegation remains a planned, separate feature (PR 219), intentionally held until after the 0.2.0 rollout
+
 ## [0.3.22] — 2026-06-19
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.3.22",
+	"version": "0.3.23",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {

--- a/src/routes/(authed)/witness-assistant/ConsensusStakeModal.svelte
+++ b/src/routes/(authed)/witness-assistant/ConsensusStakeModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { getAuth } from '$lib/auth/store';
-	import Username from '$lib/auth/Username.svelte';
+	import { Lock } from '@lucide/svelte';
 	import PillButton from '$lib/PillButton.svelte';
 	import Amount from '$lib/currency/OldAmountInput.svelte';
 	import { Coin, Network } from '$lib/sendswap/utils/sendOptions';
@@ -12,14 +12,18 @@
 	import InfoTooltip from '$lib/components/InfoTooltip.svelte';
 	let auth = $derived(getAuth()());
 	let username = $derived(auth.value?.username);
-	let nodeRunnerAccount: string | undefined = $state();
+	// Consensus staking is locked to the signed-in account: the on-chain op's
+	// `to` must equal `from`. There is no delegation feature yet — staking to a
+	// different account actually TRANSFERS the HIVE to that account and stakes it
+	// there, so funds sent to an account you don't control can't be recovered.
+	// Derive (not just UI-lock) so the value can never be anything but the
+	// logged-in user. (Delegation is a planned feature, held until after the
+	// 0.2.0 fixes.)
+	let nodeRunnerAccount = $derived(username);
 	let amount: string | undefined = $state('');
 	let status = $state('');
 	let error = $state('');
 	let shouldDeposit = $state(true);
-	$effect(() => {
-		nodeRunnerAccount = username;
-	});
 	const sendTransaction = async (
 		amount: string,
 		nodeRunnerAccount: string
@@ -83,60 +87,78 @@
 	};
 </script>
 
-<form
-	onsubmit={(e) => {
-		e.preventDefault();
-		sendTransaction(amount!, nodeRunnerAccount!).then(async (res) => {
-			if (!res.success) {
+{#if auth.value == undefined || auth.value!.username != undefined}
+	<form
+		onsubmit={(e) => {
+			e.preventDefault();
+			sendTransaction(amount!, nodeRunnerAccount!).then(async (res) => {
+				if (!res.success) {
+					status = '';
+					error = res.error;
+					return;
+				}
+				status = 'Transaction broadcasted successfully!';
+				await sleep(1);
 				status = '';
-				error = res.error;
-				return;
-			}
-			status = 'Transaction broadcasted successfully!';
-			await sleep(1);
-			status = '';
-			amount = '';
-		});
-	}}
->
-	<div class="modal-title">
-		<h2>Consensus Staking</h2>
-		<InfoTooltip>
-			Staking deposits your HIVE into VSC and locks it while staked. Unstaking has a short
-			cooldown (about a day) before the HIVE returns to your liquid balance. Only Hive accounts
-			can stake. <a href="https://docs.vsc.eco" target="_blank" rel="noopener">Learn more →</a>
-		</InfoTooltip>
-	</div>
-	<p>Be sure to be signed in with the account you'd like to deposit and stake hive from.</p>
-	{#if error}<p class="error">{error}</p>{/if}
-	<Username label="Witness Account" id="node-runner" bind:value={nodeRunnerAccount} required />
-	<div class="amount-flex">
-		<Amount
-			selectItems={[Coin.hive]}
-			id="consensus-stake-amount"
-			label="Deposit and Stake Amount:"
-			coin={Coin.hive}
-			network={shouldDeposit ? Network.hiveMainnet : Network.magi}
-			bind:amountOfOriginalCoin={amount}
-			required
-			maxField={shouldDeposit ? undefined : 'hive'}
-		/>
-	</div>
-	<label for="deposit-checkbox">
-		<input type="checkbox" id="deposit-checkbox" bind:checked={shouldDeposit} />
-		First Deposit HIVE into VSC
-	</label>
-	<PillButton disabled={!!status} styleType="invert" theme="primary" onclick={() => {}}
-		>{#if shouldDeposit}Deposit and{/if} Stake</PillButton
+				amount = '';
+			});
+		}}
 	>
-	<span class="status">{status}</span>
-</form>
+		<div class="modal-title">
+			<h2>Consensus Staking</h2>
+			<InfoTooltip>
+				Staking deposits your HIVE into VSC and locks it while staked. Unstaking has a short
+				cooldown (about a day) before the HIVE returns to your liquid balance. Only Hive accounts
+				can stake. <a href="https://docs.vsc.eco" target="_blank" rel="noopener">Learn more →</a>
+			</InfoTooltip>
+		</div>
+		<p>Be sure to be signed in with the account you'd like to deposit and stake hive from.</p>
+		{#if error}<p class="error">{error}</p>{/if}
+		<div class="account-lock">
+			<span class="account-label">Witness Account</span>
+			<div class="account-value">
+				<Lock size={14} />
+				<span>@{username ?? '—'}</span>
+			</div>
+			<span class="account-hint">
+				Locked to the account you're signed in with — consensus staking can only target your own
+				account.
+			</span>
+		</div>
+		<div class="amount-flex">
+			<Amount
+				selectItems={[Coin.hive]}
+				id="consensus-stake-amount"
+				label="Deposit and Stake Amount:"
+				coin={Coin.hive}
+				network={shouldDeposit ? Network.hiveMainnet : Network.magi}
+				bind:amountOfOriginalCoin={amount}
+				required
+				maxField={shouldDeposit ? undefined : 'hive'}
+			/>
+		</div>
+		<label for="deposit-checkbox">
+			<input type="checkbox" id="deposit-checkbox" bind:checked={shouldDeposit} />
+			First Deposit HIVE into VSC
+		</label>
+		<PillButton disabled={!!status} styleType="invert" theme="primary" onclick={() => {}}
+			>{#if shouldDeposit}Deposit and{/if} Stake</PillButton
+		>
+		<span class="status">{status}</span>
+	</form>
+{:else}
+	<p class="error">
+		Consensus staking with an EVM wallet is currently unsupported. Please <a href="/logout"
+			>logout</a
+		> and login with a hive account instead.
+	</p>
+{/if}
 
 <style>
 	input[type='checkbox'] {
 		width: 1rem;
 		height: 1rem;
-		accent-color: #6F6AF8;
+		accent-color: #6f6af8;
 		cursor: pointer;
 	}
 	form {
@@ -153,6 +175,30 @@
 	}
 	.amount-flex {
 		display: flex;
+	}
+	.account-lock {
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+	}
+	.account-label {
+		font-size: 0.9rem;
+	}
+	.account-value {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		max-width: 16rem;
+		box-sizing: border-box;
+		padding: 0.5rem 0.75rem;
+		border: 1px solid var(--border-color, #444);
+		border-radius: 8px;
+		font-family: 'Noto Sans Mono Variable', monospace;
+		opacity: 0.85;
+	}
+	.account-hint {
+		font-size: 0.8rem;
+		opacity: 0.6;
 	}
 	.status {
 		color: var(--dash-accent-purple);

--- a/src/routes/(authed)/witness-assistant/ConsensusUnstakeModal.svelte
+++ b/src/routes/(authed)/witness-assistant/ConsensusUnstakeModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { getAuth } from '$lib/auth/store';
-	import Username from '$lib/auth/Username.svelte';
+	import { Lock } from '@lucide/svelte';
 	import PillButton from '$lib/PillButton.svelte';
 	import Amount from '$lib/currency/OldAmountInput.svelte';
 	import { Coin, Network } from '$lib/sendswap/utils/sendOptions';
@@ -11,13 +11,14 @@
 	import InfoTooltip from '$lib/components/InfoTooltip.svelte';
 	let auth = $derived(getAuth()());
 	let username = $derived(auth.value?.username);
-	let nodeRunnerAccount: string | undefined = $state();
+	// Locked to the signed-in account: the on-chain op's `to` must equal `from`.
+	// There is no delegation feature yet, so you can only unstake HIVE staked on
+	// the account you're signed in as. Derive (not just UI-lock) so the value can
+	// never be anything but the logged-in user.
+	let nodeRunnerAccount = $derived(username);
 	let amount: string | undefined = $state('');
 	let status = $state('');
 	let error = $state('');
-	$effect(() => {
-		nodeRunnerAccount = username;
-	});
 	const sendTransaction = async (amount: string, nodeRunnerAccount: string) => {
 		if (!username || !auth.value?.aioha)
 			return {
@@ -88,7 +89,16 @@
 			(about a day).
 		</p>
 		{#if error}<p class="error">{error}</p>{/if}
-		<Username label="Witness Account" id="node-runner" bind:value={nodeRunnerAccount} required />
+		<div class="account-lock">
+			<span class="account-label">Witness Account</span>
+			<div class="account-value">
+				<Lock size={14} />
+				<span>@{username ?? '—'}</span>
+			</div>
+			<span class="account-hint">
+				Locked to the account you're signed in with — you can only unstake your own account.
+			</span>
+		</div>
 		<div class="amount-flex">
 			<Amount
 				selectItems={[Coin.hive]}
@@ -129,6 +139,30 @@
 	}
 	.amount-flex {
 		display: flex;
+	}
+	.account-lock {
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+	}
+	.account-label {
+		font-size: 0.9rem;
+	}
+	.account-value {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		max-width: 16rem;
+		box-sizing: border-box;
+		padding: 0.5rem 0.75rem;
+		border: 1px solid var(--border-color, #444);
+		border-radius: 8px;
+		font-family: 'Noto Sans Mono Variable', monospace;
+		opacity: 0.85;
+	}
+	.account-hint {
+		font-size: 0.8rem;
+		opacity: 0.6;
 	}
 	.status {
 		color: var(--dash-accent-purple);


### PR DESCRIPTION
## What
The "Witness Account" field in the Consensus Staking / Unstaking modals is now
locked to the account you're signed in with. It was previously an editable input
that defaulted to your username but accepted any account.

## Why
That typed value becomes the `to` of the on-chain op (`from: hive:<you>`,
`to: hive:<typed>`). There is **no delegation feature**, so staking to an account
that isn't yours doesn't delegate — it *transfers* the HIVE to that account and
stakes it there, recoverable only with that account's keys. lordbutterfly hit
exactly this (staked to `magi-team-node` from the witness page, not realising it
was also a transfer) and asked that we lock the input to the signed-in account.

## How
- `nodeRunnerAccount = $derived(username)` in both modals — locked at the data
  layer, not just the UI. The field is now a read-only `@username` row with a lock
  icon; no input can change it.
- `to` therefore always equals `from`, which is also the required signer
  (`required_auths: [username]`).
- The consensus stake/unstake ops have no other callers, so this closes the path
  completely.
- The stake modal also gained the same EVM-wallet guard the unstake modal had.

## Scope / non-goals
- Preventive going forward — does **not** recover anything already staked to
  another account (that comes back the normal way: unstake from that account and
  send it back).
- Does **not** add delegation — that's the planned separate feature (PR 219),
  held until after the 0.2.0 rollout.

## Verification
- Traced every path: only the two modals call the consensus ops, and
  `nodeRunnerAccount` has no other write.
- `svelte-check` at baseline (no new errors). UI-only change; no tested logic
  touched.