### PR TITLE
fix(review): title the review step by flow type, not always 'Review Swap'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to Altera are documented here.
 > CI / build-banner / release-script use, and so a glance at `package.json`
 > matches reality.
 
+## [0.3.24] — 2026-06-20
+
+### Fixes
+
+- **The review step always read "Review Swap", even for a deposit, withdrawal, or send.** The review stage is shared across every flow, but its dialog title was hardcoded — so a Hive-mainnet deposit (and likewise a withdrawal or a send) showed "Review Swap" over the confirmation (spotted by Jux). The title now follows the flow's `txState.kind`: **Review Deposit** / **Review Withdrawal** / **Review Send** / **Review Swap**
+
 ## [0.3.22] — 2026-06-19
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.3.22",
+	"version": "0.3.24",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {

--- a/src/lib/sendswap/stages/ReviewSwap.svelte
+++ b/src/lib/sendswap/stages/ReviewSwap.svelte
@@ -56,6 +56,18 @@
 	const txState = requireTxState();
 	const asSwap = $derived(txState.kind === 'swap' ? txState : null);
 
+	// This review stage is shared across all flows, so the title follows the
+	// txState kind — otherwise a deposit/withdraw/send reads "Review Swap".
+	const reviewTitle = $derived(
+		txState.kind === 'deposit'
+			? 'Review Deposit'
+			: txState.kind === 'withdraw'
+				? 'Review Withdrawal'
+				: txState.kind === 'transfer'
+					? 'Review Send'
+					: 'Review Swap'
+	);
+
 	// Mark the review stage as "complete" (user can proceed) as soon as it
 	// becomes the active stage. The user clicking the forward button is then
 	// what triggers the actual broadcast.
@@ -665,7 +677,7 @@
 {#if popup}
 	<Dialog bind:open={dialogOpen} bind:toggle={dialogToggle}>
 		{#snippet title()}
-			Review Swap
+			{reviewTitle}
 		{/snippet}
 		{#snippet content()}
 			{@render reviewContent()}


### PR DESCRIPTION
## What
The review/confirmation step now titles itself by the flow type instead of
always reading "Review Swap".

| flow | title |
|------|-------|
| deposit | Review Deposit |
| withdraw | Review Withdrawal |
| send (transfer) | Review Send |
| swap | Review Swap |

## Why
`ReviewSwap` is the shared review stage for every flow, but its dialog title
was a hardcoded "Review Swap" — so a Hive-mainnet deposit showed "Review Swap"
over the confirmation (spotted by Jux). Same applied to withdrawals and sends.

## How
Added a `reviewTitle` derived from `txState.kind` (the existing flow
discriminator: `deposit | withdraw | transfer | swap`) and used it in the
dialog title snippet. Display-only change.

## Verification
- `svelte-check` at baseline, no new errors.
- Checked the sibling shared stage (`Complete.svelte`) — no other user-facing
  "Swap" string leaks into non-swap flows, so this was the only spot.