### PR TITLE
feat(withdraw): asset-first /withdraw page mirroring the deposit flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to Altera are documented here.
 > CI / build-banner / release-script use, and so a glance at `package.json`
 > matches reality.
 
+## [0.3.25] — 2026-06-22
+
+### Features
+
+- **Withdraw is now a dedicated `/withdraw` page instead of a modal**, mirroring the `/deposit` page (0.3.20). The dashboard "Withdraw" button navigates to a full route. It's an **asset-first 3-step timeline** — (1) "I want to withdraw" (only assets you hold on Magi, each with its live balance — you can't withdraw what you don't have), (2) "To" (destinations filtered to what the asset supports: HIVE/HBD → Hive mainnet; BTC → Bitcoin mainnet, Lightning, Coinbase-soon), (3) "Send" (the per-destination form). A persistent recent-withdrawals + FAQ side rail stays visible throughout, and the review + completion stages render as dialogs over the page
+
+### Internal
+
+- **Shared per-destination init.** The txState initialization for each destination was extracted into `withdrawInit.ts` so the new picker and the legacy menu route through one code path; broadcast payloads are identical by construction. `HiveMainnetWithdraw` gained a `lockAsset` mode that pins step 3 to the step-1 asset (so a withdraw can never silently become a different-asset swap; the BTC/Lightning rails are single-asset and lock implicitly). The legacy `Withdraw.svelte` modal stays (still used by `StakeUnstakeTabsModal`); only the dashboard entry point moved to the page
+
+### Testing
+
+- 5 `withdrawInit` tests pin that each (asset, destination) yields the same `from`/`to` as the legacy menu, and the per-chain withdraw flow tests (hive / btc / lightning) confirm the broadcast paths are unchanged
+
 ## [0.3.24] — 2026-06-20
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.3.24",
+	"version": "0.3.25",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {

--- a/schema.graphql
+++ b/schema.graphql
@@ -112,6 +112,21 @@ type ChainOracleStatus {
 
 """A smart contract deployed on the Magi network."""
 type Contract {
+  """
+  Hive block height at/after which this version's code becomes active. For a
+  pending (timelocked) update this is in the future; until the chain head
+  reaches it, the previously-active code keeps running. Equals creation_height
+  for immediate versions (deploys, networks without a timelock).
+  """
+  activation_height: Uint64!
+
+  """
+  Estimated timestamp at which this version becomes active (creation timestamp
+  plus the remaining timelock at ~3s/block). Null when the creation timestamp
+  is unavailable.
+  """
+  activation_ts: String
+
   """CID of the contract's WASM bytecode."""
   code: String
 
@@ -135,6 +150,11 @@ type Contract {
 
   """Current owner of the contract."""
   owner: String
+
+  """
+  Account that submitted this version (creator on deploy, signer on update).
+  """
+  proposer: String
 
   """WASM runtime version used by this contract."""
   runtime: String!
@@ -591,7 +611,12 @@ type Query {
     blockHeight: Uint64
   ): ElectionResult!
 
-  """Search for smart contracts matching the given filter criteria."""
+  """
+  Search for smart contracts matching the given filter criteria. By default
+  returns the version currently ACTIVE at the chain head for each contract;
+  queued (timelocked) updates are excluded — use findPendingContractUpdates for
+  those. Pass historical: true to return every stored version.
+  """
   findContract(
     """Filter criteria for the contract search."""
     filterOptions: FindContractFilter
@@ -624,6 +649,17 @@ type Query {
     """Filter criteria for the ledger transfer search."""
     filterOptions: LedgerTxFilter
   ): [LedgerRecord!]
+
+  """
+  List contract updates that are queued but not yet active (still inside their
+  timelock window). Each result shows which contract (id), the new code (code),
+  who submitted it (proposer/owner), and when it goes live (activation_height /
+  activation_ts). Filter by contract id via filterOptions.byId.
+  """
+  findPendingContractUpdates(
+    """Filter criteria; byId restricts to a single contract."""
+    filterOptions: FindContractFilter
+  ): [Contract!]
 
   """Search for transactions matching the given filter criteria."""
   findTransaction(

--- a/src/lib/cards/Balance/Balance.svelte
+++ b/src/lib/cards/Balance/Balance.svelte
@@ -6,7 +6,6 @@
 	import AccBalance from '$lib/AccBalance.svelte';
 	import { Send } from '@lucide/svelte';
 	import { goto } from '$app/navigation';
-	import Withdraw from '$lib/sendswap/Withdraw.svelte';
 	import QuickSend from '$lib/sendswap/QuickSend.svelte';
 	import { getTxSessionId } from '$lib/sendswap/utils/sendUtils';
 
@@ -34,9 +33,6 @@
 	let quickSendOpen = $state(false);
 	let sendSessionId = $state(getTxSessionId());
 	let toggleQuickSend = $state<(open?: boolean) => void>(() => {});
-	let withdrawOpen = $state(false);
-	let withdrawSessionId = $state(getTxSessionId());
-	let toggleWithdraw = $state<(open?: boolean) => void>(() => {});
 
 	function openDeposit() {
 		// eslint-disable-next-line svelte/no-navigation-without-resolve -- static route; resolve() not exported in this kit version
@@ -86,11 +82,6 @@
 	bind:dialogOpen={quickSendOpen}
 	bind:toggle={toggleQuickSend}
 	sessionId={sendSessionId}
-/>
-<Withdraw
-	bind:dialogOpen={withdrawOpen}
-	bind:toggle={toggleWithdraw}
-	sessionId={withdrawSessionId}
 />
 
 <style lang="scss">

--- a/src/lib/cards/Balance/Balance.svelte
+++ b/src/lib/cards/Balance/Balance.svelte
@@ -42,6 +42,10 @@
 		// eslint-disable-next-line svelte/no-navigation-without-resolve -- static route; resolve() not exported in this kit version
 		goto('/deposit');
 	}
+	function openWithdraw() {
+		// eslint-disable-next-line svelte/no-navigation-without-resolve -- static route; resolve() not exported in this kit version
+		goto('/withdraw');
+	}
 </script>
 
 <Card>
@@ -66,15 +70,7 @@
 
 		<div class="action-buttons">
 			<button class="action-btn action-btn-filled" onclick={openDeposit}> Deposit </button>
-			<button
-				class="action-btn action-btn-outline"
-				onclick={() => {
-					withdrawSessionId = getTxSessionId();
-					toggleWithdraw(true);
-				}}
-			>
-				Withdraw
-			</button>
+			<button class="action-btn action-btn-outline" onclick={openWithdraw}> Withdraw </button>
 		</div>
 
 		{#if did}

--- a/src/lib/sendswap/WithdrawPage.svelte
+++ b/src/lib/sendswap/WithdrawPage.svelte
@@ -1,0 +1,106 @@
+<!--
+	Withdraw flow as a dedicated page (route: /withdraw).
+
+	Page-layout sibling of Withdraw.svelte (the legacy modal). Same flow, same
+	txState/broadcast wiring — the differences mirror DepositPage:
+	  • renders StepsMachine with size="page" (no Dialog)
+	  • "close" navigates home instead of toggling a dialog
+	  • the options stage is the asset-first WithdrawTimeline; review + complete
+	    render as modal dialogs over the page (the `popup` flag)
+-->
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import WithdrawTimeline from './stages/withdraw/WithdrawTimeline.svelte';
+	import WithdrawSidebar from './stages/withdraw/WithdrawSidebar.svelte';
+	import { WithdrawTxState, provideTxState } from './utils/txState.svelte';
+	import Complete from './stages/Complete.svelte';
+	import ReviewSwap from './stages/ReviewSwap.svelte';
+	import StepsMachine, { type MixedStepsArray } from './StepsMachine.svelte';
+
+	const txState = new WithdrawTxState();
+	provideTxState(txState);
+
+	function applyWithdrawDetails() {
+		txState.toUsername = '';
+		txState.from = undefined;
+		txState.to = undefined;
+		txState.fromAmount = '0';
+		txState.toAmount = '0';
+		txState.fee = undefined;
+		txState.deductFee = false;
+		txState.maxFee = undefined;
+	}
+
+	// Page is always "open": initialise once at mount (parallel to DepositPage).
+	applyWithdrawDetails();
+
+	function leave() {
+		// eslint-disable-next-line svelte/no-navigation-without-resolve -- static root navigation; resolve() not exported in this kit version
+		goto('/');
+	}
+
+	const stepsData: MixedStepsArray = [
+		{ value: 'options', component: WithdrawTimeline },
+		{ value: 'review', component: ReviewSwap, popup: true },
+		{ value: 'complete', component: Complete, popup: true }
+	];
+
+	let extraProps = $derived({
+		close: leave,
+		onClose: leave,
+		compact: false
+	});
+</script>
+
+<div class="withdraw-page-wrapper">
+	<div class="withdraw-layout">
+		<div class="withdraw-flow-col">
+			<StepsMachine
+				size="page"
+				txType="withdraw"
+				resetState={applyWithdrawDetails}
+				{stepsData}
+				{extraProps}
+			/>
+		</div>
+		<aside class="withdraw-rail-col">
+			<WithdrawSidebar />
+		</aside>
+	</div>
+</div>
+
+<style lang="scss">
+	.withdraw-page-wrapper {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		min-height: 0;
+	}
+	.withdraw-layout {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) 18rem;
+		gap: 4rem;
+		max-width: 66rem;
+		margin: 0 auto;
+		padding: 2rem 1.5rem 4rem;
+		width: 100%;
+	}
+	.withdraw-flow-col {
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+	}
+	.withdraw-rail-col {
+		min-width: 0;
+	}
+	@media (max-width: 1440px) {
+		.withdraw-layout {
+			grid-template-columns: 1fr;
+		}
+	}
+	@media (max-width: 720px) {
+		.withdraw-layout {
+			padding: 1.25rem 1rem 3rem;
+		}
+	}
+</style>

--- a/src/lib/sendswap/stages/withdraw/HiveMainnetWithdraw.svelte
+++ b/src/lib/sendswap/stages/withdraw/HiveMainnetWithdraw.svelte
@@ -2,6 +2,7 @@
 	import { getAuth } from '$lib/auth/store';
 	import { getUsernameFromAuth } from '$lib/getAccountName';
 	import ClickableCard from '$lib/cards/ClickableCard.svelte';
+	import Card from '$lib/cards/Card.svelte';
 	import AmountInput from '$lib/currency/AmountInput.svelte';
 	import { CoinAmount } from '$lib/currency/CoinAmount';
 	import PillButton from '$lib/PillButton.svelte';
@@ -19,8 +20,16 @@
 	let {
 		editStage,
 		open,
-		secondaryMenu = $bindable(false)
-	}: { editStage: (complete: boolean) => void; open: boolean; secondaryMenu: boolean } = $props();
+		secondaryMenu = $bindable(false),
+		lockAsset = false
+	}: {
+		editStage: (complete: boolean) => void;
+		open: boolean;
+		secondaryMenu: boolean;
+		/** When true the asset is fixed by the parent (the timeline picked it in
+		 *  step 1), so we render a read-only asset card instead of the picker. */
+		lockAsset?: boolean;
+	} = $props();
 
 	const txState = useWithdrawState();
 	const auth = $derived(getAuth()());
@@ -256,25 +265,42 @@
 		{/if}
 		<div class="sections">
 			<div class="section">
-				<label for="asset-card">Withdraw From</label>
-				<ClickableCard onclick={() => toggleAsset(true)}>
-					<div class="asset-card">
-						{#if txState.from}
-							<BalanceInfo
-								coin={txState.from.coin}
-								network={txState.from.network}
-								size="large"
-								styleType="vertical"
-							/>
-						{:else}
-							<span class="user-icon-placeholder"
-								><Coins size="40" absoluteStrokeWidth={true} /></span
-							>
-							Select Withdrawal Asset
-						{/if}
-						<span class="edit"> Edit </span>
-					</div>
-				</ClickableCard>
+				{#if !lockAsset}
+					<label for="asset-card">Withdraw From</label>
+				{/if}
+				{#if lockAsset}
+					<Card>
+						<div class="asset-card">
+							{#if txState.from}
+								<BalanceInfo
+									coin={txState.from.coin}
+									network={txState.from.network}
+									size="large"
+									styleType="vertical"
+								/>
+							{/if}
+						</div>
+					</Card>
+				{:else}
+					<ClickableCard onclick={() => toggleAsset(true)}>
+						<div class="asset-card">
+							{#if txState.from}
+								<BalanceInfo
+									coin={txState.from.coin}
+									network={txState.from.network}
+									size="large"
+									styleType="vertical"
+								/>
+							{:else}
+								<span class="user-icon-placeholder"
+									><Coins size="40" absoluteStrokeWidth={true} /></span
+								>
+								Select Withdrawal Asset
+							{/if}
+							<span class="edit"> Edit </span>
+						</div>
+					</ClickableCard>
+				{/if}
 			</div>
 			<div class="section">
 				<label for={inputId}>Amount</label>

--- a/src/lib/sendswap/stages/withdraw/WithdrawSidebar.svelte
+++ b/src/lib/sendswap/stages/withdraw/WithdrawSidebar.svelte
@@ -1,0 +1,667 @@
+<!--
+	Withdraw page right column — recent-withdrawals rail + FAQ accordion.
+
+	Asset-first sibling of DepositSidebar.svelte: same structure and the same
+	hidden-Tr + SidePopup trick for opening a real transaction's detail modal,
+	but filters for withdrawal-typed ledger/ops instead of deposits. Self
+	contained: pulls `auth` via getAuth() itself.
+-->
+<script lang="ts">
+	import Card from '$lib/cards/Card.svelte';
+	import SidePopup from '$lib/components/SidePopup.svelte';
+	import WaveLoading from '$lib/components/WaveLoading.svelte';
+	import { getAuth } from '$lib/auth/store';
+	import { GetTransactionsStore } from '$houdini';
+	import moment from 'moment';
+	import { type Snippet } from 'svelte';
+	import Tr from '../../../../routes/(authed)/transactions/Table/tr/Tr.svelte';
+	import { getTimestamp, type TransactionInter } from '$lib/stores/txStores';
+	import { Check, ChevronDown, Clock } from '@lucide/svelte';
+
+	// ─── Recent withdrawals ─────────────────────────────────────────────────
+	type DisplayWithdrawal = {
+		id: string;
+		asset: string;
+		amount: string;
+		destination: string;
+		timeAgo: string;
+		status: 'confirmed' | 'pending';
+		realRef?: { tx: string; index: number };
+	};
+
+	const MOCK_RECENT_WITHDRAWALS: DisplayWithdrawal[] = [
+		{
+			id: 'mock-w-001',
+			asset: 'BTC',
+			amount: '0.00400000',
+			destination: 'Bitcoin mainnet',
+			timeAgo: '2 h ago',
+			status: 'confirmed'
+		},
+		{
+			id: 'mock-w-002',
+			asset: 'HIVE',
+			amount: '300.000',
+			destination: 'Hive mainnet',
+			timeAgo: 'yesterday',
+			status: 'confirmed'
+		},
+		{
+			id: 'mock-w-003',
+			asset: 'BTC',
+			amount: '0.00015000',
+			destination: 'Lightning',
+			timeAgo: '3 d ago',
+			status: 'pending'
+		}
+	];
+
+	const authValue = $derived(getAuth()());
+	let loadState = $state<'unauth' | 'loading' | 'loaded'>('loading');
+	let didFetch = $state(false);
+	let realWithdrawals = $state<DisplayWithdrawal[]>([]);
+	let realTxs = $state<TransactionInter[]>([]);
+	let hasMore = $state(false);
+	const RECENT_LIMIT = 10;
+	const RAW_TX_FETCH_LIMIT = 30;
+
+	let openSnippet = $state<(() => ReturnType<Snippet>) | undefined>();
+	let popupOpen = $state(false);
+	function captureSnippet(_op: [string, number], content: () => ReturnType<Snippet>) {
+		openSnippet = content;
+		popupOpen = true;
+	}
+	function togglePopup() {
+		popupOpen = !popupOpen;
+	}
+
+	function formatTime(ts: string): string {
+		const m = moment(ts);
+		if (!m.isValid()) return '—';
+		if (moment().diff(m, 'days') < 7) return m.fromNow();
+		return m.format('MMM DD, YYYY');
+	}
+	function formatAmount(raw: unknown, asset: string): string {
+		const dp = asset.toLowerCase() === 'btc' ? 8 : 3;
+		if (typeof raw === 'number') return (raw / 10 ** dp).toFixed(dp);
+		if (typeof raw === 'string') {
+			const n = Number(raw);
+			if (Number.isFinite(n) && raw.indexOf('.') === -1) return (n / 10 ** dp).toFixed(dp);
+			return raw;
+		}
+		return '—';
+	}
+	function isWithdrawType(t: unknown): boolean {
+		return String(t ?? '')
+			.toLowerCase()
+			.includes('withdraw');
+	}
+	function destinationFor(asset: string): string {
+		const a = asset.toLowerCase();
+		if (a === 'hive' || a === 'hbd') return 'Hive mainnet';
+		if (a === 'btc' || a === 'sats') return 'Bitcoin / Lightning';
+		return 'Withdrawal';
+	}
+
+	/** Pull every withdrawal-typed entry out of a single TransactionRecord. */
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	function extractWithdrawals(tx: any): DisplayWithdrawal[] {
+		if (tx?.status === 'FAILED') return [];
+		const out: DisplayWithdrawal[] = [];
+		const ts = tx ? getTimestamp(tx) : null;
+		const status: 'confirmed' | 'pending' =
+			tx?.status === 'CONFIRMED' || tx?.status === 'PROCESSED' || tx?.status === 'INCLUDED'
+				? 'confirmed'
+				: 'pending';
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(tx?.ledger ?? []).forEach((entry: any, index: number) => {
+			if (!isWithdrawType(entry?.type)) return;
+			const assetRaw = String(entry?.asset ?? '').split('_')[0] || 'hive';
+			out.push({
+				id: `${tx.id}-l${index}`,
+				asset: assetRaw.toUpperCase(),
+				amount: formatAmount(entry?.amount, assetRaw),
+				destination: destinationFor(assetRaw),
+				timeAgo: ts ? formatTime(ts) : '—',
+				status,
+				realRef: { tx: tx.id, index }
+			});
+		});
+		if (out.length > 0) return out;
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(tx?.ops ?? []).forEach((op: any, index: number) => {
+			if (!isWithdrawType(op?.type)) return;
+			const assetRaw = String(op?.data?.asset ?? '').split('_')[0] || 'hive';
+			out.push({
+				id: `${tx.id}-o${index}`,
+				asset: assetRaw.toUpperCase(),
+				amount: formatAmount(op?.data?.amount, assetRaw),
+				destination: destinationFor(assetRaw),
+				timeAgo: ts ? formatTime(ts) : '—',
+				status,
+				realRef: { tx: tx.id, index }
+			});
+		});
+		return out;
+	}
+
+	$effect(() => {
+		if (didFetch) return;
+		if (authValue.status === 'pending') return;
+		didFetch = true;
+		const did = authValue.value?.did;
+		if (!did) {
+			loadState = 'unauth';
+			return;
+		}
+		new GetTransactionsStore()
+			.fetch({ variables: { did, limit: RAW_TX_FETCH_LIMIT, offset: 0 }, policy: 'NetworkOnly' })
+			.then((result) => {
+				const rawTxs = (result.data?.findTransaction ?? []) as TransactionInter[];
+				const all = rawTxs.flatMap((tx) => extractWithdrawals(tx));
+				hasMore = all.length > RECENT_LIMIT || rawTxs.length >= RAW_TX_FETCH_LIMIT;
+				realTxs = rawTxs.map((tx) => ({ ...tx, isPending: false }));
+				realWithdrawals = all.slice(0, RECENT_LIMIT);
+				loadState = 'loaded';
+			})
+			.catch(() => {
+				realWithdrawals = [];
+				loadState = 'loaded';
+			});
+	});
+
+	const displayWithdrawals = $derived<DisplayWithdrawal[]>(
+		loadState === 'unauth' ? MOCK_RECENT_WITHDRAWALS : realWithdrawals
+	);
+
+	let activeMock = $state<DisplayWithdrawal | null>(null);
+	function handleClick(d: DisplayWithdrawal) {
+		if (d.realRef) {
+			const root = document.querySelector(
+				`[data-mock-tr-withdraw-id="${CSS.escape(d.id)}"] tr.clickable-row`
+			) as HTMLElement | null;
+			root?.click();
+		} else {
+			activeMock = d;
+			openSnippet = mockSnippet;
+			popupOpen = true;
+		}
+	}
+
+	let openFaqIdx = $state<number | null>(null);
+	function toggleFaq(idx: number) {
+		openFaqIdx = openFaqIdx === idx ? null : idx;
+	}
+</script>
+
+<aside class="rail">
+	<section>
+		<h5>Recent withdrawals</h5>
+		{#if loadState === 'loading'}
+			<div class="recent-loading"><WaveLoading size={18} /></div>
+		{:else if displayWithdrawals.length === 0}
+			<p class="rail-empty">No recent withdrawals yet.</p>
+		{:else}
+			<ul class="recent-list">
+				{#each displayWithdrawals as d (d.id)}
+					<li>
+						<button class="recent-item" type="button" onclick={() => handleClick(d)}>
+							<div class="recent-icon" data-status={d.status}>
+								{#if d.status === 'confirmed'}<Check size={12} strokeWidth={3} />{:else}<Clock
+										size={12}
+									/>{/if}
+							</div>
+							<div class="recent-body">
+								<div class="recent-top">
+									<span class="recent-amount">−{d.amount} {d.asset}</span>
+									<span class="recent-time">{d.timeAgo}</span>
+								</div>
+								<div class="recent-bottom">
+									<span class="recent-source">to {d.destination}</span>
+									{#if d.status === 'pending'}<span class="recent-status pending">pending</span
+										>{/if}
+								</div>
+							</div>
+						</button>
+					</li>
+				{/each}
+			</ul>
+			{#if hasMore}
+				<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- static internal link; resolve() not exported in this kit version -->
+				<a class="recent-view-more" href="/transactions"> View all withdrawals → </a>
+			{/if}
+		{/if}
+	</section>
+
+	<section>
+		<h5>FAQ</h5>
+		<Card>
+			<button
+				class="faq-trigger"
+				class:open={openFaqIdx === 0}
+				type="button"
+				onclick={() => toggleFaq(0)}
+				aria-expanded={openFaqIdx === 0}
+			>
+				<span>How long does a withdrawal take?</span>
+				<ChevronDown class="faq-chevron" size={16} />
+			</button>
+			{#if openFaqIdx === 0}
+				<div class="faq-divider"><hr /></div>
+				<div class="faq-body">
+					<p>Depends on the destination you pick:</p>
+					<ul>
+						<li><strong>Hive mainnet</strong> — instant once the block confirms</li>
+						<li><strong>Lightning</strong> — about a minute</li>
+						<li><strong>Bitcoin mainnet</strong> — about 10 minutes (1 confirmation)</li>
+					</ul>
+					<p>Each option shows its ETA in step 2.</p>
+				</div>
+			{/if}
+		</Card>
+		<Card>
+			<button
+				class="faq-trigger"
+				class:open={openFaqIdx === 1}
+				type="button"
+				onclick={() => toggleFaq(1)}
+				aria-expanded={openFaqIdx === 1}
+			>
+				<span>Are there fees?</span>
+				<ChevronDown class="faq-chevron" size={16} />
+			</button>
+			{#if openFaqIdx === 1}
+				<div class="faq-divider"><hr /></div>
+				<div class="faq-body">
+					<ul>
+						<li><strong>Hive mainnet</strong> — free</li>
+						<li><strong>Lightning</strong> — small gateway fee (~10 sats)</li>
+						<li>
+							<strong>Bitcoin mainnet</strong> — pays the on-chain network fee (you can cap it)
+						</li>
+					</ul>
+				</div>
+			{/if}
+		</Card>
+		<Card>
+			<button
+				class="faq-trigger"
+				class:open={openFaqIdx === 2}
+				type="button"
+				onclick={() => toggleFaq(2)}
+				aria-expanded={openFaqIdx === 2}
+			>
+				<span>Why can&rsquo;t I see an asset?</span>
+				<ChevronDown class="faq-chevron" size={16} />
+			</button>
+			{#if openFaqIdx === 2}
+				<div class="faq-divider"><hr /></div>
+				<div class="faq-body">
+					<p>
+						Step 1 only lists assets you currently hold on Magi — you can&rsquo;t withdraw a balance
+						you don&rsquo;t have. Deposit or swap into an asset first and it&rsquo;ll appear here.
+					</p>
+				</div>
+			{/if}
+		</Card>
+		<Card>
+			<button
+				class="faq-trigger"
+				class:open={openFaqIdx === 3}
+				type="button"
+				onclick={() => toggleFaq(3)}
+				aria-expanded={openFaqIdx === 3}
+			>
+				<span>Withdrawal hasn&rsquo;t arrived?</span>
+				<ChevronDown class="faq-chevron" size={16} />
+			</button>
+			{#if openFaqIdx === 3}
+				<div class="faq-divider"><hr /></div>
+				<div class="faq-body">
+					<ol>
+						<li>For Bitcoin mainnet, allow at least 1 on-chain confirmation (~10 min).</li>
+						<li>Double-check the destination address/account was correct.</li>
+						<li>
+							Refresh the
+							<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- static internal link; resolve() not exported in this kit version -->
+							<a href="/transactions">Transactions</a> page — there&rsquo;s no live polling yet.
+						</li>
+						<li>Still missing? Share the tx id with support.</li>
+					</ol>
+				</div>
+			{/if}
+		</Card>
+	</section>
+</aside>
+
+<div class="hidden-tr-mount" aria-hidden="true">
+	{#each realWithdrawals ?? [] as d (d.id)}
+		{#if d.realRef}
+			{@const tx = realTxs.find((t) => t.id === d.realRef!.tx)}
+			{@const op = tx?.ops?.[d.realRef.index]}
+			{#if tx && op}
+				<table data-mock-tr-withdraw-id={d.id}>
+					<tbody>
+						<Tr {tx} {op} onRowClick={captureSnippet} />
+					</tbody>
+				</table>
+			{/if}
+		{/if}
+	{/each}
+</div>
+
+{#snippet mockSnippet()}
+	{#if activeMock}
+		<h3 class="mock-modal-title">Withdrawal · {activeMock.asset}</h3>
+		<p class="mock-modal-amount">−{activeMock.amount} {activeMock.asset}</p>
+		<dl class="mock-modal-fields">
+			<div>
+				<dt>To</dt>
+				<dd>{activeMock.destination}</dd>
+			</div>
+			<div>
+				<dt>When</dt>
+				<dd>{activeMock.timeAgo}</dd>
+			</div>
+			<div>
+				<dt>Status</dt>
+				<dd class="mock-modal-status" data-status={activeMock.status}>{activeMock.status}</dd>
+			</div>
+		</dl>
+		<p class="mock-modal-hint">
+			This is mock data. Sign in with a Hive account that has real withdrawals to see live
+			transaction details here.
+		</p>
+	{/if}
+{/snippet}
+
+<SidePopup content={openSnippet} bind:open={popupOpen} toggle={togglePopup} />
+
+<style lang="scss">
+	$accent: #6f6af8;
+	$accent-soft: rgba(111, 106, 248, 0.16);
+	$border: rgba(255, 255, 255, 0.09);
+	$border-strong: rgba(255, 255, 255, 0.16);
+	$surface: rgba(255, 255, 255, 0.035);
+	$surface-strong: rgba(255, 255, 255, 0.06);
+
+	.rail {
+		display: flex;
+		flex-direction: column;
+		gap: 1.75rem;
+	}
+	.rail h5 {
+		margin: 0 0 0.6rem;
+		font-size: 0.72rem;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--dash-text-secondary);
+	}
+	.rail section {
+		display: flex;
+		flex-direction: column;
+		gap: 0.6rem;
+	}
+	.rail-empty {
+		margin: 0;
+		color: var(--dash-text-muted);
+		font-size: 0.85rem;
+	}
+
+	:global(.faq-trigger) {
+		width: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		margin: -1.25rem;
+		padding: 1.25rem;
+		background: transparent;
+		border: none;
+		color: var(--dash-text-primary);
+		font: inherit;
+		font-weight: 500;
+		text-align: left;
+		cursor: pointer;
+		border-radius: 27px;
+	}
+	:global(.faq-trigger.open) {
+		margin-bottom: 0;
+	}
+	:global(.faq-trigger) :global(.faq-chevron) {
+		flex-shrink: 0;
+		transition: transform 200ms ease;
+		color: var(--dash-text-secondary);
+	}
+	:global(.faq-trigger[aria-expanded='true']) :global(.faq-chevron) {
+		transform: rotate(180deg);
+	}
+	:global(.faq-divider) {
+		padding: 0.5rem 0;
+	}
+	:global(.faq-divider hr) {
+		margin: 0;
+		border: none;
+		border-top: 1px solid rgba(255, 255, 255, 0.08);
+	}
+	:global(.faq-body) {
+		font-size: 0.83rem;
+		line-height: 1.5;
+		color: var(--dash-text-secondary);
+		font-weight: 400;
+	}
+	:global(.faq-body p) {
+		margin: 0 0 0.5rem;
+	}
+	:global(.faq-body p:last-child) {
+		margin-bottom: 0;
+	}
+	:global(.faq-body ul),
+	:global(.faq-body ol) {
+		margin: 0.25rem 0 0.5rem;
+		padding-left: 1.1rem;
+	}
+	:global(.faq-body li) {
+		margin: 0.25rem 0;
+	}
+	:global(.faq-body li::marker) {
+		color: var(--dash-text-muted);
+	}
+	:global(.faq-body strong) {
+		color: var(--dash-text-primary);
+		font-weight: 600;
+	}
+	:global(.faq-body a) {
+		color: $accent;
+		text-decoration: none;
+		border-bottom: 1px solid rgba(111, 106, 248, 0.35);
+	}
+
+	.recent-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+	.recent-item {
+		display: grid;
+		grid-template-columns: 1.6rem 1fr;
+		gap: 0.6rem;
+		align-items: center;
+		padding: 0.55rem 0.65rem;
+		background: $surface;
+		border: 1px solid $border;
+		border-radius: 10px;
+		color: inherit;
+		font: inherit;
+		text-align: left;
+		cursor: pointer;
+		width: 100%;
+		transition:
+			background-color 150ms ease,
+			border-color 150ms ease;
+	}
+	.recent-item:hover,
+	.recent-item:focus-visible {
+		background: $surface-strong;
+		border-color: $border-strong;
+		outline: none;
+	}
+	.recent-icon {
+		width: 1.6rem;
+		height: 1.6rem;
+		border-radius: 50%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+	}
+	.recent-icon[data-status='confirmed'] {
+		background: rgba(74, 222, 128, 0.18);
+		color: #6ee7a1;
+	}
+	.recent-icon[data-status='pending'] {
+		background: rgba(255, 200, 0, 0.15);
+		color: #f5c451;
+	}
+	.recent-body {
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.1rem;
+	}
+	.recent-top {
+		display: flex;
+		justify-content: space-between;
+		gap: 0.5rem;
+		align-items: baseline;
+	}
+	.recent-amount {
+		font-weight: 600;
+		font-size: 0.85rem;
+		color: var(--dash-text-primary);
+		font-variant-numeric: tabular-nums;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	.recent-time {
+		font-size: 0.7rem;
+		color: var(--dash-text-muted);
+		white-space: nowrap;
+		flex-shrink: 0;
+	}
+	.recent-bottom {
+		display: flex;
+		gap: 0.5rem;
+		align-items: baseline;
+		font-size: 0.72rem;
+		color: var(--dash-text-secondary);
+	}
+	.recent-source {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.recent-status.pending {
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		font-size: 0.6rem;
+		font-weight: 700;
+		color: #f5c451;
+		flex-shrink: 0;
+	}
+	.recent-loading {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		padding: 1rem 0;
+		color: var(--dash-text-secondary);
+	}
+	.recent-view-more {
+		display: inline-flex;
+		margin-top: 0.5rem;
+		padding: 0.45rem 0.6rem;
+		font-size: 0.75rem;
+		font-weight: 500;
+		color: $accent;
+		text-decoration: none;
+		border-radius: 8px;
+		transition: background-color 150ms ease;
+	}
+	.recent-view-more:hover {
+		background: $accent-soft;
+	}
+
+	.hidden-tr-mount {
+		position: absolute;
+		left: -9999px;
+		top: 0;
+		width: 0;
+		height: 0;
+		overflow: hidden;
+		opacity: 0;
+		pointer-events: none;
+	}
+
+	.mock-modal-title {
+		margin: 0 0 0.25rem;
+		font-size: 1.1rem;
+		color: var(--dash-text-primary);
+		font-family: 'Nunito Sans', sans-serif;
+	}
+	.mock-modal-amount {
+		margin: 0 0 1rem;
+		font-size: 1.6rem;
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
+		color: var(--dash-text-primary);
+	}
+	.mock-modal-fields {
+		display: grid;
+		grid-template-columns: 6rem 1fr;
+		gap: 0.5rem 1rem;
+		margin: 0 0 1rem;
+		font-size: 0.88rem;
+	}
+	.mock-modal-fields > div {
+		display: contents;
+	}
+	.mock-modal-fields dt {
+		font-size: 0.72rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--dash-text-secondary);
+		font-weight: 600;
+		padding-top: 0.15rem;
+	}
+	.mock-modal-fields dd {
+		margin: 0;
+		color: var(--dash-text-primary);
+	}
+	.mock-modal-status {
+		text-transform: capitalize;
+		font-weight: 500;
+	}
+	.mock-modal-status[data-status='confirmed'] {
+		color: #6ee7a1;
+	}
+	.mock-modal-status[data-status='pending'] {
+		color: #f5c451;
+	}
+	.mock-modal-hint {
+		font-size: 0.78rem;
+		color: var(--dash-text-muted);
+		font-style: italic;
+		margin: 0;
+		padding: 0.6rem 0.75rem;
+		background: rgba(255, 255, 255, 0.03);
+		border: 1px dashed rgba(255, 255, 255, 0.1);
+		border-radius: 8px;
+	}
+</style>

--- a/src/lib/sendswap/stages/withdraw/WithdrawTimeline.svelte
+++ b/src/lib/sendswap/stages/withdraw/WithdrawTimeline.svelte
@@ -1,0 +1,575 @@
+<!--
+	Withdraw flow — production timeline.
+
+	Asset-first sibling of DepositTimeline.svelte (the 3-step Asset → Destination
+	→ Send timeline), wired to the SAME real txState/broadcast plumbing the
+	legacy WithdrawOptions used. Differences from deposit, by design:
+	  • step 1 lists ONLY assets the user holds on Magi (you can't withdraw what
+	    you don't have) — each chip shows its live balance
+	  • step 2 destinations filter to what the chosen asset supports (HIVE/HBD →
+	    Hive mainnet; BTC → Bitcoin mainnet, Lightning, Coinbase-soon)
+	  • step 3 mounts the REAL per-destination components (HiveMainnetWithdraw
+	    with lockAsset, BitcoinMainnetWithdraw, KeepsatsWithdraw)
+	  • selections route through useWithdrawState() + initWithdrawStateForDestination
+	    so the broadcast payload matches the legacy menu
+
+	The recent-withdrawals rail + FAQ live in WithdrawSidebar.svelte (page-level
+	column) — this component is the flow only.
+-->
+<script lang="ts">
+	import * as steps from '@zag-js/steps';
+	import { useMachine, normalizeProps } from '@zag-js/svelte';
+	import { untrack, type ComponentProps } from 'svelte';
+	import { Check, Clock, Info, Receipt } from '@lucide/svelte';
+	import Tooltip from '$lib/components/Tooltip.svelte';
+
+	import { Coin, Network } from '../../utils/sendOptions';
+	import { useWithdrawState } from '../../utils/txState.svelte';
+	import { accountBalance, getBalanceAmount } from '$lib/stores/currentBalance';
+	import { initWithdrawStateForDestination, type WithdrawDestination } from './withdrawInit';
+	import HiveMainnetWithdraw from './HiveMainnetWithdraw.svelte';
+	import BitcoinMainnetWithdraw from './BitcoinMainnetWithdraw.svelte';
+	import KeepsatsWithdraw from './KeepsatsWithdraw.svelte';
+	import type NavButtons from '$lib/sendswap/components/NavButtons.svelte';
+
+	// Props contract matches WithdrawOptions so the StepsMachine wiring is a
+	// one-line swap. onHomePage / customButtons MUST stay $bindable.
+	let {
+		editStage,
+		onHomePage = $bindable(),
+		customButtons = $bindable()
+	}: {
+		editStage: (complete: boolean) => void;
+		onHomePage: boolean;
+		customButtons: ComponentProps<typeof NavButtons>['buttons'] | undefined;
+	} = $props();
+
+	const txState = useWithdrawState();
+
+	// ─── Step machine (Zag) — drives the timeline indicators ─────────────────
+	const stepDefs = [
+		{ id: 'asset', label: 'I want to withdraw' },
+		{ id: 'destination', label: 'To' },
+		{ id: 'send', label: 'Send' }
+	] as const;
+
+	const stepId = $props.id();
+	const stepsService = useMachine(steps.machine, {
+		id: stepId,
+		orientation: 'vertical',
+		count: stepDefs.length,
+		linear: true
+	});
+	const stepsApi = $derived(steps.connect(stepsService, normalizeProps));
+
+	// ─── Held assets (step 1) — only what the user has on Magi ────────────────
+	// Withdrawing is bounded by your balance, so step 1 shows held assets only,
+	// each with its live amount. Deposit shows everything; withdraw does not.
+	const ASSET_DEFS = [
+		{ value: Coin.hive.value, coin: Coin.hive, label: 'HIVE', icon: '/hive/hive.svg' },
+		{ value: Coin.hbd.value, coin: Coin.hbd, label: 'HBD', icon: '/hive/hbd.svg' },
+		{ value: Coin.btc.value, coin: Coin.btc, label: 'BTC', icon: '/btc/btc.svg' }
+	];
+	const heldAssets = $derived(
+		ASSET_DEFS.map((a) => ({
+			...a,
+			balance: getBalanceAmount($accountBalance, a.coin, Network.magi)
+		})).filter((a) => a.balance.amount > 0)
+	);
+
+	// ─── Destinations (step 2) — filtered by the chosen asset ─────────────────
+	type DestDef = {
+		value: WithdrawDestination;
+		label: string;
+		icon: string;
+		eta: string;
+		fee: string;
+		blurb: string;
+		supports: string[];
+		disabled?: boolean;
+	};
+	const DESTINATIONS: DestDef[] = [
+		{
+			value: 'hive_mainnet',
+			label: 'Hive mainnet',
+			icon: '/hive/hive.svg',
+			eta: 'instant',
+			fee: 'no fee',
+			blurb: 'Send to any Hive account on the Hive blockchain.',
+			supports: [Coin.hive.value, Coin.hbd.value]
+		},
+		{
+			value: 'btc_mainnet',
+			label: 'Bitcoin mainnet',
+			icon: '/btc/btc.svg',
+			eta: '≈ 10 min',
+			fee: 'network fee varies',
+			blurb: 'Send BTC to an on-chain Bitcoin address.',
+			supports: [Coin.btc.value]
+		},
+		{
+			value: 'lightning',
+			label: 'Lightning',
+			icon: '/btc/lightning.svg',
+			eta: '≈ 1 min',
+			fee: '~10 sats',
+			blurb: 'Withdraw sats to your Keepsats balance on V4VApp.',
+			supports: [Coin.btc.value]
+		},
+		{
+			value: 'coinbase',
+			label: 'Coinbase',
+			icon: '/btc/CoinBase_logo.svg',
+			eta: '—',
+			fee: 'coming soon',
+			blurb: 'Cash out straight to your Coinbase account.',
+			supports: [Coin.btc.value],
+			disabled: true
+		}
+	];
+
+	let selectedAsset = $state<string | null>(null);
+	let selectedDest = $state<WithdrawDestination | null>(null);
+	let secondaryMenu = $state(false);
+
+	const availableDestinations = $derived(
+		selectedAsset ? DESTINATIONS.filter((d) => d.supports.includes(selectedAsset!)) : []
+	);
+
+	// Drive the step indicator from selections.
+	$effect(() => {
+		if (selectedAsset && !selectedDest) stepsApi.setStep(1);
+		else if (selectedAsset && selectedDest) stepsApi.setStep(2);
+		else stepsApi.setStep(0);
+	});
+
+	function pickAsset(value: string) {
+		selectedAsset = value;
+		const def = ASSET_DEFS.find((a) => a.value === value);
+		// Source is always Magi for a withdrawal — express it before dest init.
+		untrack(() => {
+			if (def) txState.from = { coin: def.coin, network: Network.magi };
+		});
+		// Invalidate a destination the new asset doesn't support.
+		if (
+			selectedDest &&
+			!DESTINATIONS.find((d) => d.value === selectedDest)?.supports.includes(value)
+		) {
+			selectedDest = null;
+			editStage(false);
+		}
+		if (selectedDest && def) {
+			untrack(() => initWithdrawStateForDestination(txState, selectedDest!, def.coin));
+		}
+	}
+
+	function pickDest(value: WithdrawDestination) {
+		const def = DESTINATIONS.find((d) => d.value === value);
+		if (def?.disabled) return;
+		selectedDest = value;
+		editStage(false);
+		const asset = ASSET_DEFS.find((a) => a.value === selectedAsset);
+		if (asset) untrack(() => initWithdrawStateForDestination(txState, value, asset.coin));
+	}
+
+	// Parent NavButtons (Review) show once a real destination is chosen — every
+	// withdraw rail completes via editStage → the parent's Review button.
+	$effect(() => {
+		onHomePage = !!selectedDest && selectedDest !== 'coinbase';
+		customButtons = undefined;
+	});
+</script>
+
+<div class="page" class:bare={secondaryMenu}>
+	<div class="main">
+		{#if !secondaryMenu}
+			<header class="page-head">
+				<h2>Withdraw</h2>
+				<p class="lead">Send funds from your Magi balance.</p>
+			</header>
+		{/if}
+
+		<div {...stepsApi.getRootProps()} class="timeline">
+			<!-- ─── Step 1: Asset (held only) ──────────────────────────────── -->
+			{#if !secondaryMenu}
+				<div {...stepsApi.getItemProps({ index: 0 })} class="timeline-item">
+					<div {...stepsApi.getIndicatorProps({ index: 0 })} class="timeline-indicator">
+						{#if stepsApi.value > 0}<Check size={14} strokeWidth={3} />{:else}1{/if}
+					</div>
+					<div class="timeline-content">
+						<h4 class="step-heading">{stepDefs[0].label}</h4>
+						<div class="step-body">
+							{#if heldAssets.length === 0}
+								<p class="picker-empty">You have no withdrawable balance on Magi yet.</p>
+							{:else}
+								<div class="chip-row">
+									{#each heldAssets as a (a.value)}
+										<button
+											type="button"
+											class="asset-chip"
+											class:sel={selectedAsset === a.value}
+											onclick={() => pickAsset(a.value)}
+										>
+											<img src={a.icon} alt="" width="22" height="22" />
+											<span class="chip-text">
+												<span class="chip-tk">{a.label}</span>
+												<span class="chip-bal">{a.balance.toPrettyAmountString()}</span>
+											</span>
+										</button>
+									{/each}
+								</div>
+								<p class="held-note">Only assets you hold on Magi are shown.</p>
+							{/if}
+						</div>
+					</div>
+				</div>
+
+				<!-- ─── Step 2: Destination ────────────────────────────────── -->
+				<div {...stepsApi.getItemProps({ index: 1 })} class="timeline-item">
+					<div {...stepsApi.getIndicatorProps({ index: 1 })} class="timeline-indicator">
+						{#if stepsApi.value > 1}<Check size={14} strokeWidth={3} />{:else}2{/if}
+					</div>
+					<div class="timeline-content">
+						<h4 class="step-heading">{stepDefs[1].label}</h4>
+						<div class="step-body dest-picker">
+							{#if availableDestinations.length === 0}
+								<p class="picker-empty">Pick an asset first.</p>
+							{:else}
+								{#each availableDestinations as d (d.value)}
+									<button
+										type="button"
+										class="dest-card"
+										class:sel={selectedDest === d.value}
+										class:off={d.disabled}
+										disabled={d.disabled}
+										onclick={() => pickDest(d.value)}
+									>
+										<div class="dest-icon">
+											<img src={d.icon} alt={d.label} width="28" height="28" />
+										</div>
+										<div class="dest-body">
+											<div class="dest-head">
+												<span class="dest-label">{d.label}</span>
+												{#if d.disabled}
+													<span class="dest-soon">soon</span>
+												{:else}
+													<span
+														class="dest-info"
+														tabindex="0"
+														role="button"
+														aria-label="Show {d.label} details"
+													>
+														<Info size={14} />
+														<Tooltip>
+															<span class="info-tooltip">
+																<span class="info-row"
+																	><Clock size={12} strokeWidth={2.25} /><span>{d.eta}</span></span
+																>
+																<span class="info-row"
+																	><Receipt size={12} strokeWidth={2.25} /><span>{d.fee}</span
+																	></span
+																>
+															</span>
+														</Tooltip>
+													</span>
+												{/if}
+											</div>
+											<p class="dest-blurb">{d.blurb}</p>
+										</div>
+									</button>
+								{/each}
+							{/if}
+						</div>
+					</div>
+				</div>
+			{/if}
+
+			<!-- ─── Step 3: Send ───────────────────────────────────────────── -->
+			<div
+				{...stepsApi.getItemProps({ index: 2 })}
+				class="timeline-item"
+				class:bare={secondaryMenu}
+			>
+				{#if !secondaryMenu}
+					<div {...stepsApi.getIndicatorProps({ index: 2 })} class="timeline-indicator">
+						{#if stepsApi.value > 2}<Check size={14} strokeWidth={3} />{:else}3{/if}
+					</div>
+				{/if}
+				<div class="timeline-content">
+					{#if !secondaryMenu}<h4 class="step-heading">{stepDefs[2].label}</h4>{/if}
+					<div class="step-body">
+						{#if selectedDest === 'hive_mainnet'}
+							<HiveMainnetWithdraw {editStage} open={true} bind:secondaryMenu lockAsset={true} />
+						{:else if selectedDest === 'btc_mainnet'}
+							<BitcoinMainnetWithdraw {editStage} open={true} />
+						{:else if selectedDest === 'lightning'}
+							<KeepsatsWithdraw {editStage} open={true} />
+						{:else}
+							<p class="locked-hint">Select a destination above to continue.</p>
+						{/if}
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<style lang="scss">
+	$accent: #6f6af8;
+	$accent-soft: rgba(111, 106, 248, 0.16);
+	$border: rgba(255, 255, 255, 0.09);
+	$border-strong: rgba(255, 255, 255, 0.16);
+	$surface: rgba(255, 255, 255, 0.035);
+
+	.page {
+		display: flex;
+		flex-direction: column;
+		padding: 0.5rem 0.75rem;
+	}
+	.page.bare {
+		padding: 0;
+	}
+	.page-head {
+		margin-bottom: 2rem;
+	}
+	.page-head h2 {
+		margin: 0 0 0.25rem;
+		font-size: 1.85rem;
+	}
+	.lead {
+		color: var(--dash-text-secondary);
+		margin: 0;
+	}
+
+	.timeline {
+		display: flex;
+		flex-direction: column;
+		gap: 1.25rem;
+	}
+	.timeline-item {
+		display: grid;
+		grid-template-columns: 2.5rem 1fr;
+		gap: 1rem;
+		position: relative;
+	}
+	.timeline-item.bare {
+		grid-template-columns: 1fr;
+	}
+	.timeline-item:not(:last-child)::before {
+		content: '';
+		position: absolute;
+		top: 2.5rem;
+		left: 1.2rem;
+		bottom: -1.25rem;
+		width: 1px;
+		background: linear-gradient(to bottom, $border, transparent);
+	}
+	.timeline-indicator {
+		width: 2.5rem;
+		height: 2.5rem;
+		border-radius: 50%;
+		border: 1px solid $border;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: $surface;
+		font-weight: 600;
+		color: var(--dash-text-secondary);
+		font-size: 0.9rem;
+		transition: all 200ms ease;
+	}
+	.timeline-indicator[data-state='current'] {
+		border-color: $accent;
+		background: $accent-soft;
+		color: #fff;
+		box-shadow: 0 0 0 4px rgba(111, 106, 248, 0.08);
+	}
+	.timeline-indicator[data-state='complete'] {
+		border-color: $accent;
+		background: $accent;
+		color: #fff;
+	}
+	.timeline-content {
+		min-width: 0;
+	}
+	.step-heading {
+		font-size: 1.05rem;
+		font-weight: 600;
+		color: var(--dash-text-primary);
+	}
+	.step-body {
+		margin-top: 0.4rem;
+	}
+
+	/* Step 1 — asset chips with balance */
+	.chip-row {
+		display: flex;
+		gap: 0.6rem;
+		flex-wrap: wrap;
+	}
+	.asset-chip {
+		display: flex;
+		align-items: center;
+		gap: 0.55rem;
+		padding: 0.55rem 0.75rem;
+		border-radius: 14px;
+		border: 1px solid $border;
+		background: $surface;
+		color: inherit;
+		font: inherit;
+		cursor: pointer;
+		transition:
+			background-color 150ms ease,
+			border-color 150ms ease;
+	}
+	.asset-chip:hover {
+		border-color: $border-strong;
+	}
+	.asset-chip.sel {
+		border-color: $accent;
+		background: $accent-soft;
+	}
+	.chip-text {
+		display: flex;
+		flex-direction: column;
+		line-height: 1.2;
+		text-align: left;
+	}
+	.chip-tk {
+		font-weight: 600;
+		font-size: 0.92rem;
+		color: var(--dash-text-primary);
+	}
+	.chip-bal {
+		font-size: 0.72rem;
+		color: var(--dash-text-secondary);
+		font-variant-numeric: tabular-nums;
+	}
+	.held-note {
+		margin: 0.6rem 0 0;
+		font-size: 0.72rem;
+		color: var(--dash-text-muted);
+	}
+
+	/* Step 2 — destination cards */
+	.dest-picker {
+		display: flex;
+		flex-direction: column;
+		gap: 0.6rem;
+	}
+	.dest-card {
+		display: grid;
+		grid-template-columns: 2.5rem 1fr;
+		gap: 0.85rem;
+		align-items: start;
+		width: 100%;
+		text-align: left;
+		padding: 1.1rem 1.25rem;
+		border-radius: 14px;
+		border: 1px solid $border;
+		background: $surface;
+		color: inherit;
+		font: inherit;
+		cursor: pointer;
+		transition:
+			background-color 150ms ease,
+			border-color 150ms ease;
+	}
+	.dest-card:hover:not(.off) {
+		background: rgba(255, 255, 255, 0.05);
+		border-color: $border-strong;
+	}
+	.dest-card.sel {
+		border-color: $accent;
+		background: $accent-soft;
+	}
+	.dest-card.off {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+	.dest-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 2.5rem;
+		height: 2.5rem;
+		flex-shrink: 0;
+	}
+	.dest-icon img {
+		display: block;
+		object-fit: contain;
+	}
+	.dest-head {
+		display: flex;
+		justify-content: space-between;
+		flex-wrap: wrap;
+		gap: 0.25rem 1rem;
+		align-items: baseline;
+		min-width: 0;
+	}
+	.dest-label {
+		font-weight: 600;
+		font-size: 0.95rem;
+	}
+	.dest-soon {
+		font-size: 0.62rem;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--dash-text-muted);
+		border: 1px solid $border-strong;
+		border-radius: 1rem;
+		padding: 0.05rem 0.45rem;
+	}
+	.dest-info {
+		position: relative;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--dash-text-secondary);
+		cursor: default;
+		flex-shrink: 0;
+		outline: none;
+	}
+	.dest-info:hover,
+	.dest-info:focus-visible {
+		color: var(--dash-text-primary);
+	}
+	.dest-info:hover :global(.tooltip),
+	.dest-info:focus-visible :global(.tooltip) {
+		opacity: 1;
+		visibility: visible;
+	}
+	.info-tooltip {
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+		align-items: flex-start;
+		white-space: normal;
+	}
+	.info-row {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		font-size: 0.7rem;
+		font-weight: 500;
+		white-space: nowrap;
+	}
+	.dest-blurb {
+		margin: 0.3rem 0 0;
+		font-size: 0.85rem;
+		color: var(--dash-text-secondary);
+		line-height: 1.4;
+	}
+
+	.locked-hint {
+		color: var(--dash-text-muted);
+		font-style: italic;
+		margin: 0;
+	}
+	.picker-empty {
+		color: var(--dash-text-muted);
+		font-style: italic;
+		margin: 0;
+		padding: 0.5rem 0;
+	}
+</style>

--- a/src/lib/sendswap/stages/withdraw/withdrawInit.test.ts
+++ b/src/lib/sendswap/stages/withdraw/withdrawInit.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { Coin, Network } from '../../utils/sendOptions';
+import {
+	initHiveMainnetWithdraw,
+	initBtcMainnetWithdraw,
+	initLightningWithdraw,
+	initWithdrawStateForDestination,
+	type WithdrawInitState
+} from './withdrawInit';
+
+function blank(): WithdrawInitState {
+	return { from: undefined, to: undefined };
+}
+
+describe('withdrawInit', () => {
+	it('Hive mainnet: from = {asset, magi}, to = {asset, hiveMainnet}', () => {
+		for (const coin of [Coin.hive, Coin.hbd]) {
+			const s = blank();
+			initHiveMainnetWithdraw(s, coin);
+			expect(s.from).toEqual({ coin, network: Network.magi });
+			expect(s.to).toEqual({ coin, network: Network.hiveMainnet });
+		}
+	});
+
+	it('Bitcoin mainnet: BTC from magi → BTC on btcMainnet', () => {
+		const s = blank();
+		initBtcMainnetWithdraw(s);
+		expect(s.from).toEqual({ coin: Coin.btc, network: Network.magi });
+		expect(s.to).toEqual({ coin: Coin.btc, network: Network.btcMainnet });
+	});
+
+	it('Lightning: BTC from magi → lightning network', () => {
+		const s = blank();
+		initLightningWithdraw(s);
+		expect(s.from).toEqual({ coin: Coin.btc, network: Network.magi });
+		expect(s.to?.network.value).toBe(Network.lightning.value);
+	});
+
+	it('dispatch routes by destination and uses the chosen asset', () => {
+		const s = blank();
+		initWithdrawStateForDestination(s, 'hive_mainnet', Coin.hbd);
+		expect(s.to).toEqual({ coin: Coin.hbd, network: Network.hiveMainnet });
+
+		const s2 = blank();
+		initWithdrawStateForDestination(s2, 'btc_mainnet', Coin.btc);
+		expect(s2.to?.network.value).toBe(Network.btcMainnet.value);
+	});
+
+	it('coinbase is a no-op (coming soon)', () => {
+		const s = blank();
+		initWithdrawStateForDestination(s, 'coinbase', Coin.btc);
+		expect(s.from).toBeUndefined();
+		expect(s.to).toBeUndefined();
+	});
+});

--- a/src/lib/sendswap/stages/withdraw/withdrawInit.ts
+++ b/src/lib/sendswap/stages/withdraw/withdrawInit.ts
@@ -1,0 +1,73 @@
+/**
+ * Per-destination txState initialization for the withdraw flow.
+ *
+ * EXTRACTED from the `$effect` blocks in WithdrawOptions.svelte (the
+ * hiveMainnetOpen / btcMainnetOpen / lightningTransferOpen effects) so the
+ * new WithdrawTimeline picker and the legacy WithdrawOptions menu initialize
+ * `WithdrawTxState` through the SAME code path → identical broadcast payload
+ * by construction (the txState → decideBroadcast → sendUtils pipeline is
+ * pinned by the existing withdraw flow tests).
+ *
+ * Withdraw is asset-first: the user picks the Magi asset in step 1, so the
+ * chosen coin is passed in here (unlike the legacy menu, which auto-detected
+ * HIVE-vs-HBD by balance). Source is always Magi; the destination only sets
+ * `to`'s network. The functions mutate the passed state object's `from`/`to`,
+ * matching the original effects mutating the context txState.
+ */
+import { getToOption, Coin, Network, type CoinOnNetwork } from '../../utils/sendOptions';
+
+/** The destinations the withdraw picker offers. */
+export type WithdrawDestination = 'hive_mainnet' | 'btc_mainnet' | 'lightning' | 'coinbase';
+
+/** Minimal slice of WithdrawTxState the init functions touch. */
+export type WithdrawInitState = {
+	from: CoinOnNetwork | undefined;
+	to: CoinOnNetwork | undefined;
+};
+
+/**
+ * Hive Mainnet withdraw — mirror of WithdrawOptions' `hiveMainnetOpen` effect,
+ * but with the asset chosen up-front (HIVE or HBD) instead of balance-detected.
+ * rail derives `magi → hiveMainnet`.
+ */
+export function initHiveMainnetWithdraw(txState: WithdrawInitState, assetCoin: Coin): void {
+	txState.from = { coin: assetCoin, network: Network.magi };
+	txState.to = { coin: assetCoin, network: Network.hiveMainnet };
+}
+
+/**
+ * Bitcoin Mainnet withdraw — mirror of WithdrawOptions' `btcMainnetOpen`
+ * effect. rail derives `magi → btcMainnet`.
+ */
+export function initBtcMainnetWithdraw(txState: WithdrawInitState): void {
+	txState.from = { coin: Coin.btc, network: Network.magi };
+	txState.to = { coin: Coin.btc, network: Network.btcMainnet };
+}
+
+/**
+ * Lightning / Keepsats withdraw — mirror of WithdrawOptions'
+ * `lightningTransferOpen` effect. The `to` coin comes from `getToOption` (BTC
+ * isn't necessarily in the from-list with a lightning network). rail derives
+ * to lightning from `to.network = lightning`.
+ */
+export function initLightningWithdraw(txState: WithdrawInitState): void {
+	const btcTo = getToOption(Coin.btc.value);
+	txState.from = { coin: Coin.btc, network: Network.magi };
+	txState.to = btcTo
+		? { coin: btcTo.coin, network: Network.lightning }
+		: { coin: Coin.btc, network: Network.lightning };
+}
+
+/**
+ * Dispatch helper for the picker: initialize txState for the chosen
+ * destination. Coinbase intentionally does nothing (coming soon).
+ */
+export function initWithdrawStateForDestination(
+	txState: WithdrawInitState,
+	destination: WithdrawDestination,
+	assetCoin: Coin
+): void {
+	if (destination === 'hive_mainnet') initHiveMainnetWithdraw(txState, assetCoin);
+	else if (destination === 'btc_mainnet') initBtcMainnetWithdraw(txState);
+	else if (destination === 'lightning') initLightningWithdraw(txState);
+}

--- a/src/routes/(authed)/withdraw/+page.svelte
+++ b/src/routes/(authed)/withdraw/+page.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import WithdrawPage from '$lib/sendswap/WithdrawPage.svelte';
+</script>
+
+<svelte:head>
+	<title>Withdraw</title>
+</svelte:head>
+
+<div class="withdraw-route">
+	<WithdrawPage />
+</div>
+
+<style lang="scss">
+	.withdraw-route {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		min-height: 0;
+	}
+</style>


### PR DESCRIPTION
## What
Adds a dedicated **`/withdraw` page** — an asset-first redesign of the withdraw
flow, mirroring the `/deposit` page (0.3.20). The dashboard "Withdraw" button now
navigates here instead of opening a modal.

## Flow
A 3-step timeline:
1. **I want to withdraw** — pick an asset you hold on Magi. Only held assets are
   shown, each with its live balance (you can't withdraw what you don't have).
2. **To** — pick a destination, filtered to what the asset supports: HIVE/HBD →
   Hive mainnet; BTC → Bitcoin mainnet, Lightning, Coinbase (soon).
3. **Send** — the real per-destination form (Hive recipient + amount, BTC address
   + fee options, Lightning/Keepsats).

A persistent **recent-withdrawals + FAQ sidebar** stays visible throughout; the
review + completion steps render as dialogs over the page.

## How
- Reuses the existing withdraw rails (`HiveMainnetWithdraw`,
  `BitcoinMainnetWithdraw`, `KeepsatsWithdraw`) and the existing broadcast
  pipeline **unchanged** — the redesign is the shell around the same money
  plumbing.
- Per-destination txState init is extracted into `withdrawInit.ts`, so the new
  picker and the legacy menu initialise state through one code path → identical
  broadcast payloads by construction.
- `HiveMainnetWithdraw` gained a `lockAsset` mode so step 3 can't override the
  step-1 asset choice (HIVE vs HBD). The BTC/Lightning rails are BTC-only and
  lock implicitly.
- The legacy `Withdraw.svelte` modal stays (still used by
  `StakeUnstakeTabsModal`); only the dashboard entry point moved to the page.

## Destination coverage
Hive mainnet, Bitcoin mainnet, Lightning (→ Keepsats/V4VApp), Coinbase (soon) —
matches the legacy `WithdrawOptions` menu exactly.

## Verification
- `svelte-check` at baseline (no new errors).
- Full suite: **344 passed / 2 skipped**, including 5 new `withdrawInit` tests
  pinning that each (asset, destination) yields the same `from`/`to` as the
  legacy menu.
- Manual smoke test: _<fill in — asset→destination→send for Hive + BTC, the
  review/complete dialogs, and the sidebar>_.

## Notes
- `LightningWithdraw.svelte` (an unused external-Lightning-address rail) is left
  untouched — pre-existing orphan code, flagged separately for a
  delete-vs-wire-up decision.