### PR TITLE
fix(transactions): failed swap shows no output amount or loading dots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to Altera are documented here.
 > CI / build-banner / release-script use, and so a glance at `package.json`
 > matches reality.
 
+## [0.3.26] — 2026-06-24
+
+### Fixes
+
+- **A failed swap showed an output amount it never delivered.** On the transactions page a confirmed-but-FAILED new-router swap produces no settlement event, so the row fell back to the `min_amount_out` floor and rendered it as a green "received" amount — and the settling indicator (the three loading dots) never resolved, since the indexer would never report a settled amount for a swap that failed. A failed swap delivers nothing, so the output now renders a dimmed "—" in both the table row and the detail popup (with a "Failed — nothing was received" note), and the futile settlement-polling is skipped for failed txs. `isAwaitingSettledAmount` gained an `isFailed` guard, pinned by a unit test
+
 ## [0.3.25] — 2026-06-22
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.3.25",
+	"version": "0.3.26",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {

--- a/src/routes/(authed)/transactions/Table/tds/Amount.svelte
+++ b/src/routes/(authed)/transactions/Table/tds/Amount.svelte
@@ -19,6 +19,8 @@
 		// Confirmed swap whose settled output isn't known yet — show a placeholder
 		// instead of the slippage floor (which would mis-state what was received).
 		pendingAmount?: boolean;
+		// Failed tx — nothing was received, so don't show an output amount at all.
+		failed?: boolean;
 	};
 	let {
 		amount,
@@ -26,7 +28,8 @@
 		fromAmount = null,
 		secondAmount = null,
 		lpInfo = null,
-		pendingAmount = false
+		pendingAmount = false,
+		failed = false
 	}: Props = $props();
 
 	function unitFor(coin: UnkCoinAmount['coin']): string {
@@ -43,7 +46,9 @@
 		<span class="amount outgoing">{fromAmount.toPrettyAmountString()}</span>
 		<span class="token outgoing">{unitFor(fromAmount.coin)}</span>
 		<span class="swap-arrow">→</span>
-		{#if pendingAmount}
+		{#if failed}
+			<span class="amount none" title="Swap failed — nothing received">—</span>
+		{:else if pendingAmount}
 			<span class="amount settling"><WaveLoading size={18} /></span>
 		{:else}
 			<span class="amount green">{amount.toPrettyAmountString()}</span>
@@ -90,6 +95,9 @@
 	}
 	.amount.green {
 		color: var(--dash-accent-green-light);
+	}
+	.amount.none {
+		color: var(--dash-text-muted);
 	}
 	.token {
 		color: var(--dash-text-secondary);

--- a/src/routes/(authed)/transactions/Table/tr/ContractTr.svelte
+++ b/src/routes/(authed)/transactions/Table/tr/ContractTr.svelte
@@ -79,7 +79,8 @@
 	// self-heals on the next open.
 	let startedFetchTxId = '';
 	$effect(() => {
-		if (!isSwap || !swapPayload?.isNewRouter || tx.isPending) return;
+		// A failed swap produces no settlement event — don't poll the indexer for it.
+		if (!isSwap || !swapPayload?.isNewRouter || tx.isPending || tx.status === 'FAILED') return;
 		const thisTxId = tx.id;
 		if (thisTxId === startedFetchTxId) return;
 		startedFetchTxId = thisTxId;
@@ -116,12 +117,14 @@
 
 	// True while a confirmed new-router swap's real output is still unknown — the
 	// window in which we must NOT show min_amount_out. Drives the loading copy.
+	const isFailedTx = $derived(tx.status === 'FAILED');
 	const awaitingSettledAmount = $derived(
 		isAwaitingSettledAmount({
 			isSwap,
 			isNewRouter: !!swapPayload?.isNewRouter,
 			isPending: tx.isPending,
-			hasIndexerAmount: !!indexerAmountOut
+			hasIndexerAmount: !!indexerAmountOut,
+			isFailed: isFailedTx
 		})
 	);
 
@@ -254,6 +257,7 @@
 		{fromAmount}
 		{direction}
 		pendingAmount={awaitingSettledAmount}
+		failed={isFailedTx}
 		secondAmount={opKind === 'add-liquidity' ? liqAmount1 : removeLiqAmount1}
 		lpInfo={lpAmount}
 	/>
@@ -271,7 +275,9 @@
 		<div class="amount">
 			{#if isSwap && fromAmount}
 				{fromAmount.toPrettyString()} →
-				{#if awaitingSettledAmount}
+				{#if isFailedTx}
+					<span class="none">—</span>
+				{:else if awaitingSettledAmount}
 					<span class="settling"><WaveLoading size={28} /></span>
 				{:else}
 					{amount.toPrettyString()}
@@ -289,7 +295,9 @@
 				{amount.toPrettyString()}
 			{/if}
 			<span class="approx-usd">
-				{#if awaitingSettledAmount}
+				{#if isFailedTx}
+					Failed — nothing was received.
+				{:else if awaitingSettledAmount}
 					Waiting for the network to report the settled amount…
 					{#if minReceived}
 						<span class="settle-floor">You'll receive at least {minReceived.toPrettyString()}.</span
@@ -342,6 +350,9 @@
 		display: inline-flex;
 		align-items: center;
 		vertical-align: middle;
+		color: var(--dash-text-muted);
+	}
+	.none {
 		color: var(--dash-text-muted);
 	}
 	.settle-floor {

--- a/src/routes/(authed)/transactions/Table/tr/swapDisplay.test.ts
+++ b/src/routes/(authed)/transactions/Table/tr/swapDisplay.test.ts
@@ -101,10 +101,20 @@ describe('swapEventHashCandidates — bare hash + op-index-suffixed key', () => 
 });
 
 describe('isAwaitingSettledAmount — when the floor must be hidden', () => {
-	const base = { isSwap: true, isNewRouter: true, isPending: false, hasIndexerAmount: false };
+	const base = {
+		isSwap: true,
+		isNewRouter: true,
+		isPending: false,
+		hasIndexerAmount: false,
+		isFailed: false
+	};
 
 	it('confirmed new-router swap with no indexer value yet → awaiting (hide floor)', () => {
 		expect(isAwaitingSettledAmount(base)).toBe(true);
+	});
+
+	it('failed swap → not awaiting (it will never settle; show the failed status, not dots)', () => {
+		expect(isAwaitingSettledAmount({ ...base, isFailed: true })).toBe(false);
 	});
 
 	it('once the settled amount arrives → not awaiting', () => {

--- a/src/routes/(authed)/transactions/Table/tr/swapDisplay.ts
+++ b/src/routes/(authed)/transactions/Table/tr/swapDisplay.ts
@@ -110,14 +110,19 @@ export function swapEventHashCandidates(txId: string, opIndex: number): string[]
 /**
  * True while a confirmed new-router swap's settled output is still unknown — the
  * window in which the UI must show a loading placeholder instead of the
- * min_amount_out floor. Old-pool swaps (settled amount in-payload) and pending
- * swaps are never "awaiting".
+ * min_amount_out floor. Old-pool swaps (settled amount in-payload), pending
+ * swaps, and FAILED swaps are never "awaiting" — a failed swap will never
+ * settle an amount, so it should show its failed status, not the loading dots.
  */
 export function isAwaitingSettledAmount(args: {
 	isSwap: boolean;
 	isNewRouter: boolean;
 	isPending: boolean;
 	hasIndexerAmount: boolean;
+	/** A failed swap never settles — it's done, not "awaiting". */
+	isFailed: boolean;
 }): boolean {
-	return args.isSwap && args.isNewRouter && !args.isPending && !args.hasIndexerAmount;
+	return (
+		args.isSwap && args.isNewRouter && !args.isPending && !args.hasIndexerAmount && !args.isFailed
+	);
 }


### PR DESCRIPTION
## What
On the transactions page, a confirmed-but-**FAILED** new-router swap was showing
a "received" output amount it never delivered — plus an endless loading spinner.

## Why
A failed swap produces no settlement event, so:
- the row fell back to the `min_amount_out` floor and rendered it as a green
  "received" amount (`100 HIVE → 50 HBD`), and
- the settling indicator (three dots) never resolved — the indexer never reports
  a settled amount for a swap that failed.

A failed swap delivers nothing, so both were misleading.

## Change
- A failed swap's output now renders a dimmed **"—"** in the table row and the
  detail popup ("Failed — nothing was received").
- `isAwaitingSettledAmount` gained an `isFailed` guard so the dots never show for
  a failed swap (+ a unit test for the failed case).
- The futile indexer settlement-polling is skipped for failed txs.

## Verification
- `swapDisplay` tests: **13 pass** (incl. the new failed case).
- `svelte-check` at baseline; prettier clean.
- `StatusBadge` untouched — an earlier label change was reverted, labels unchanged.