### PR TITLE
fix(transactions): consensus unstake shows as incoming, not outgoing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to Altera are documented here.
 > CI / build-banner / release-script use, and so a glance at `package.json`
 > matches reality.
 
+## [0.3.27] — 2026-06-24
+
+### Fixes
+
+- **A consensus unstake showed in the transactions table as money leaving your wallet.** A `consensus_unstake` op carries `from = you, to = node`, so the table derived its direction from those fields and rendered it as **outgoing (−)** — like a send — even though unstaking returns the HIVE *to* you. It now renders as **incoming (+)**. (Surfaced while walking the transactions-type map; the rest of the tx types were verified to render correctly.)
+
 ## [0.3.26] — 2026-06-24
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.3.26",
+	"version": "0.3.27",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {

--- a/src/routes/(authed)/transactions/Table/tr/Tr.svelte
+++ b/src/routes/(authed)/transactions/Table/tr/Tr.svelte
@@ -208,6 +208,11 @@
 			}
 			return 'incoming';
 		}
+		// A consensus unstake has from=you, to=node — but the HIVE comes back to
+		// YOU, so it's incoming (+), not outgoing (−) like a send.
+		if (t.includes('unstake')) {
+			return 'incoming';
+		}
 		if (to == did) {
 			return 'incoming';
 		}


### PR DESCRIPTION
## What
A consensus **unstake** showed in the transactions table as money *leaving* your
wallet (`−`, outgoing) when it actually returns HIVE *to* you.

## Why
`consensus_unstake` carries `from = you, to = node` (same shape as a stake), so
`Tr.svelte` derived the row direction from those fields → `to != you` → outgoing.
But unstaking moves the HIVE back to your balance — it's incoming.

## Change
One guard in `Tr.svelte`'s `direction` derived: any `unstake` with `to ≠ from` is
`incoming` (+). Consensus *stake* (outgoing −) and self-tx HBD stake/unstake
(unchanged) are unaffected.

## Context
Found while walking the "[TRANSACTIONS page] map of all the possible transactions"
ticket. The rest of the tx types (BTC transfer/unmap/deposit, swaps, liquidity,
transfer/deposit/withdraw, the stake family) were verified to render correctly —
this was the one real bug.

## Verification
- `svelte-check` at baseline; prettier clean.