### PR TITLE
fix(notifications): sender, cross-account clear, and popup polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to Altera are documented here.
 > CI / build-banner / release-script use, and so a glance at `package.json`
 > matches reality.
 
+## [0.3.28] — 2026-06-24
+
+### Fixes
+
+- **Notifications named the wrong account on incoming txs, and leaked across accounts.** (1) A received-transaction notification read `op.data.to` (the recipient — you) instead of `op.data.from`, so it showed "from @yourself" instead of the real sender. (2) Notifications and pending transactions live under single global localStorage keys and were never cleared on logout, so signing in with a *different* account inherited the previous user's data. Both are now wiped on logout via `clearNotifications()` / `clearLocalTransactions()` in `cleanUpLogout()`. Contacts are intentionally left device-level (not cleared, not DID-scoped) so they follow you across your own wallets (Hive ↔ EVM) rather than fragmenting — the chosen model is single-session login/logout with no cross-wallet account switcher, matching standard DeFi-dapp practice (react to the connected wallet, clear account-activity data on disconnect)
+- **Notifications popup polish.** Roomier padding, smaller text, the close (✕) is centered with the title instead of jammed in the corner, and each row was restructured — inline unread dot, the message on one line, a muted timestamp beneath it, delete on the right — replacing the cramped absolute-positioned layout
+
 ## [0.3.27] — 2026-06-24
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.3.27",
+	"version": "0.3.28",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {

--- a/src/lib/Topbar/Notifications.svelte
+++ b/src/lib/Topbar/Notifications.svelte
@@ -75,17 +75,17 @@
 {#snippet notificationSnippet(ntf: Notification, id: string)}
 	{@const fromYou = 'to' in ntf}
 	<div class="notif">
-		{formatOpType(ntf.type)}
-		{fromYou ? 'to' : 'from'}
-		{`@${getAccountNameFromDid(fromYou ? ntf.to : ntf.from)}`}
-		{`${ntf.status.toLowerCase()}.`}
-		<span class="at">
-			{moment(ntf.timestamp).format('MMM DD H:mm')}
-		</span>
-		{#if !ntf.read}
-			<span class="unread"></span>
-		{/if}
-		<span class="delete">
+		<span class="notif-dot" class:filled={!ntf.read}></span>
+		<div class="notif-body">
+			<span class="notif-text">
+				{formatOpType(ntf.type)}
+				{fromYou ? 'to' : 'from'}
+				<strong>@{getAccountNameFromDid(fromYou ? ntf.to : ntf.from)}</strong>
+				· {ntf.status.toLowerCase()}
+			</span>
+			<span class="notif-time">{moment(ntf.timestamp).format('MMM DD · H:mm')}</span>
+		</div>
+		<span class="notif-delete">
 			<PillButton
 				onclick={() => {
 					removeNotification(id);
@@ -93,7 +93,7 @@
 				}}
 				styleType="icon-subtle"
 			>
-				<Trash2 />
+				<Trash2 size={14} />
 			</PillButton>
 		</span>
 	</div>
@@ -142,36 +142,55 @@
 
 <style lang="scss">
 	.notif {
-		position: relative;
-		padding-top: 1.5rem;
 		display: flex;
-		align-items: center;
-		.at {
-			position: absolute;
-			top: 0;
-			right: 0;
-			font-size: var(--text-sm);
+		align-items: flex-start;
+		gap: 0.55rem;
+		padding: 0.1rem 0.15rem;
+		.notif-dot {
+			flex-shrink: 0;
+			width: 0.4rem;
+			height: 0.4rem;
+			border-radius: 50%;
+			margin-top: 0.4rem;
+			background: transparent;
+			&.filled {
+				background: var(--dash-accent-red);
+			}
+		}
+		.notif-body {
+			flex: 1;
+			min-width: 0;
+			display: flex;
+			flex-direction: column;
+			gap: 0.1rem;
+		}
+		.notif-text {
+			font-size: 0.82rem;
+			line-height: 1.35;
+			color: var(--dash-text-primary);
+			:global(strong) {
+				font-weight: 600;
+			}
+		}
+		.notif-time {
+			font-size: 0.7rem;
 			color: var(--dash-text-muted);
 		}
-		.delete {
-			margin-left: auto;
-			padding-left: 0.5rem;
+		.notif-delete {
+			flex-shrink: 0;
 			:global(svg) {
 				color: var(--dash-accent-red);
 			}
 		}
-		.unread {
-			position: absolute;
-			top: 0;
-			left: 0;
-		}
 	}
 	tr {
-		height: 2.5rem;
 		border-bottom: 1px solid var(--dash-divider);
 	}
+	tr:last-child {
+		border-bottom: none;
+	}
 	td {
-		padding: 0.25rem 0;
+		padding: 0.55rem 0;
 	}
 	.more-button {
 		padding-top: 0.5rem;

--- a/src/lib/Topbar/notifications.ts
+++ b/src/lib/Topbar/notifications.ts
@@ -55,3 +55,16 @@ export function removeNotification(id: string) {
 	get(notifications).delete(id);
 	setLocalNotifications(get(notifications));
 }
+
+/**
+ * Wipe all notifications (store + localStorage). Called on logout so a
+ * different account signing in afterwards doesn't inherit the previous
+ * user's notifications. Notifications are global (not DID-scoped), so the
+ * single `notifications` key must be cleared with the rest of the account
+ * state — see cleanUpLogout.
+ */
+export function clearNotifications() {
+	notifications.set(new Map());
+	localStorage.removeItem('notifications');
+	notificationUpdateIndicator.set('');
+}

--- a/src/lib/auth/store.ts
+++ b/src/lib/auth/store.ts
@@ -3,6 +3,8 @@ import type { Aioha } from '@aioha/aioha';
 import { getContext } from 'svelte';
 import { derived, writable } from 'svelte/store';
 import { clearAllStores } from '$lib/stores/txStores';
+import { clearLocalTransactions } from '$lib/stores/localStorageTxs';
+import { clearNotifications } from '$lib/Topbar/notifications';
 import { accountBalance, getDefaultBalance } from '$lib/stores/currentBalance';
 import { accountBalanceHistory } from '$lib/stores/balanceHistory';
 
@@ -22,6 +24,8 @@ export type Auth = {
 
 export function cleanUpLogout() {
 	clearAllStores();
+	clearNotifications();
+	clearLocalTransactions();
 	accountBalance.set({
 		loading: true,
 		bal: getDefaultBalance(),

--- a/src/lib/stores/localStorageTxs.ts
+++ b/src/lib/stores/localStorageTxs.ts
@@ -77,3 +77,14 @@ export function removeLocalTransaction(id: string) {
 	const newTxList = txList.filter((element, _) => element.id !== id);
 	localStorage.setItem('transactions', JSON.stringify(newTxList));
 }
+
+/**
+ * Wipe persisted pending transactions on logout, so a different account
+ * signing in afterwards doesn't inherit the previous user's pending txs.
+ * The in-memory store is reset separately by clearAllStores(); this clears
+ * the global `transactions` key (account-activity data, same ownership class
+ * as notifications — see cleanUpLogout).
+ */
+export function clearLocalTransactions() {
+	localStorage.removeItem('transactions');
+}

--- a/src/lib/zag/Popover.svelte
+++ b/src/lib/zag/Popover.svelte
@@ -70,16 +70,16 @@
 	.top-flex {
 		display: flex;
 		gap: 1rem;
-		align-items: baseline;
-		padding-bottom: 0.5rem;
-		margin-bottom: 0.5rem;
+		align-items: center;
+		padding-bottom: 0.6rem;
+		margin-bottom: 0.6rem;
 		width: 100%;
 		justify-content: space-between;
 		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 	}
 	.top-flex :global([data-part='close-trigger']) {
 		margin-bottom: 0;
-		transform: translate(0.5rem, 0);
+		flex-shrink: 0;
 	}
 	[data-part='content'][data-variant='full'] {
 		max-width: calc(100vw - 2rem);
@@ -87,8 +87,7 @@
 		background: linear-gradient(135deg, rgba(255,255,255,0.1) 0%, rgba(255,255,255,0.05) 100%);
 		backdrop-filter: blur(10px);
 		border: 1px solid var(--dash-card-border);
-		padding: 0.5rem;
-		padding-top: 0;
+		padding: 0.85rem 1rem 1rem;
 		z-index: 2;
 		border-radius: 16px;
 		box-shadow: var(--dash-card-shadow);

--- a/src/routes/(authed)/transactions/Table/tr/Tr.svelte
+++ b/src/routes/(authed)/transactions/Table/tr/Tr.svelte
@@ -115,7 +115,7 @@
 									status: tx.status
 								}
 							: {
-									from: op.data.to,
+									from: op.data.from,
 									type: op.type ?? tx.type,
 									timestamp: getTimestamp(tx),
 									read: false,


### PR DESCRIPTION
## What
The full "Fix notifications" ticket — three items:
1. **"to"/"from" directions wrong** — incoming notifications named the wrong account.
2. **Cross-account leak** — after logout, a *different* account inherited the previous user's notifications.
3. **Layout** — the popup needed polish.

## Fixes
- **#1 (sender):** the notification builder read `op.data.to` (the recipient — you) for the `from` field on an incoming tx, so it showed "from @yourself". Now uses `op.data.from`.
- **#2 (leak):** notifications and pending transactions live under single global localStorage keys and were never cleared on logout. Added `clearNotifications()` / `clearLocalTransactions()`, called from `cleanUpLogout()`.
- **#3 (layout):** roomier popup padding, smaller text, the close ✕ is centered with the title (was jammed in the corner), and each row was restructured — inline unread dot, message on one line, muted timestamp beneath, delete on the right — replacing the cramped absolute-positioned layout. The `title` ("full") Popover variant is only used by notifications, so this is scoped.

## Design note (the architecture call)
We clear **account-activity data** (notifications, pending txs) on logout but **leave contacts device-level** (untouched). Contacts belong to the *person*, not a wallet — clearing or DID-scoping them would wipe your address book when switching between your own Hive ↔ EVM logins. The chosen model is **single-session login/logout with no cross-wallet account switcher**, matching standard DeFi-dapp practice (react to the connected wallet; clear account data on disconnect). A custom multi-wallet switcher was researched and rejected (unnecessary complexity + a security surface). True cross-device per-identity contact sync is a future "wallet-linking" feature, not a switcher.

## Not changed
- Contacts (intentionally — see above).
- Other popovers — the simple Popover variant (InfoTooltip) is untouched.

## Verification
- `svelte-check` at baseline (no new errors).
- Full suite: 345 passed / 2 skipped, 0 failures.
- Notification rows eyeballed across to/from, read/unread, and a FAILED status.