### PR TITLE
fix(deposit): changing the receive asset now propagates to the Send step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to Altera are documented here.
 > CI / build-banner / release-script use, and so a glance at `package.json`
 > matches reality.
 
+## [0.3.29] — 2026-06-25
+
+### Fixes
+
+- **Deposit page: changing the receive asset after picking a source kept the old asset until refresh.** In the asset-first deposit flow, switching "I want to receive" between two assets the chosen source supports (HIVE↔HBD on Hive Mainnet) left the Send step and amount on the previous asset. Root cause: `initHiveMainnetDeposit` prioritizes a previously-derived `from` coin over the newly-chosen asset (`to`) — and even reverts `to` back to it. Fixed in the asset-first picker (`DepositTimeline.pickAsset`) by clearing the stale `from` before re-init so the chosen asset re-derives both sides. Other paths were unaffected: Lightning already derives `to` from the asset first, and the BTC-only sources (Bitcoin Mainnet, Coinbase) don't read `from`. The withdraw flow was audited and is immune — its init takes the asset coin as an explicit parameter and overwrites both sides unconditionally. Added regression tests pinning the Hive-Mainnet conflict and the Lightning contrast
+
 ## [0.3.28] — 2026-06-24
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.3.28",
+	"version": "0.3.29",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {

--- a/src/lib/sendswap/stages/deposit/DepositTimeline.svelte
+++ b/src/lib/sendswap/stages/deposit/DepositTimeline.svelte
@@ -193,6 +193,13 @@
 		untrack(() => {
 			const coin = Object.values(Coin).find((c) => c.value === value);
 			if (coin) txState.to = { coin, network: Network.magi };
+			// In this asset-first flow the chosen asset (txState.to) is the source
+			// of truth. Drop any previously-derived `from` so the source init
+			// re-derives it from the NEW asset. Otherwise switching between two
+			// assets a source supports (HIVE↔HBD on Hive Mainnet) makes
+			// initHiveMainnetDeposit preserve the stale `from` — and even revert
+			// `to` back to it — so the Send step keeps the old asset until refresh.
+			txState.from = undefined;
 		});
 		// Invalidate an incompatible previously-picked source.
 		if (

--- a/src/lib/sendswap/stages/deposit/depositInit.test.ts
+++ b/src/lib/sendswap/stages/deposit/depositInit.test.ts
@@ -87,6 +87,23 @@ describe('initLightningDeposit (legacy lightningOpen effect parity)', () => {
 		initLightningDeposit(s);
 		expect(s.to?.coin.value).toBe(Coin.sats.value);
 	});
+
+	it('asset switch: a stale `from` does NOT override a newly-chosen `to` (lightning is to-first)', () => {
+		// Contrast with the hiveMainnet CONFLICT case: lightning derives `to`
+		// from txState.to FIRST, so an asset switch always follows the new asset
+		// even with a stale `from` present. This is why the asset-switch bug was
+		// Hive-Mainnet-specific — lightning (the only other multi-asset source)
+		// was never affected, and pickAsset's `from` clear is a no-op for it
+		// (the rail re-defaults to BTC/Lightning either way).
+		const s = state(
+			{ coin: Coin.btc, network: Network.lightning },
+			{ coin: Coin.hbd, network: Network.magi }
+		);
+		initLightningDeposit(s);
+		expect(s.to?.coin.value).toBe(Coin.hbd.value);
+		expect(s.from?.coin.value).toBe(Coin.btc.value);
+		expect(s.from?.network.value).toBe(Network.lightning.value);
+	});
 });
 
 // ─── Hive Mainnet ─────────────────────────────────────────────────────────────
@@ -124,6 +141,23 @@ describe('initHiveMainnetDeposit (legacy hiveMainnetOpen effect parity)', () => 
 		initHiveMainnetDeposit(s);
 		expect(s.from?.coin.value).toBe(Coin.hbd.value);
 		expect(s.to?.coin.value).toBe(Coin.hbd.value);
+	});
+
+	it('CONFLICT: a stale hiveMainnet `from` wins over a newly-chosen `to` — why pickAsset clears `from`', () => {
+		// Reproduces the asset-switch bug: the user picks HIVE (from=HIVE),
+		// then switches the asset to HBD (to=HBD) while Hive Mainnet stays
+		// selected. Because HIVE is hiveMainnet-capable, init PRESERVES the
+		// stale from AND reverts `to` back to it — so the Send step keeps HIVE.
+		// This is exactly why DepositTimeline.pickAsset clears `from` before
+		// re-init in the asset-first flow; the post-clear expectation is the
+		// `existing to=HBD → both sides become HBD` test above.
+		const s = state(
+			{ coin: Coin.hive, network: Network.hiveMainnet },
+			{ coin: Coin.hbd, network: Network.magi }
+		);
+		initHiveMainnetDeposit(s);
+		expect(s.from?.coin.value).toBe(Coin.hive.value);
+		expect(s.to?.coin.value).toBe(Coin.hive.value);
 	});
 
 	it('non-hiveMainnet from (BTC) with no to → falls to the HIVE default', () => {


### PR DESCRIPTION
## What
Bug reported by Jux: on the Deposit page, picking an asset, scrolling to the bottom,
then changing "I want to receive" at the top kept the old asset everywhere — you had
to refresh.

## Root cause
Only triggered when both assets are served by the *same* source (HIVE↔HBD on Hive
Mainnet), so the source isn't invalidated and `initHiveMainnetDeposit` re-runs. That
init prioritizes the already-set `from` coin over the newly-chosen asset (`to`), and
even reverts `to` back to the stale coin — so the Send step stays on the old asset.
(Switching to BTC/ETH never showed it: that invalidates the source and forces a re-pick.)

## Fix
The shared init is pinned to the legacy flow by tests, so the fix is in the asset-first
picker: `DepositTimeline.pickAsset` now clears the stale `from` before re-init, letting
the chosen asset re-derive both sides.

## Scope checked (other coins + the sibling flow)
- **Lightning** (HIVE/HBD/BTC): derives `to` from the asset first — never affected; the clear is a no-op.
- **Bitcoin Mainnet / Coinbase**: don't read `txState.from` — unaffected.
- **Withdraw flow**: audited and immune — its init takes the asset coin as an explicit param and overwrites both sides unconditionally.

## Tests
- Added a regression test for the Hive-Mainnet conflict (the bug) and a Lightning contrast test (the asymmetry).
- All deposit + withdraw suites green (59 + 47).