### PR TITLE
feat(governance): witness governance voting — vote ops, witness gate, polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to Altera are documented here.
 > CI / build-banner / release-script use, and so a glance at `package.json`
 > matches reality.
 
+## [0.3.30] — 2026-06-29
+
+### Added
+
+- **Witness governance voting — production-ready.** The Witness Assistant's governance panel now lets elected witnesses vote on both kinds of on-chain proposals from the UI instead of hand-crafting custom_json: **reserve payouts** (`vsc.reserve_vote`, keyed by `proposalId`) and **slash restorations** (`vsc.slash_restore`, keyed by the slash tx id + slashed account — the same op proposes and votes). Voting is **gated to the elected witness committee** — the panel queries the current election and only enables the vote action for members, failing closed with a clear notice for non-witnesses, EVM logins, and Active-key-less sessions. Account matching is normalized (lowercase + `hive:`-strip) to mirror the node so the gate can't silently misfire; unknown proposal types are refused rather than mis-routed to the wrong op; and the proposal poll pauses while the tab is hidden. The Witness Assistant sections were reordered to lead with Stake/Unstake (the primary action), then contract updates, then governance. NOTE: safety slashing isn't active on any network yet, so this panel is dormant (no proposals) until it is.
+
 ## [0.3.29] — 2026-06-25
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.3.29",
+	"version": "0.3.30",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {

--- a/src/lib/magiTransactions/hive/index.ts
+++ b/src/lib/magiTransactions/hive/index.ts
@@ -12,7 +12,7 @@ import { getHbdStakeOp, getHbdUnstakeOp } from './vscOperations/stake';
 import { getBitcoinTransferOp } from './vscOperations/bitcoin';
 import { getAddLiquidityOp, getRemoveLiquidityOp } from './vscOperations/liquidity';
 import { getBtcApproveOp } from './vscOperations/swap';
-import { getReserveVoteOp } from './vscOperations/governance';
+import { getReserveVoteOp, getSlashRestoreVoteOp } from './vscOperations/governance';
 import type { PoolRow } from '$lib/pools/poolsData';
 
 export const consensusTx = async (
@@ -181,6 +181,22 @@ export const reserveVoteTx = async (
 			errorCode: 0
 		};
 	const op = getReserveVoteOp(voter, proposalId);
+	return executeTx(aioha, [op]);
+};
+
+export const slashRestoreVoteTx = async (
+	voter: string,
+	slashTxId: string,
+	slashedAccount: string,
+	aioha: Aioha
+): Promise<OperationResult> => {
+	if (!slashTxId || !slashedAccount)
+		return {
+			success: false,
+			error: 'Error: missing slash tx id or account.',
+			errorCode: 0
+		};
+	const op = getSlashRestoreVoteOp(voter, slashTxId, slashedAccount);
 	return executeTx(aioha, [op]);
 };
 

--- a/src/lib/magiTransactions/hive/vscOperations/governance.test.ts
+++ b/src/lib/magiTransactions/hive/vscOperations/governance.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getReserveVoteOp } from './governance';
+import { getReserveVoteOp, getSlashRestoreVoteOp } from './governance';
 
 describe('getReserveVoteOp', () => {
 	it('builds the vsc.reserve_vote custom_json with the exact wire shape', () => {
@@ -25,5 +25,42 @@ describe('getReserveVoteOp', () => {
 		const [, payload] = getReserveVoteOp('alice', 'reserve_payout:deadbeef');
 		expect(payload.required_auths).toEqual(['alice']);
 		expect(payload.required_posting_auths).toEqual([]);
+	});
+});
+
+describe('getSlashRestoreVoteOp', () => {
+	it('builds the vsc.slash_restore custom_json keyed by slash tx id + account', () => {
+		// NOTE: keyed by the slash tx id + slashed account, NOT proposalId — and
+		// signed by the voter alone (Active auth), distinct from vsc.reserve_vote.
+		expect(getSlashRestoreVoteOp('witness2', 'abc123txid', 'slashed.acct')).toEqual([
+			'custom_json',
+			{
+				required_auths: ['witness2'],
+				required_posting_auths: [],
+				id: 'vsc.slash_restore',
+				json: JSON.stringify({ id: 'abc123txid', account: 'slashed.acct' })
+			}
+		]);
+	});
+
+	it('is a distinct op from reserve_vote (different id + payload shape)', () => {
+		expect(getSlashRestoreVoteOp('alice', 'tx1', 'bob')).toEqual([
+			'custom_json',
+			{
+				required_auths: ['alice'],
+				required_posting_auths: [],
+				id: 'vsc.slash_restore',
+				json: JSON.stringify({ id: 'tx1', account: 'bob' })
+			}
+		]);
+		expect(getReserveVoteOp('alice', 'reserve_payout:tx1')).toEqual([
+			'custom_json',
+			{
+				required_auths: ['alice'],
+				required_posting_auths: [],
+				id: 'vsc.reserve_vote',
+				json: JSON.stringify({ id: 'reserve_payout:tx1' })
+			}
+		]);
 	});
 });

--- a/src/lib/magiTransactions/hive/vscOperations/governance.ts
+++ b/src/lib/magiTransactions/hive/vscOperations/governance.ts
@@ -2,7 +2,8 @@ import type { CustomJsonOperation } from '@hiveio/dhive';
 
 /**
  * Build a `vsc.reserve_vote` custom_json op — a witness's approval vote on an
- * open governance proposal (a reserve payout or a slash restoration).
+ * open RESERVE-PAYOUT proposal. (Slash restorations use a different op — see
+ * `getSlashRestoreVoteOp`.)
  *
  * The payload's `id` is the proposal's deterministic `proposalId` (e.g.
  * `reserve_payout:<sha256hex>`), which is the unit witnesses reference when
@@ -20,6 +21,38 @@ export function getReserveVoteOp(voter: string, proposalId: string): CustomJsonO
 			required_posting_auths: [],
 			id: 'vsc.reserve_vote',
 			json: JSON.stringify({ id: proposalId })
+		}
+	];
+}
+
+/**
+ * Build a `vsc.slash_restore` custom_json op — a witness's vote to restore a
+ * wrongfully-slashed bond while the slash is still pending.
+ *
+ * Unlike reserve spends (`vsc.reserve_vote`, keyed by proposalId), restorations
+ * use THIS op for BOTH proposing and voting, keyed by the slash's Hive tx id +
+ * the slashed account — the first such op creates the proposal and records the
+ * proposer's vote. Mirrors the node's `vsc.slash_restore` handler payload
+ * (`{ id: <slash tx id>, account: <slashed account> }`, see go-vsc-node
+ * modules/state-processing/governance_slash_restore.go). Signed with the
+ * voter's Active authority.
+ *
+ * @param voter the voting witness's Hive account (the signed-in user)
+ * @param slashTxId the Hive tx id of the safety slash (GovernanceProposal.slashTxId)
+ * @param slashedAccount the slashed account to restore (GovernanceProposal.slashedAccount)
+ */
+export function getSlashRestoreVoteOp(
+	voter: string,
+	slashTxId: string,
+	slashedAccount: string
+): CustomJsonOperation {
+	return [
+		'custom_json',
+		{
+			required_auths: [voter],
+			required_posting_auths: [],
+			id: 'vsc.slash_restore',
+			json: JSON.stringify({ id: slashTxId, account: slashedAccount })
 		}
 	];
 }

--- a/src/routes/(authed)/witness-assistant/+page.svelte
+++ b/src/routes/(authed)/witness-assistant/+page.svelte
@@ -6,6 +6,9 @@
 	import ContractUpdatesSection from '$lib/witness/contractUpdates/ContractUpdatesSection.svelte';
 	import GovernanceProposals from './GovernanceProposals.svelte';
 	let auth = $derived(getAuth()());
+	// True for Hive logins (and the not-yet-signed-in state); false only for EVM
+	// wallets, which can't stake consensus or sign governance votes.
+	let canStake = $derived(auth.value == undefined || auth.value.username != undefined);
 </script>
 
 <document:head>
@@ -15,21 +18,25 @@
 <h1>Witness Assistant</h1>
 
 <div>
-	<!-- Contract updates — visible regardless of auth provider, since
-	     auditing pending changes doesn't require a Hive account. -->
-	<ContractUpdatesSection />
-
-	{#if auth.value == undefined || auth.value.username != undefined}
+	<!-- 1. Stake / Unstake — the primary witness action (and the prerequisite to
+	     voting), so it leads. EVM wallets can't stake → show the redirect notice. -->
+	{#if canStake}
 		<StakeUnstakeTabsModal />
-
-		<!-- Governance proposals — open reserve/slash votes. Visible to all,
-	     but the vote action requires a Hive account (it signs a custom_json). -->
-		<GovernanceProposals />
 	{:else}
 		<p class="error">
 			Consensus staking with an EVM wallet is unsupported. Please <a href="/logout">logout</a> and login
 			with a hive account instead.
 		</p>
+	{/if}
+
+	<!-- 2. Contract updates — auditing pending changes; visible regardless of auth
+	     provider, so it sits outside the Hive gate. -->
+	<ContractUpdatesSection />
+
+	<!-- 3. Governance proposals — open reserve/slash votes (Hive witnesses only).
+	     Last because it's dormant until safety slashing activates (usually empty). -->
+	{#if canStake}
+		<GovernanceProposals />
 	{/if}
 </div>
 

--- a/src/routes/(authed)/witness-assistant/CurrentElection.gql
+++ b/src/routes/(authed)/witness-assistant/CurrentElection.gql
@@ -1,0 +1,8 @@
+query CurrentElection {
+	electionByBlockHeight {
+		epoch
+		members {
+			account
+		}
+	}
+}

--- a/src/routes/(authed)/witness-assistant/GovernanceProposals.svelte
+++ b/src/routes/(authed)/witness-assistant/GovernanceProposals.svelte
@@ -7,7 +7,11 @@
 	Hive op). Only Hive accounts can vote; EVM logins see a notice.
 -->
 <script lang="ts">
-	import { FindGovernanceProposalsStore, type FindGovernanceProposals$result } from '$houdini';
+	import {
+		FindGovernanceProposalsStore,
+		CurrentElectionStore,
+		type FindGovernanceProposals$result
+	} from '$houdini';
 	import { getAuth } from '$lib/auth/store';
 	import Card from '$lib/cards/Card.svelte';
 	import PillButton from '$lib/PillButton.svelte';
@@ -22,9 +26,30 @@
 
 	let auth = $derived(getAuth()());
 	let username = $derived(auth.value?.username);
-	// A reserve_vote is a Hive Active-key custom_json — only a Hive account
-	// (with an Aioha provider) can sign it. EVM wallets cannot.
-	let canVote = $derived(!!username && !!auth.value?.aioha);
+
+	// Elected witness set for the current consensus election. Only its members
+	// may cast a governance vote — the on-chain reserve_vote op rejects everyone
+	// else, so we gate the UI to match (and explain why). `null` = not yet
+	// loaded; we fail CLOSED (no vote until membership is confirmed).
+	let witnessAccounts = $state<Set<string> | null>(null);
+	let witnessLoadError = $state(false);
+	async function fetchWitnesses() {
+		try {
+			const res = await new CurrentElectionStore().fetch({ policy: 'NetworkOnly' });
+			if (res.errors?.length) throw new Error(res.errors[0].message);
+			const members = res.data?.electionByBlockHeight?.members ?? [];
+			witnessAccounts = new Set(members.map((m) => m.account));
+			witnessLoadError = false;
+		} catch (e) {
+			witnessLoadError = true;
+			console.error('Failed to load current election members', e);
+		}
+	}
+
+	let isWitness = $derived(!!username && witnessAccounts?.has(username) === true);
+	// A reserve_vote is a Hive Active-key custom_json — needs a Hive account
+	// (Aioha provider, not EVM) AND membership in the elected witness set.
+	let canVote = $derived(!!username && !!auth.value?.aioha && isWitness);
 
 	let load = $state<'loading' | 'loaded' | 'error'>('loading');
 	let loadError = $state('');
@@ -42,7 +67,6 @@
 				policy: 'NetworkOnly'
 			})
 			.then((res) => {
-				console.log('received response', res);
 				if (res.errors?.length) throw new Error(res.errors[0].message);
 				proposals = [...(res.data?.findGovernanceProposals ?? [])];
 				load = 'loaded';
@@ -53,9 +77,36 @@
 			});
 	}
 
+	// One poll tick: refresh proposals, and keep retrying the election fetch
+	// until the committee loads (so a transient failure self-heals).
+	function tick() {
+		fetchProposals();
+		if (witnessAccounts === null) fetchWitnesses();
+	}
+
 	$effect(() => {
-		const intervalId = setInterval(fetchProposals, 2000);
-		return () => clearInterval(intervalId);
+		tick();
+		let intervalId: ReturnType<typeof setInterval> | undefined;
+		const start = () => (intervalId ??= setInterval(tick, 2000));
+		const stop = () => {
+			clearInterval(intervalId);
+			intervalId = undefined;
+		};
+		// Pause polling while the tab is hidden; resume (with an immediate
+		// refresh) when it returns, so we don't churn the API in the background.
+		const onVisibility = () => {
+			if (document.hidden) stop();
+			else {
+				tick();
+				start();
+			}
+		};
+		start();
+		document.addEventListener('visibilitychange', onVisibility);
+		return () => {
+			stop();
+			document.removeEventListener('visibilitychange', onVisibility);
+		};
 	});
 
 	function hasVoted(p: Proposal): boolean {
@@ -106,11 +157,21 @@
 
 	{#if !canVote}
 		<p class="notice">
-			{#if username}
-				Connecting…
-			{:else}
+			{#if !username}
 				Governance voting requires a Hive witness account. Please <a href="/logout">logout</a> and sign
 				in with a Hive account to vote.
+			{:else if !auth.value?.aioha}
+				Governance voting needs your Hive Active key — connect with a Hive wallet (Keychain,
+				PeakVault, …) to vote.
+			{:else if witnessLoadError}
+				Couldn't verify your witness status — retrying. Voting stays disabled until the current
+				election loads.
+			{:else if witnessAccounts === null}
+				Verifying witness status…
+			{:else}
+				Only elected witnesses can vote on governance proposals. Your account (<code
+					>@{username}</code
+				>) isn't in the current consensus committee.
 			{/if}
 		</p>
 	{/if}

--- a/src/routes/(authed)/witness-assistant/GovernanceProposals.svelte
+++ b/src/routes/(authed)/witness-assistant/GovernanceProposals.svelte
@@ -2,9 +2,11 @@
 	Governance Proposals panel — lists the currently OPEN witness-vote
 	governance proposals (reserve payouts + slash restorations) from the
 	`FindGovernanceProposals` Houdini query and lets a signed-in witness
-	approve each one with a single Active-key `vsc.reserve_vote` custom_json
-	(built in $lib/magiTransactions/hive — same signing path as every other
-	Hive op). Only Hive accounts can vote; EVM logins see a notice.
+	approve each one with a single Active-key custom_json — `vsc.reserve_vote`
+	for reserve payouts, `vsc.slash_restore` for restorations (built in
+	$lib/magiTransactions/hive, same signing path as every other Hive op). Only
+	elected witnesses can vote (gated against the current election); other Hive
+	accounts and EVM logins see a notice.
 -->
 <script lang="ts">
 	import {
@@ -27,6 +29,17 @@
 	let auth = $derived(getAuth()());
 	let username = $derived(auth.value?.username);
 
+	// Match accounts the way the node does (governance.NormalizeAccount): lowercase
+	// + strip any `hive:` prefix. Used for BOTH the witness gate and the "voted"
+	// check so neither silently fails if the API or wallet returns a different
+	// casing/prefix than the bare account name.
+	const normalizeAccount = (a: string) =>
+		a
+			.trim()
+			.toLowerCase()
+			.replace(/^hive:/, '');
+	const isKnownType = (t: string) => t === 'reserve_payout' || t === 'slash_restore';
+
 	// Elected witness set for the current consensus election. Only its members
 	// may cast a governance vote — the on-chain reserve_vote op rejects everyone
 	// else, so we gate the UI to match (and explain why). `null` = not yet
@@ -38,7 +51,7 @@
 			const res = await new CurrentElectionStore().fetch({ policy: 'NetworkOnly' });
 			if (res.errors?.length) throw new Error(res.errors[0].message);
 			const members = res.data?.electionByBlockHeight?.members ?? [];
-			witnessAccounts = new Set(members.map((m) => m.account));
+			witnessAccounts = new Set(members.map((m) => normalizeAccount(m.account)));
 			witnessLoadError = false;
 		} catch (e) {
 			witnessLoadError = true;
@@ -46,7 +59,7 @@
 		}
 	}
 
-	let isWitness = $derived(!!username && witnessAccounts?.has(username) === true);
+	let isWitness = $derived(!!username && witnessAccounts?.has(normalizeAccount(username)) === true);
 	// A reserve_vote is a Hive Active-key custom_json — needs a Hive account
 	// (Aioha provider, not EVM) AND membership in the elected witness set.
 	let canVote = $derived(!!username && !!auth.value?.aioha && isWitness);
@@ -110,11 +123,23 @@
 	});
 
 	function hasVoted(p: Proposal): boolean {
-		return !!username && p.votes.some((v) => v.voter === username);
+		if (!username) return false;
+		const me = normalizeAccount(username);
+		return p.votes.some((v) => normalizeAccount(v.voter) === me);
 	}
 
 	async function vote(p: Proposal) {
 		if (!username || !auth.value?.aioha) return;
+		// Defensive: only the two known types map to a vote op. A future/unknown
+		// type must NOT silently fall through to reserve_vote (wrong op).
+		if (!isKnownType(p.type)) {
+			voteState[p.proposalId] = {
+				busy: false,
+				status: '',
+				error: `Unsupported proposal type: ${p.type}`
+			};
+			return;
+		}
 		voteState[p.proposalId] = { busy: true, status: 'Awaiting signature…', error: '' };
 		// Reserve payouts and slash restorations use DIFFERENT custom_json ops:
 		// reserve_vote is keyed by proposalId; slash_restore is keyed by the
@@ -151,8 +176,8 @@
 				Governance proposals
 				<InfoTooltip>
 					Open witness-vote proposals — reserve disbursements and wrongful-slash restorations.
-					Voting signs a <code>vsc.reserve_vote</code> custom_json with your witness account's
-					Active key. <a href="https://docs.vsc.eco" target="_blank" rel="noopener">Learn more →</a>
+					Voting signs a custom_json with your witness account's Active key. Only elected witnesses
+					can vote. <a href="https://docs.vsc.eco" target="_blank" rel="noopener">Learn more →</a>
 				</InfoTooltip>
 			</h3>
 			<p class="lead">
@@ -225,7 +250,7 @@
 							<PillButton
 								styleType="invert"
 								theme="primary"
-								disabled={!canVote || ui.busy}
+								disabled={!canVote || ui.busy || !isKnownType(p.type)}
 								onclick={() => vote(p)}
 							>
 								{#if ui.busy}

--- a/src/routes/(authed)/witness-assistant/GovernanceProposals.svelte
+++ b/src/routes/(authed)/witness-assistant/GovernanceProposals.svelte
@@ -16,7 +16,7 @@
 	import Card from '$lib/cards/Card.svelte';
 	import PillButton from '$lib/PillButton.svelte';
 	import InfoTooltip from '$lib/components/InfoTooltip.svelte';
-	import { reserveVoteTx } from '$lib/magiTransactions/hive';
+	import { reserveVoteTx, slashRestoreVoteTx } from '$lib/magiTransactions/hive';
 	import { Landmark, Loader2, Check } from '@lucide/svelte';
 	import { CoinAmount } from '$lib/currency/CoinAmount';
 	import { Coin } from '$lib/sendswap/utils/sendOptions';
@@ -116,7 +116,13 @@
 	async function vote(p: Proposal) {
 		if (!username || !auth.value?.aioha) return;
 		voteState[p.proposalId] = { busy: true, status: 'Awaiting signature…', error: '' };
-		const res = await reserveVoteTx(username, p.proposalId, auth.value.aioha);
+		// Reserve payouts and slash restorations use DIFFERENT custom_json ops:
+		// reserve_vote is keyed by proposalId; slash_restore is keyed by the
+		// slash's tx id + slashed account (same op proposes and votes).
+		const res =
+			p.type === 'slash_restore'
+				? await slashRestoreVoteTx(username, p.slashTxId, p.slashedAccount, auth.value.aioha)
+				: await reserveVoteTx(username, p.proposalId, auth.value.aioha);
 		if (!res.success) {
 			voteState[p.proposalId] = { busy: false, status: '', error: res.error };
 			return;


### PR DESCRIPTION
Polishes milo's MVP governance-vote widget into a production-ready feature on the
Witness Assistant page. Branch is off `main`; ships as 0.3.30.

## What's in it
- **Vote on both proposal types** (not just reserve spends): `vsc.reserve_vote`
  for reserve payouts (keyed by proposalId) and `vsc.slash_restore` for slash
  restorations (keyed by slash tx id + slashed account — same op proposes & votes).
  Op shapes verified against go-vsc-node `modules/state-processing/`.
- **Witness-only gating**: queries the current election (`electionByBlockHeight`)
  and enables voting only for elected committee members. Fails closed, with clear
  notices for non-witnesses / EVM logins / Active-key-less sessions.
- **Hardening**: account matching normalized (lowercase + `hive:`-strip) to mirror
  the node so the gate can't silently misfire; unknown proposal types refused
  rather than mis-routed; proposal poll pauses on hidden tab; debug log removed.
- **Page reorder**: Witness Assistant now leads with Stake/Unstake, then contract
  updates, then governance.

## Verification
- Production build ✅, type-check at baseline, governance op tests 5/5, prettier clean.
- Account matching, both vote ops, all auth/UI states walked manually.

## Caveats (known, by design)
- Safety slashing isn't active on any network yet → the panel is **dormant** (no
  proposals) until it is; the slash-restore path gets its first real-data exercise
  when slashing activates.
- `amount` renders as HIVE (milliHIVE, consistent with shipped `hive_consensus`
  display) though the schema comment says "sats" — worth one eyeball against the
  first real proposal.
- Widget votes on existing proposals; *initiating* a restoration (separate form)
  is a future follow-up.