### PR TITLE
fix(swap): swap guard no longer blocks dust trades (rounding false-positive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to Altera are documented here.
 > CI / build-banner / release-script use, and so a glance at `package.json`
 > matches reality.
 
+## [0.3.30] — 2026-06-26
+
+### Fixes
+
+- **Swap guard no longer blocks dust trades on a rounding artifact.** A tiny swap (e.g. 0.001 HBD → HIVE) was wrongly blocked with "abnormally high fee (~9.5%)". The on-chain `floor 1` minimum fee × the 2× stabilizer is ~2 smallest units, which as a fraction of a ~20-unit gross output reads as ~10% — even though the absolute fee is ~$0.0005. The guard's `feeBps` is now computed from the STRUCTURAL (un-floored) fee, so dust trades read ~0% and pass while a genuine percentage-scaling overcharge still trips it; `totalFee`/`expectedOutput` keep the floored values so the quote stays honest about what's charged. The gap the guard now ignores is capped at ~2 smallest units (the unavoidable on-chain minimum) regardless of trade size, so it can never hide a real overcharge. Also: when the guard does fire, the QuickSwap card shows the block message in place of the rate/fee/route details instead of overlapping it. (The contract overcharge this guard was built for is fixed on-chain in go-vsc-node #220, making the guard effectively a dormant net.)
+
 ## [0.3.29] — 2026-06-25
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.3.29",
+	"version": "0.3.30",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {

--- a/schema.graphql
+++ b/schema.graphql
@@ -325,6 +325,93 @@ input FindContractFilter {
   offset: Int
 }
 
+"""
+A witness-vote governance proposal. Encapsulates BOTH governance actions: a
+safety-slash restoration (type 'slash_restore' — re-credit a wrongfully slashed
+bond while it is still pending) and a reserve spend (type 'reserve_payout' —
+disburse from the keyless insurance reserve to a recipient). Kind-specific
+fields are populated according to `type`; the shared fields apply to both.
+"""
+type GovernanceProposal {
+  """Amount in satoshis (restored bond / disbursed reserve value)."""
+  amount: Int64!
+
+  """Block height at which the proposal was applied (0 if not yet applied)."""
+  appliedBlock: Uint64!
+
+  """
+  Hive tx id of the vote that crossed the threshold (empty if not applied).
+  """
+  appliedTxId: String!
+
+  """
+  Account excluded from the tally (slashed account / payout recipient — no self-dealing).
+  """
+  beneficiary: String!
+
+  """
+  Block height of the first vote; anchors expiry window + electorate snapshot.
+  """
+  creationBlock: Uint64!
+
+  """slash_restore: evidence kind of the original slash."""
+  evidenceKind: String!
+
+  """Deterministic proposal id (the unit witnesses reference when voting)."""
+  proposalId: String!
+
+  """reserve_payout: human-readable reason logged for explorers."""
+  reason: String!
+
+  """reserve_payout: the account credited by the disbursement."""
+  recipient: String!
+
+  """slash_restore: Hive tx id of the original slash being restored."""
+  slashTxId: String!
+
+  """slash_restore: the slashed account whose bond is restored."""
+  slashedAccount: String!
+
+  """Lifecycle status: 'open', 'applied', or 'expired'."""
+  status: String!
+
+  """Proposal kind: 'slash_restore' or 'reserve_payout'."""
+  type: String!
+
+  """Recorded approval votes (excludes the proposal row itself)."""
+  votes: [GovernanceVote!]!
+}
+
+"""Filter options for querying governance proposals."""
+input GovernanceProposalFilter {
+  """Restrict to a single proposal by exact id."""
+  byProposalId: String
+
+  """Filter by lifecycle status ('open', 'applied', 'expired')."""
+  byStatus: String
+
+  """Filter by proposal type ('slash_restore' or 'reserve_payout')."""
+  byType: String
+
+  """Maximum number of records to return (for pagination)."""
+  limit: Int
+
+  """Number of records to skip (for pagination)."""
+  offset: Int
+}
+
+"""A single witness approval vote recorded against a governance proposal."""
+type GovernanceVote {
+  """L1 block height at which the vote was recorded."""
+  blockHeight: Uint64!
+
+  """Hive transaction id of the vote op."""
+  txId: String!
+
+  """Normalized Hive account of the witness that voted."""
+  voter: String!
+}
+
 """Signed 64-bit integer, serialized as a string to avoid precision loss."""
 scalar Int64
 
@@ -629,6 +716,16 @@ type Query {
     """Filter criteria for the contract output search."""
     filterOptions: ContractOutputFilter
   ): [ContractOutput!]
+
+  """
+  Search witness-vote governance proposals — both safety-slash restorations
+  ('slash_restore') and reserve spends ('reserve_payout') — and their recorded
+  approval votes. Returns newest-created first.
+  """
+  findGovernanceProposals(
+    """Filter criteria for the governance proposal search."""
+    filterOptions: GovernanceProposalFilter
+  ): [GovernanceProposal!]!
 
   """Search for ledger action records matching the given filter criteria."""
   findLedgerActions(

--- a/src/lib/cards/QuickSwap.svelte
+++ b/src/lib/cards/QuickSwap.svelte
@@ -1390,8 +1390,17 @@
 
 	<!-- Variable content: grows to fill space, content anchored to bottom so button never moves -->
 	<div class="swap-middle">
-	<!-- Swap Details -->
-	{#if txState.from && txState.to}
+	<!-- Swap Details — replaced by the guard notice when the fee guard trips, so the
+	     block reason occupies the quote area instead of crowding it from below. -->
+	{#if feeGuardTripped}
+		<div class="swap-blocked">
+			<p class="fee-guard-warning">
+				Swap blocked: the network would charge an abnormally high fee
+				(~{((txState.swapFeeBps ?? 0) / 100).toFixed(1)}%) on this trade right now. Try a
+				smaller amount, or wait until it's resolved.
+			</p>
+		</div>
+	{:else if txState.from && txState.to}
 		<div class="swap-details">
 			<div class="detail-row">
 				<span class="detail-label">Rate</span>
@@ -1464,7 +1473,7 @@
 		</div>
 	{/if}
 
-	{#if priceImpactPct >= 10}
+	{#if priceImpactPct >= 10 && !feeGuardTripped}
 		<p class="swap-status error" class:severe={priceImpactPct >= 15}>
 			{#if priceImpactPct >= 15}
 				⚠ Very high price impact. Pool liquidity is low. Try a smaller amount.
@@ -1482,14 +1491,6 @@
 		<p class="swap-status error">Amount exceeds 50% of pool depth — reduce the amount.</p>
 	{/if}
 	</div><!-- end .swap-middle -->
-
-	{#if feeGuardTripped}
-		<p class="fee-guard-warning">
-			Swap blocked: the network would charge an abnormally high fee
-			(~{((txState.swapFeeBps ?? 0) / 100).toFixed(1)}%) on this trade right now. Try a smaller
-			amount, or wait until it's resolved.
-		</p>
-	{/if}
 
 	<!-- Exchange -->
 	<PillButton
@@ -1617,8 +1618,18 @@
 </Dialog>
 
 <style lang="scss">
+	/* Occupies the same flex area the .swap-details quote would, so the guard
+	   notice replaces the rate/fee/route block cleanly and the Swap button
+	   below it doesn't shift. */
+	.swap-blocked {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0.75rem 0 0.25rem;
+	}
 	.fee-guard-warning {
-		margin: 0 0 0.75rem;
+		margin: 0;
 		padding: 0.6rem 0.8rem;
 		border: 1px solid var(--dash-accent-red, #dc2626);
 		border-radius: 12px;

--- a/src/lib/pools/swapCalc.test.ts
+++ b/src/lib/pools/swapCalc.test.ts
@@ -396,6 +396,27 @@ describe('swap fee guard', () => {
 		expect(swapFeeExceedsGuard(r.feeBps)).toBe(false);
 	});
 
+	it('dust trade does NOT trip the guard despite the floored fee looking high', () => {
+		// Repro of the reported false-positive: 0.001 HBD (x = 1) into a skewed pool
+		// (rate ≈ 20). The on-chain floor-1 minimum fee × the 2× stabilizer ≈ 2
+		// smallest units; as a fraction of the ~20-unit gross output that's ~10%, so
+		// the OLD floored feeBps wrongly tripped the 3% guard — even though the
+		// absolute fee is ~$0.0005. `feeBps` is now computed from the structural
+		// (un-floored) fee, which is ~0 for dust, so the guard lets it through while
+		// `totalFee` still honestly reflects the few units actually charged.
+		const r = calculateSwap(1n, 100_000n, 2_000_000n, 100);
+
+		// The naive floored ratio (what the guard used to see) DOES look abnormal…
+		const grossOut = r.expectedOutput + r.totalFee;
+		const flooredFeeBps = Number((r.totalFee * 10000n) / grossOut);
+		expect(r.totalFee).toBeGreaterThan(0n); // a real (tiny) fee is still charged
+		expect(flooredFeeBps).toBeGreaterThan(SWAP_FEE_GUARD_BPS);
+
+		// …but the structural feeBps that drives the guard does not trip.
+		expect(r.feeBps).toBeLessThan(SWAP_FEE_GUARD_BPS);
+		expect(swapFeeExceedsGuard(r.feeBps)).toBe(false);
+	});
+
 	it('a large swap that pre-fix exceeded the guard now stays under it (fee fix)', () => {
 		// 200,000 units ≈ 9% of reserve. Pre-2026-06-19 (CLP × 2× stabilizer) this
 		// modelled at ~4% and was wrongly blocked; post-fix (CLP × 1/16) it's well

--- a/src/lib/pools/swapCalc.ts
+++ b/src/lib/pools/swapCalc.ts
@@ -289,6 +289,20 @@ export function calculateSwap(
 	const slipBps = BigInt(Math.max(0, Math.min(slippageBps, 10000)));
 	const minAmountOut = (expectedOutput * (10000n - slipBps)) / 10000n;
 
+	// `feeBps` drives the overcharge guard, and is computed from the STRUCTURAL
+	// (un-floored) fee — NOT `totalFee`. The `floor 1` minimums above are a fixed
+	// sub-unit cost (mirroring the on-chain minimum), not the percentage-scaling
+	// overcharge the guard exists to catch. On dust trades they dominate: a 1-unit
+	// protocol floor × the 2× stabilizer is 2 units, which on a ~20-unit gross
+	// output reads as ~10% and would wrongly BLOCK an economically negligible
+	// (~$0.0005) swap. The structural fee is ≈0 for dust (so the guard ignores it)
+	// while still rising with a genuine large-fee regression. `totalFee` /
+	// `expectedOutput` keep the floored values so the quote stays honest about
+	// what's actually charged.
+	const structuralFee =
+		((grossOut * 8n) / 10000n) * (STABILIZER_CAP_BPS / BPS_SCALE) +
+		(((x * x * Y) / (newX * newX)) * CLP_SCALE_BPS) / BPS_SCALE;
+
 	return {
 		baseFee: chargedProtocolFee,
 		clpFee: chargedClpFee,
@@ -296,7 +310,7 @@ export function calculateSwap(
 		expectedOutput,
 		minAmountOut,
 		slippageBps,
-		feeBps: feeBpsOf(totalFee, expectedOutput)
+		feeBps: feeBpsOf(structuralFee, grossOut - structuralFee)
 	};
 }
 


### PR DESCRIPTION
A tiny swap (e.g. 0.001 HBD → HIVE) was wrongly blocked: "abnormally high fee (~9.5%)".

## Root cause
The on-chain `floor 1` minimum fee × the 2× stabilizer ≈ 2 smallest units. As a
fraction of a ~20-unit gross output that reads as ~10%, tripping the 3% guard —
even though the absolute fee is ~$0.0005.

## Fix
- `feeBps` (the guard input) now uses the **structural** (un-floored) fee. Dust
  reads ~0% and passes; a genuine percentage overcharge still trips. `totalFee` /
  `expectedOutput` stay floored, so the displayed quote is still honest about
  what's charged.
- The gap the guard now ignores is capped at ~2 smallest units regardless of
  trade size — so it can never hide a real overcharge.
- Independent safety net unchanged: the on-chain `min_amount_out` gate still
  protects against under-delivery.
- UX: when the guard fires, the QuickSwap card shows the block message **in place
  of** the rate/fee/route block instead of overlapping it.

## Scope
- Files: `src/lib/pools/swapCalc.ts`, `src/lib/pools/swapCalc.test.ts`,
  `src/lib/cards/QuickSwap.svelte` (shared fix → applies to QuickSwap, SwapOptions,
  ReviewSwap).
- Added a dust regression test (floored ratio looks >3% but structural feeBps
  does not trip).

## Verification
- Type-check at baseline, 50 swapCalc tests pass, production build green,
  smoke-tested live (0.01 HBD → HIVE goes through).
- Re-numbered to **0.3.31** (governance took 0.3.30) and merged with current main.