### PR TITLE
refactor: list components render a Component per item (snippet → Component)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to Altera are documented here.
 > CI / build-banner / release-script use, and so a glance at `package.json`
 > matches reality.
 
+## [0.3.32] — 2026-06-29
+
+### Changed
+
+- **List components can render a Component per item, not just a snippet.** `RadioGroup` and `AssetList` now accept a `component` + `props` per item (rendered dynamically), alongside the existing `snippet` path — additive, so nothing else changes. Converts the two repetitive, trivial-wrapper cases: the deposit "I want to receive" asset chips (5 near-identical snippets → one `AssetChip`) and the QuickSend/Transfer "from" asset pickers (the `assetCard` snippet wrapper → `AssetInfo` directly). No user-facing behavior change. Snippets that encapsulate non-trivial mapping or vary per item (contacts, login-method labels, etc.) were intentionally left as snippets.
+
 ## [0.3.31] — 2026-06-29
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.3.31",
+	"version": "0.3.32",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {

--- a/src/lib/sendswap/components/assetSelection/AssetList.svelte
+++ b/src/lib/sendswap/components/assetSelection/AssetList.svelte
@@ -140,7 +140,10 @@
 						if (itemVal === value) clickAsset(itemVal);
 					}}
 				>
-					{#if item.snippet}
+					{#if item.component}
+						{@const Item = item.component}
+						<Item {...item.props} />
+					{:else if item.snippet}
 						{@render item.snippet(item.snippetData ?? item)}
 					{:else}
 						{item.label}

--- a/src/lib/sendswap/components/info/SendSnippets.svelte
+++ b/src/lib/sendswap/components/info/SendSnippets.svelte
@@ -11,10 +11,17 @@
 	import ContactInfo from './ContactInfo.svelte';
 	import { getDidFromUsername, getUsernameFromDid } from '$lib/getAccountName';
 	import moment from 'moment';
+	import { type Component } from 'svelte';
 
 	export interface AssetObject extends Coin {
-		snippetData: { fromOpt: CoinOptionParam | undefined; net?: Network };
-		snippet: typeof assetCardSnippet;
+		// Item content is supplied EITHER as a Component (preferred — `component`
+		// + `props`, rendered dynamically) OR the legacy `snippet` + `snippetData`
+		// pair. Both optional so call sites can use whichever; list components
+		// (AssetList/RadioGroup/…) render `component` first, then `snippet`.
+		component?: Component<any>;
+		props?: Record<string, any>;
+		snippetData?: { fromOpt: CoinOptionParam | undefined; net?: Network };
+		snippet?: typeof assetCardSnippet;
 		disabled?: boolean;
 		disabledMemo?: string;
 	}

--- a/src/lib/sendswap/stages/QuickSendOptions.svelte
+++ b/src/lib/sendswap/stages/QuickSendOptions.svelte
@@ -10,7 +10,8 @@
 		type CoinOnNetwork,
 		type AssetOption
 	} from '../utils/sendOptions';
-	import { assetCard, type AssetObject } from '../components/info/SendSnippets.svelte';
+	import { type AssetObject } from '../components/info/SendSnippets.svelte';
+	import AssetInfo from '../components/info/AssetInfo.svelte';
 	import { untrack } from 'svelte';
 	import RecipientCard from '../components/RecipientCard.svelte';
 	import ContactSearchBox from '../contacts/ContactSearchBox.svelte';
@@ -65,8 +66,8 @@
 	const fromAssetObjs: AssetObject[] = $derived(
 		swapOptions.from.map((opt) => ({
 			...opt.coin,
-			snippet: assetCard,
-			snippetData: { fromOpt: opt, net: txState.to?.network, size: 'medium' }
+			component: AssetInfo,
+			props: { coinOpt: opt, network: txState.to?.network, size: 'medium' }
 		}))
 	);
 

--- a/src/lib/sendswap/stages/TransferOptions.svelte
+++ b/src/lib/sendswap/stages/TransferOptions.svelte
@@ -32,7 +32,8 @@
 	import ClickableCard from '$lib/cards/ClickableCard.svelte';
 	import ContactSearchBox from '$lib/sendswap/contacts/ContactSearchBox.svelte';
 	import { CoinAmount } from '$lib/currency/CoinAmount';
-	import { assetCard, type AssetObject } from '../components/info/SendSnippets.svelte';
+	import { type AssetObject } from '../components/info/SendSnippets.svelte';
+	import AssetInfo from '../components/info/AssetInfo.svelte';
 	import AmountInput from '$lib/currency/AmountInput.svelte';
 	import TransferBar from '../components/TransferBar.svelte';
 	import SelectAssetFlattened from '../components/assetSelection/SelectAssetFlattened.svelte';
@@ -144,8 +145,8 @@
 	const fromAssetObjs: AssetObject[] = $derived(
 		swapOptions.from.map((opt) => ({
 			...opt.coin,
-			snippet: assetCard,
-			snippetData: { fromOpt: opt, net: txState.to?.network, size: 'medium' }
+			component: AssetInfo,
+			props: { coinOpt: opt, network: txState.to?.network, size: 'medium' }
 		}))
 	);
 

--- a/src/lib/sendswap/stages/deposit/AssetChip.svelte
+++ b/src/lib/sendswap/stages/deposit/AssetChip.svelte
@@ -1,0 +1,29 @@
+<!--
+	Asset chip for the deposit timeline's "I want to receive" RadioGroup.
+
+	Replaces the per-asset snippets (hiveChip / hbdChip / …) that were forced by
+	RadioGroup's self-referential Item generic — now a single component passed via
+	the items' `component` field, parameterised by `props`.
+-->
+<script lang="ts">
+	let { icon, label }: { icon: string; label: string } = $props();
+</script>
+
+<span class="asset-chip">
+	<img src={icon} alt="" width="18" height="18" />
+	<span>{label}</span>
+</span>
+
+<style>
+	.asset-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-weight: 600;
+		font-size: 0.95rem;
+		line-height: 1;
+	}
+	.asset-chip img {
+		display: block;
+	}
+</style>

--- a/src/lib/sendswap/stages/deposit/DepositTimeline.svelte
+++ b/src/lib/sendswap/stages/deposit/DepositTimeline.svelte
@@ -33,6 +33,7 @@
 	import { Coin, Network } from '../../utils/sendOptions';
 	import { useDepositState } from '../../utils/txState.svelte';
 	import { initDepositStateForSource, type DepositSource } from './depositInit';
+	import AssetChip from './AssetChip.svelte';
 	import HiveMainnetDeposit from './HiveMainnetDeposit.svelte';
 	import LightningDeposit from './LightningDeposit.svelte';
 	import BtcMainnetDeposit from './BitcoinMainnetDeposit.svelte';
@@ -264,20 +265,6 @@
 	let secondaryMenu = $state(false);
 </script>
 
-<!-- Asset chip snippets — one per asset (per HiveLogin pattern; RadioGroup's
-     Item generic is self-referential and rejects a shared snippet). -->
-{#snippet hiveChip()}{@render assetChipLayout(ASSETS[0])}{/snippet}
-{#snippet hbdChip()}{@render assetChipLayout(ASSETS[1])}{/snippet}
-{#snippet btcChip()}{@render assetChipLayout(ASSETS[2])}{/snippet}
-{#snippet ethChip()}{@render assetChipLayout(ASSETS[3])}{/snippet}
-
-{#snippet assetChipLayout(a: (typeof ASSETS)[number])}
-	<span class="asset-chip">
-		<img src={a.icon} alt="" width="18" height="18" />
-		<span>{a.label}</span>
-	</span>
-{/snippet}
-
 <!-- Source card snippets — one per source (same reason). -->
 {#snippet hiveMainnetCard()}{@render sourceCardLayout(SOURCES[0])}{/snippet}
 {#snippet lightningCard()}{@render sourceCardLayout(SOURCES[1])}{/snippet}
@@ -361,12 +348,12 @@
 						<div class="step-body">
 							<div class="chip-row">
 								<RadioGroup
-									items={[
-										{ value: ASSETS[0].value, snippet: hiveChip },
-										{ value: ASSETS[1].value, snippet: hbdChip },
-										{ value: ASSETS[2].value, snippet: btcChip },
-										{ value: ASSETS[3].value, snippet: ethChip, disabled: true }
-									]}
+									items={ASSETS.map((a) => ({
+										value: a.value,
+										component: AssetChip,
+										props: { icon: a.icon, label: a.label },
+										disabled: a.disabled
+									}))}
 									bind:value={assetRadio}
 								/>
 								<button
@@ -555,18 +542,6 @@
 		align-items: center;
 		gap: 0.75rem;
 		flex-wrap: wrap;
-	}
-	/* RadioGroup styles its own items; we override the inner content with .asset-chip */
-	:global(.asset-chip) {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.5rem;
-		font-weight: 600;
-		font-size: 0.95rem;
-		line-height: 1;
-	}
-	:global(.asset-chip img) {
-		display: block;
 	}
 	.other-asset-btn {
 		display: inline-flex;

--- a/src/lib/zag/RadioGroup.svelte
+++ b/src/lib/zag/RadioGroup.svelte
@@ -1,17 +1,19 @@
 <script
 	lang="ts"
 	generics="Item extends {
-			label?: string, 
-			snippet?: (item?: Item) => ReturnType<Snippet<[Item]>>; 
-			value: string, 
-			disabled?: boolean 
+			label?: string,
+			snippet?: (item?: Item) => ReturnType<Snippet<[Item]>>;
+			component?: Component<any>;
+			props?: Record<string, any>;
+			value: string,
+			disabled?: boolean
 		}"
 >
 	import * as radio from '@zag-js/radio-group';
 	import { normalizeProps, useMachine } from '@zag-js/svelte';
 	import { getUniqueId } from './idgen';
 	import { Check } from '@lucide/svelte';
-	import { untrack, type Snippet } from 'svelte';
+	import { untrack, type Component, type Snippet } from 'svelte';
 	type Props = {
 		required?: boolean;
 		id?: string;
@@ -75,7 +77,10 @@
 						disabled: opt.disabled === undefined ? false : opt.disabled
 					})}
 				>
-					{#if opt.snippet}
+					{#if opt.component}
+						{@const Item = opt.component}
+						<Item {...opt.props} />
+					{:else if opt.snippet}
 						{@render opt.snippet(opt)}
 					{:else}
 						{opt.label}


### PR DESCRIPTION
Tech-debt refactor (no user-facing behavior change). Lets `RadioGroup` and
`AssetList` take a `component` + `props` per item, rendered dynamically, alongside
the existing `snippet` path (additive — nothing else changes).

## Converted (the two repetitive, trivial-wrapper cases)
- Deposit "I want to receive" asset chips: 5 near-identical snippets → one `AssetChip`.
- QuickSend / Transfer "from" asset pickers: the `assetCard` snippet wrapper → `AssetInfo` directly.

## Intentionally NOT converted
Snippets that encapsulate non-trivial mapping or vary per item (contacts,
login-method labels, Topbar, networkCard) — converting them would duplicate
logic / hurt readability. Left as snippets by design.

## Verification
- Type-check at baseline, 72 tests pass (deposit/swap/governance), smoke-tested
  (deposit chips + QuickSend/Transfer pickers render + select as before).
- Bumps to 0.3.32; synced with current main.