### PR TITLE
feat(witness): block-production feed + governance history (0.3.33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to Altera are documented here.
 > CI / build-banner / release-script use, and so a glance at `package.json`
 > matches reality.
 
+## [0.3.33] — 2026-06-30
+
+### Added
+
+- **Witness Assistant — live block-production feed.** A new "Block production" card leads the page and shows, in real time, **who is producing blocks now and who's up next**, with validator avatars for quick identification. It's built entirely first-party on `api.vsc.eco`: the current head (`localNodeInfo.last_processed_block`) is polled every 10s and matched against the per-slot producer schedule (`witnessSchedule(height)`), so the "Now producing @account · block N" hero advances as blocks are signed. The full elected committee for the current epoch (`electionByBlockHeight`) sits in an expandable below it. Performance was a design constraint so the page can sit open all day: only the tiny head field is polled (the ~120-slot schedule is cached and re-fetched only when exhausted, ~hourly), an in-flight guard prevents request pile-up, polling pauses while the tab is hidden, and avatars are direct Hive-CDN images (no API calls). Read-only and visible to everyone. (Required a schema re-pull to pick up the `witnessSchedule` / `localNodeInfo` types.)
+- **Witness Assistant — governance proposal history.** The governance panel now has a read-only "Past proposals" section listing settled reserve-payout and slash-restoration proposals (paginated "Load more"), each showing type / amount / recipient, an Approved or Expired outcome badge, the vote count, the applied block, and a "view tx ↗" link to hivehub (proposals settle as Hive txs). Complements the existing open-proposal voting; visible to Hive witnesses.
+
 ## [0.3.32] — 2026-06-29
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.3.32",
+	"version": "0.3.33",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {

--- a/schema.graphql
+++ b/schema.graphql
@@ -333,7 +333,7 @@ disburse from the keyless insurance reserve to a recipient). Kind-specific
 fields are populated according to `type`; the shared fields apply to both.
 """
 type GovernanceProposal {
-  """Amount in satoshis (restored bond / disbursed reserve value)."""
+  """Amount in base units (restored bond / disbursed reserve value)."""
   amount: Int64!
 
   """Block height at which the proposal was applied (0 if not yet applied)."""

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -35,6 +35,14 @@ export function getHiveAccountUrl(account: string): string {
 	return `https://hivehub.dev/@${encodeURIComponent(name)}`;
 }
 
+/** Direct Hive avatar CDN URL (no API call — serves a default if unset). Use for
+ *  lightweight inline avatars; the async getProfilePicUrl resolves nicer images
+ *  but costs a lookup per account. */
+export function getHiveAvatarUrl(account: string, size: 'small' | 'icon' = 'small'): string {
+	const name = account.startsWith('hive:') ? account.slice(5) : account;
+	return `https://images.hive.blog/u/${encodeURIComponent(name)}/avatar/${size}`;
+}
+
 export function getMemPoolTxUrl(btcTxId: string): string {
 	const network = isVscTestnet() ? '/testnet' : '';
 	return `https://mempool.space${network}/tx/${btcTxId}`;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -10,15 +10,29 @@ export const BTC_MAPPING_CONTRACT_ID = isVscTestnet()
 	? 'vsc1BkWohDf5fPcwn7V9B9ar6TyiWc3A2ZGJ4t'
 	: 'vsc1BdrQ6EtbQ64rq2PkPd21x4MaLnVRcJj85d';
 
+function vscExplorerBase(): string {
+	return isVscTestnet() ? 'https://magi-test.techcoderx.com' : 'https://vsc.techcoderx.com';
+}
+
 export function getVscExplorerTxUrl(txId: string): string {
-	const base = isVscTestnet() ? 'https://magi-test.techcoderx.com' : 'https://vsc.techcoderx.com';
-	return `${base}/tx/${txId}`;
+	return `${vscExplorerBase()}/tx/${txId}`;
+}
+
+/** VSC explorer home (shows the live block feed). Testnet-aware. */
+export function getVscExplorerUrl(): string {
+	return vscExplorerBase();
 }
 
 /** Hive L1 transaction on hivehub (e.g. governance vote/apply custom_json txs,
  *  which are Hive txs, not VSC ones). Hive has a single mainnet — no testnet switch. */
 export function getHiveExplorerTxUrl(txId: string): string {
 	return `https://hivehub.dev/tx/${txId}`;
+}
+
+/** A Hive account profile on hivehub (e.g. a validator/witness account). */
+export function getHiveAccountUrl(account: string): string {
+	const name = account.startsWith('hive:') ? account.slice(5) : account;
+	return `https://hivehub.dev/@${encodeURIComponent(name)}`;
 }
 
 export function getMemPoolTxUrl(btcTxId: string): string {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -15,6 +15,12 @@ export function getVscExplorerTxUrl(txId: string): string {
 	return `${base}/tx/${txId}`;
 }
 
+/** Hive L1 transaction on hivehub (e.g. governance vote/apply custom_json txs,
+ *  which are Hive txs, not VSC ones). Hive has a single mainnet — no testnet switch. */
+export function getHiveExplorerTxUrl(txId: string): string {
+	return `https://hivehub.dev/tx/${txId}`;
+}
+
 export function getMemPoolTxUrl(btcTxId: string): string {
 	const network = isVscTestnet() ? '/testnet' : '';
 	return `https://mempool.space${network}/tx/${btcTxId}`;

--- a/src/routes/(authed)/witness-assistant/+page.svelte
+++ b/src/routes/(authed)/witness-assistant/+page.svelte
@@ -5,6 +5,7 @@
 	import StakeUnstakeTabsModal from './StakeUnstakeTabsModal.svelte';
 	import ContractUpdatesSection from '$lib/witness/contractUpdates/ContractUpdatesSection.svelte';
 	import GovernanceProposals from './GovernanceProposals.svelte';
+	import CurrentValidators from './CurrentValidators.svelte';
 	let auth = $derived(getAuth()());
 	// True for Hive logins (and the not-yet-signed-in state); false only for EVM
 	// wallets, which can't stake consensus or sign governance votes.
@@ -18,6 +19,10 @@
 <h1>Witness Assistant</h1>
 
 <div>
+	<!-- 0. Current validators — a small live-ish box of the committee securing the
+	     network this epoch. Read-only, visible to everyone, so it leads the page. -->
+	<CurrentValidators />
+
 	<!-- 1. Stake / Unstake — the primary witness action (and the prerequisite to
 	     voting), so it leads. EVM wallets can't stake → show the redirect notice. -->
 	{#if canStake}

--- a/src/routes/(authed)/witness-assistant/CurrentValidators.svelte
+++ b/src/routes/(authed)/witness-assistant/CurrentValidators.svelte
@@ -1,0 +1,159 @@
+<!--
+	Current validators — a compact box showing the elected committee securing the
+	network this epoch (`electionByBlockHeight.members`).
+
+	NOTE: the per-block producer *schedule* is computed inside the node
+	(state-engine `GetSchedule`) and isn't exposed via GraphQL, so we can't show
+	"who is producing block N right now" from the frontend yet. This shows the
+	committee (per-epoch) instead — each validator links to their hivehub account,
+	with a link out to the VSC explorer for the live block feed. Refreshes every
+	30s (and on tab focus). Upgrade to true per-block once the node exposes a
+	current-producer query.
+-->
+<script lang="ts">
+	import { CurrentElectionStore } from '$houdini';
+	import Card from '$lib/cards/Card.svelte';
+	import { getHiveAccountUrl, getVscExplorerUrl } from '$lib/constants';
+	import { Users } from '@lucide/svelte';
+
+	let epoch = $state<number | null>(null);
+	let validators = $state<string[]>([]);
+	let load = $state<'loading' | 'loaded' | 'error'>('loading');
+	let loadError = $state('');
+
+	async function fetchValidators() {
+		try {
+			const res = await new CurrentElectionStore().fetch({ policy: 'NetworkOnly' });
+			if (res.errors?.length) throw new Error(res.errors[0].message);
+			const el = res.data?.electionByBlockHeight;
+			epoch = el?.epoch ?? null;
+			validators = (el?.members ?? []).map((m) => m.account);
+			load = 'loaded';
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : String(e);
+			load = 'error';
+		}
+	}
+
+	$effect(() => {
+		fetchValidators();
+		let id: ReturnType<typeof setInterval> | undefined;
+		const start = () => (id ??= setInterval(fetchValidators, 30000));
+		const stop = () => {
+			clearInterval(id);
+			id = undefined;
+		};
+		// Pause while the tab is hidden; refresh on return.
+		const onVisibility = () => {
+			if (document.hidden) stop();
+			else {
+				fetchValidators();
+				start();
+			}
+		};
+		start();
+		document.addEventListener('visibilitychange', onVisibility);
+		return () => {
+			stop();
+			document.removeEventListener('visibilitychange', onVisibility);
+		};
+	});
+</script>
+
+<Card>
+	<div class="head">
+		<h3>
+			<Users size={18} />
+			Current validators
+			{#if epoch !== null}<span class="epoch">epoch {epoch}</span>{/if}
+		</h3>
+		<a class="live-link" href={getVscExplorerUrl()} target="_blank" rel="noopener">Live blocks ↗</a>
+	</div>
+
+	{#if load === 'loading'}
+		<p class="empty">Loading validators…</p>
+	{:else if load === 'error'}
+		<p class="empty error">Couldn't load validators: {loadError}</p>
+	{:else if validators.length === 0}
+		<p class="empty">No active committee right now.</p>
+	{:else}
+		<div class="validators">
+			{#each validators as v (v)}
+				<a class="validator" href={getHiveAccountUrl(v)} target="_blank" rel="noopener">@{v}</a>
+			{/each}
+		</div>
+		<p class="count">{validators.length} witnesses securing the network this epoch.</p>
+	{/if}
+</Card>
+
+<style lang="scss">
+	.head {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 1rem;
+		margin-bottom: 0.85rem;
+	}
+	h3 {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin: 0;
+		font-size: 1.05rem;
+		font-family: 'Nunito Sans', sans-serif;
+	}
+	.epoch {
+		font-size: 0.7rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--dash-text-secondary);
+		background: rgba(255, 255, 255, 0.06);
+		padding: 0.12rem 0.45rem;
+		border-radius: 6px;
+	}
+	.live-link {
+		font-size: 0.8rem;
+		color: var(--dash-accent-purple, #b0acff);
+		text-decoration: none;
+		white-space: nowrap;
+		flex-shrink: 0;
+	}
+	.live-link:hover {
+		text-decoration: underline;
+	}
+	.validators {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.4rem;
+	}
+	.validator {
+		font-size: 0.8rem;
+		font-family: 'Noto Sans Mono', monospace;
+		color: var(--dash-text-primary);
+		text-decoration: none;
+		background: rgba(255, 255, 255, 0.05);
+		border: 1px solid rgba(255, 255, 255, 0.08);
+		padding: 0.18rem 0.5rem;
+		border-radius: 8px;
+	}
+	.validator:hover {
+		border-color: var(--dash-accent-purple, #6f6af8);
+		color: #b0acff;
+	}
+	.count {
+		margin: 0.65rem 0 0;
+		font-size: 0.78rem;
+		color: var(--dash-text-secondary);
+	}
+	.empty {
+		margin: 0;
+		font-size: 0.85rem;
+		color: var(--dash-text-muted);
+		font-style: italic;
+	}
+	.empty.error {
+		color: var(--error-text, #ff8585);
+		font-style: normal;
+	}
+</style>

--- a/src/routes/(authed)/witness-assistant/CurrentValidators.svelte
+++ b/src/routes/(authed)/witness-assistant/CurrentValidators.svelte
@@ -121,9 +121,11 @@
 	{#if prodLoad === 'error'}
 		<p class="empty error">Couldn't load the schedule: {prodError}</p>
 	{:else if currentProducer}
-		<div class="now">
-			<span class="now-dot" title="live"></span>
-			<span class="now-label">Now producing</span>
+		<div class="now-panel">
+			<div class="now-head">
+				<span class="now-dot" title="live"></span>
+				<span class="now-label">Now producing</span>
+			</div>
 			<a
 				class="now-account"
 				href={getHiveAccountUrl(currentProducer.account)}
@@ -131,13 +133,16 @@
 				rel="noopener"
 			>
 				<img
-					class="avatar avatar-lg"
+					class="avatar avatar-hero"
 					src={getHiveAvatarUrl(currentProducer.account)}
 					alt=""
 					loading="lazy"
-				/>@{currentProducer.account}</a
-			>
-			<span class="now-bn">block {currentProducer.bn}</span>
+				/>
+				<span class="now-id">
+					<span class="now-name">@{currentProducer.account}</span>
+					<span class="now-bn">block {currentProducer.bn.toLocaleString()}</span>
+				</span>
+			</a>
 		</div>
 		{#if upcoming.length}
 			<div class="upnext">
@@ -149,7 +154,7 @@
 							href={getHiveAccountUrl(s.account)}
 							target="_blank"
 							rel="noopener"
-							title="block {s.bn}"
+							title="block {s.bn.toLocaleString()}"
 						>
 							<img
 								class="avatar"
@@ -163,7 +168,16 @@
 			</div>
 		{/if}
 	{:else}
-		<p class="empty">Loading block schedule…</p>
+		<div class="now-panel skeleton-panel" aria-hidden="true">
+			<div class="now-head">
+				<span class="now-dot"></span>
+				<span class="skeleton skeleton-label"></span>
+			</div>
+			<div class="now-account">
+				<span class="skeleton skeleton-avatar"></span>
+				<span class="skeleton skeleton-name"></span>
+			</div>
+		</div>
 	{/if}
 
 	<button
@@ -218,12 +232,21 @@
 		text-decoration: underline;
 	}
 
-	/* ── Now producing ── */
-	.now {
+	/* ── Now producing (live hero) ── */
+	.now-panel {
+		display: flex;
+		flex-direction: column;
+		gap: 0.55rem;
+		padding: 0.7rem 0.85rem;
+		border-radius: 12px;
+		background: rgba(143, 220, 155, 0.06);
+		border: 1px solid rgba(143, 220, 155, 0.18);
+		border-left: 3px solid var(--dash-accent-green, #8fdc9b);
+	}
+	.now-head {
 		display: flex;
 		align-items: center;
-		gap: 0.6rem;
-		flex-wrap: wrap;
+		gap: 0.5rem;
 	}
 	.now-dot {
 		width: 0.55rem;
@@ -254,12 +277,29 @@
 	.now-account {
 		display: inline-flex;
 		align-items: center;
-		gap: 0.4rem;
-		font-size: 1.05rem;
-		font-weight: 600;
+		gap: 0.65rem;
+		width: fit-content;
+		text-decoration: none;
+	}
+	.now-id {
+		display: flex;
+		flex-direction: column;
+		line-height: 1.2;
+		gap: 0.1rem;
+	}
+	.now-name {
+		font-size: 1.15rem;
+		font-weight: 700;
 		font-family: 'Noto Sans Mono', monospace;
 		color: var(--dash-text-primary);
-		text-decoration: none;
+	}
+	.now-account:hover .now-name {
+		color: #b0acff;
+	}
+	.now-bn {
+		font-size: 0.72rem;
+		color: var(--dash-text-muted);
+		font-family: 'Noto Sans Mono', monospace;
 	}
 	/* Lightweight inline avatars (direct Hive CDN — no API call). */
 	.avatar {
@@ -270,16 +310,54 @@
 		flex-shrink: 0;
 		background: rgba(255, 255, 255, 0.08);
 	}
-	.avatar-lg {
-		width: 22px;
-		height: 22px;
+	.avatar-hero {
+		width: 38px;
+		height: 38px;
 	}
-	.now-account:hover {
-		color: #b0acff;
+	/* Loading skeleton (mirrors the hero so the layout doesn't jump) */
+	.skeleton-panel {
+		background: rgba(255, 255, 255, 0.02);
+		border-color: rgba(255, 255, 255, 0.06);
+		border-left-color: rgba(255, 255, 255, 0.12);
 	}
-	.now-bn {
-		font-size: 0.72rem;
-		color: var(--dash-text-muted);
+	.skeleton {
+		display: inline-block;
+		border-radius: 6px;
+		background: linear-gradient(
+			90deg,
+			rgba(255, 255, 255, 0.04),
+			rgba(255, 255, 255, 0.1),
+			rgba(255, 255, 255, 0.04)
+		);
+		background-size: 200% 100%;
+		animation: shimmer 1.4s ease-in-out infinite;
+	}
+	@keyframes shimmer {
+		0% {
+			background-position: 200% 0;
+		}
+		100% {
+			background-position: -200% 0;
+		}
+	}
+	.skeleton-label {
+		width: 96px;
+		height: 0.7rem;
+	}
+	.skeleton-avatar {
+		width: 38px;
+		height: 38px;
+		border-radius: 50%;
+	}
+	.skeleton-name {
+		width: 150px;
+		height: 1.15rem;
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.now-dot,
+		.skeleton {
+			animation: none;
+		}
 	}
 	.upnext {
 		display: flex;

--- a/src/routes/(authed)/witness-assistant/CurrentValidators.svelte
+++ b/src/routes/(authed)/witness-assistant/CurrentValidators.svelte
@@ -1,53 +1,105 @@
 <!--
-	Current validators — a compact box showing the elected committee securing the
-	network this epoch (`electionByBlockHeight.members`).
+	Block production — a live "who's producing now / up next" feed for the witness
+	committee, plus the full epoch committee tucked into an expandable.
 
-	NOTE: the per-block producer *schedule* is computed inside the node
-	(state-engine `GetSchedule`) and isn't exposed via GraphQL, so we can't show
-	"who is producing block N right now" from the frontend yet. This shows the
-	committee (per-epoch) instead — each validator links to their hivehub account,
-	with a link out to the VSC explorer for the live block feed. Refreshes every
-	30s (and on tab focus). Upgrade to true per-block once the node exposes a
-	current-producer query.
+	Real-time path (all first-party on vsc.eco):
+	  • `localNodeInfo.last_processed_block` → current head height
+	  • `witnessSchedule(height)` → [{ account, bn }] — the producer per slot
+	  current producer = the slot with the latest `bn` ≤ head; the rest are "up next".
+	  Polls only the cheap head every 10s (the schedule is cached — slots advance
+	  ~every 30s), pausing while the tab is hidden. Avatars are direct Hive CDN
+	  images (no API call) so they add no load.
+
+	The committee + epoch (`electionByBlockHeight`) is secondary info in the
+	expandable, fetched once on mount.
 -->
 <script lang="ts">
-	import { CurrentElectionStore } from '$houdini';
+	import { NodeHeadStore, WitnessScheduleStore, CurrentElectionStore } from '$houdini';
 	import Card from '$lib/cards/Card.svelte';
-	import { getHiveAccountUrl, getVscExplorerUrl } from '$lib/constants';
-	import { Users } from '@lucide/svelte';
+	import { getHiveAccountUrl, getHiveAvatarUrl, getVscExplorerUrl } from '$lib/constants';
+	import { Boxes, ChevronRight } from '@lucide/svelte';
+
+	type Slot = { account: string; bn: number };
+
+	let head = $state<number | null>(null);
+	let schedule = $state<Slot[]>([]);
+	let prodLoad = $state<'loading' | 'loaded' | 'error'>('loading');
+	let prodError = $state('');
 
 	let epoch = $state<number | null>(null);
-	let validators = $state<string[]>([]);
-	let load = $state<'loading' | 'loaded' | 'error'>('loading');
-	let loadError = $state('');
+	let committee = $state<string[]>([]);
+	let committeeOpen = $state(false);
 
-	async function fetchValidators() {
+	const currentProducer = $derived.by<Slot | null>(() => {
+		if (head == null || schedule.length === 0) return null;
+		const past = schedule.filter((s) => s.bn <= head!);
+		return past.length ? past[past.length - 1] : null;
+	});
+	const upcoming = $derived(head == null ? [] : schedule.filter((s) => s.bn > head!).slice(0, 5));
+
+	// The schedule covers ~120 slots forward (~an hour), so it's stable — fetch it
+	// only when we have none or we've advanced past its end, NOT every tick.
+	async function fetchSchedule(height: number) {
+		const s = await new WitnessScheduleStore().fetch({
+			variables: { height },
+			policy: 'NetworkOnly'
+		});
+		if (s.errors?.length) throw new Error(s.errors[0].message);
+		schedule = (s.data?.witnessSchedule ?? [])
+			.filter((x): x is { account: string; bn: number } => x.account != null)
+			.map((x) => ({ account: x.account, bn: x.bn }))
+			.sort((a, b) => a.bn - b.bn);
+	}
+
+	// One poll: refresh the (cheap) head; only (re)fetch the schedule when needed.
+	// `busy` guards against overlapping requests piling up if a query is slow.
+	let busy = false;
+	async function tick() {
+		if (busy) return;
+		busy = true;
+		try {
+			const h = await new NodeHeadStore().fetch({ policy: 'NetworkOnly' });
+			if (h.errors?.length) throw new Error(h.errors[0].message);
+			const bh = h.data?.localNodeInfo?.last_processed_block;
+			if (bh == null) throw new Error('no head height');
+			head = bh;
+			const maxBn = schedule.length ? schedule[schedule.length - 1].bn : 0;
+			if (schedule.length === 0 || bh >= maxBn) await fetchSchedule(bh);
+			prodLoad = 'loaded';
+		} catch (e) {
+			prodError = e instanceof Error ? e.message : String(e);
+			prodLoad = 'error';
+		} finally {
+			busy = false;
+		}
+	}
+
+	async function fetchCommittee() {
 		try {
 			const res = await new CurrentElectionStore().fetch({ policy: 'NetworkOnly' });
-			if (res.errors?.length) throw new Error(res.errors[0].message);
 			const el = res.data?.electionByBlockHeight;
 			epoch = el?.epoch ?? null;
-			validators = (el?.members ?? []).map((m) => m.account);
-			load = 'loaded';
-		} catch (e) {
-			loadError = e instanceof Error ? e.message : String(e);
-			load = 'error';
+			committee = (el?.members ?? []).map((m) => m.account);
+		} catch {
+			/* committee is secondary info — ignore failures, the live feed still shows */
 		}
 	}
 
 	$effect(() => {
-		fetchValidators();
+		tick();
+		fetchCommittee();
 		let id: ReturnType<typeof setInterval> | undefined;
-		const start = () => (id ??= setInterval(fetchValidators, 30000));
+		// Head only — a slot changes ~every 30s, so 10s polling is plenty live and
+		// cheap (the heavy schedule query is cached, not re-fetched each tick).
+		const start = () => (id ??= setInterval(tick, 10000));
 		const stop = () => {
 			clearInterval(id);
 			id = undefined;
 		};
-		// Pause while the tab is hidden; refresh on return.
 		const onVisibility = () => {
 			if (document.hidden) stop();
 			else {
-				fetchValidators();
+				tick();
 				start();
 			}
 		};
@@ -62,27 +114,80 @@
 
 <Card>
 	<div class="head">
-		<h3>
-			<Users size={18} />
-			Current validators
-			{#if epoch !== null}<span class="epoch">epoch {epoch}</span>{/if}
-		</h3>
+		<h3><Boxes size={18} /> Block production</h3>
 		<a class="live-link" href={getVscExplorerUrl()} target="_blank" rel="noopener">Live blocks ↗</a>
 	</div>
 
-	{#if load === 'loading'}
-		<p class="empty">Loading validators…</p>
-	{:else if load === 'error'}
-		<p class="empty error">Couldn't load validators: {loadError}</p>
-	{:else if validators.length === 0}
-		<p class="empty">No active committee right now.</p>
-	{:else}
-		<div class="validators">
-			{#each validators as v (v)}
-				<a class="validator" href={getHiveAccountUrl(v)} target="_blank" rel="noopener">@{v}</a>
-			{/each}
+	{#if prodLoad === 'error'}
+		<p class="empty error">Couldn't load the schedule: {prodError}</p>
+	{:else if currentProducer}
+		<div class="now">
+			<span class="now-dot" title="live"></span>
+			<span class="now-label">Now producing</span>
+			<a
+				class="now-account"
+				href={getHiveAccountUrl(currentProducer.account)}
+				target="_blank"
+				rel="noopener"
+			>
+				<img
+					class="avatar avatar-lg"
+					src={getHiveAvatarUrl(currentProducer.account)}
+					alt=""
+					loading="lazy"
+				/>@{currentProducer.account}</a
+			>
+			<span class="now-bn">block {currentProducer.bn}</span>
 		</div>
-		<p class="count">{validators.length} witnesses securing the network this epoch.</p>
+		{#if upcoming.length}
+			<div class="upnext">
+				<span class="upnext-label">Up next</span>
+				<span class="upnext-chain">
+					{#each upcoming as s, i (s.bn)}
+						{#if i > 0}<span class="arrow">→</span>{/if}
+						<a
+							href={getHiveAccountUrl(s.account)}
+							target="_blank"
+							rel="noopener"
+							title="block {s.bn}"
+						>
+							<img
+								class="avatar"
+								src={getHiveAvatarUrl(s.account)}
+								alt=""
+								loading="lazy"
+							/>@{s.account}</a
+						>
+					{/each}
+				</span>
+			</div>
+		{/if}
+	{:else}
+		<p class="empty">Loading block schedule…</p>
+	{/if}
+
+	<button
+		class="committee-toggle"
+		class:open={committeeOpen}
+		onclick={() => (committeeOpen = !committeeOpen)}
+	>
+		<ChevronRight size={14} />
+		Validators this epoch{#if committee.length}&nbsp;({committee.length}){/if}{#if epoch !== null}&nbsp;·
+			epoch
+			{epoch}{/if}
+	</button>
+	{#if committeeOpen}
+		{#if committee.length}
+			<div class="validators">
+				{#each committee as v (v)}
+					<a class="validator" href={getHiveAccountUrl(v)} target="_blank" rel="noopener">
+						<img class="avatar" src={getHiveAvatarUrl(v)} alt="" loading="lazy" />@{v}</a
+					>
+				{/each}
+			</div>
+		{:else}
+			<p class="empty">Loading committee…</p>
+		{/if}
 	{/if}
 </Card>
 
@@ -102,16 +207,6 @@
 		font-size: 1.05rem;
 		font-family: 'Nunito Sans', sans-serif;
 	}
-	.epoch {
-		font-size: 0.7rem;
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-		color: var(--dash-text-secondary);
-		background: rgba(255, 255, 255, 0.06);
-		padding: 0.12rem 0.45rem;
-		border-radius: 6px;
-	}
 	.live-link {
 		font-size: 0.8rem;
 		color: var(--dash-accent-purple, #b0acff);
@@ -122,12 +217,138 @@
 	.live-link:hover {
 		text-decoration: underline;
 	}
+
+	/* ── Now producing ── */
+	.now {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+		flex-wrap: wrap;
+	}
+	.now-dot {
+		width: 0.55rem;
+		height: 0.55rem;
+		border-radius: 50%;
+		background: var(--dash-accent-green, #8fdc9b);
+		box-shadow: 0 0 0 0 rgba(143, 220, 155, 0.6);
+		animation: pulse 1.8s ease-out infinite;
+		flex-shrink: 0;
+	}
+	@keyframes pulse {
+		0% {
+			box-shadow: 0 0 0 0 rgba(143, 220, 155, 0.5);
+		}
+		70% {
+			box-shadow: 0 0 0 6px rgba(143, 220, 155, 0);
+		}
+		100% {
+			box-shadow: 0 0 0 0 rgba(143, 220, 155, 0);
+		}
+	}
+	.now-label {
+		font-size: 0.72rem;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--dash-text-secondary);
+	}
+	.now-account {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		font-size: 1.05rem;
+		font-weight: 600;
+		font-family: 'Noto Sans Mono', monospace;
+		color: var(--dash-text-primary);
+		text-decoration: none;
+	}
+	/* Lightweight inline avatars (direct Hive CDN — no API call). */
+	.avatar {
+		width: 16px;
+		height: 16px;
+		border-radius: 50%;
+		object-fit: cover;
+		flex-shrink: 0;
+		background: rgba(255, 255, 255, 0.08);
+	}
+	.avatar-lg {
+		width: 22px;
+		height: 22px;
+	}
+	.now-account:hover {
+		color: #b0acff;
+	}
+	.now-bn {
+		font-size: 0.72rem;
+		color: var(--dash-text-muted);
+	}
+	.upnext {
+		display: flex;
+		align-items: baseline;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+		margin-top: 0.55rem;
+		font-size: 0.82rem;
+	}
+	.upnext-label {
+		font-size: 0.72rem;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--dash-text-secondary);
+	}
+	.upnext-chain {
+		display: flex;
+		align-items: center;
+		gap: 0.35rem;
+		flex-wrap: wrap;
+		font-family: 'Noto Sans Mono', monospace;
+		a {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.3rem;
+			color: var(--dash-text-primary);
+			text-decoration: none;
+		}
+		a:hover {
+			color: #b0acff;
+		}
+		.arrow {
+			color: var(--dash-text-muted);
+		}
+	}
+
+	/* ── Expandable committee ── */
+	.committee-toggle {
+		display: flex;
+		align-items: center;
+		gap: 0.3rem;
+		margin-top: 1rem;
+		padding: 0.35rem 0;
+		background: none;
+		border: none;
+		color: var(--dash-text-secondary);
+		font: inherit;
+		font-size: 0.82rem;
+		cursor: pointer;
+		:global(svg) {
+			transition: transform 150ms ease;
+		}
+	}
+	.committee-toggle:hover {
+		color: var(--dash-text-primary);
+	}
+	.committee-toggle.open :global(svg) {
+		transform: rotate(90deg);
+	}
 	.validators {
 		display: flex;
 		flex-wrap: wrap;
 		gap: 0.4rem;
+		margin-top: 0.4rem;
 	}
 	.validator {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
 		font-size: 0.8rem;
 		font-family: 'Noto Sans Mono', monospace;
 		color: var(--dash-text-primary);
@@ -140,11 +361,6 @@
 	.validator:hover {
 		border-color: var(--dash-accent-purple, #6f6af8);
 		color: #b0acff;
-	}
-	.count {
-		margin: 0.65rem 0 0;
-		font-size: 0.78rem;
-		color: var(--dash-text-secondary);
 	}
 	.empty {
 		margin: 0;

--- a/src/routes/(authed)/witness-assistant/GovernanceProposals.svelte
+++ b/src/routes/(authed)/witness-assistant/GovernanceProposals.svelte
@@ -22,6 +22,7 @@
 	import { Landmark, Loader2, Check } from '@lucide/svelte';
 	import { CoinAmount } from '$lib/currency/CoinAmount';
 	import { Coin } from '$lib/sendswap/utils/sendOptions';
+	import { getHiveExplorerTxUrl } from '$lib/constants';
 	import WaveLoading from '$lib/components/WaveLoading.svelte';
 
 	type Proposal = FindGovernanceProposals$result['findGovernanceProposals'][number];
@@ -90,6 +91,43 @@
 			});
 	}
 
+	// ── Past proposals (read-only history) ──
+	// Same query, no `byStatus` filter → returns ALL proposals newest-first; we
+	// keep the settled/expired ones and paginate via limit/offset (there's no
+	// height param — load in blocks, per milo). Visible to everyone, no voting.
+	const HISTORY_PAGE = 10;
+	let pastProposals = $state<Proposal[]>([]);
+	let historyOffset = $state(0);
+	let historyLoad = $state<'loading' | 'loaded' | 'error'>('loading');
+	let historyError = $state('');
+	let historyHasMore = $state(false);
+	let historyLoading = $state(false);
+
+	async function fetchHistory(reset = false) {
+		if (historyLoading) return;
+		historyLoading = true;
+		const offset = reset ? 0 : historyOffset;
+		try {
+			const res = await new FindGovernanceProposalsStore().fetch({
+				variables: { filterOptions: { limit: HISTORY_PAGE, offset } },
+				policy: 'NetworkOnly'
+			});
+			if (res.errors?.length) throw new Error(res.errors[0].message);
+			const page = res.data?.findGovernanceProposals ?? [];
+			// Open proposals live in the votable section above — keep only closed.
+			const closed = page.filter((p) => p.status !== 'open');
+			pastProposals = reset ? closed : [...pastProposals, ...closed];
+			historyOffset = offset + page.length;
+			historyHasMore = page.length === HISTORY_PAGE; // full page → maybe more
+			historyLoad = 'loaded';
+		} catch (e) {
+			historyError = e instanceof Error ? e.message : String(e);
+			historyLoad = 'error';
+		} finally {
+			historyLoading = false;
+		}
+	}
+
 	// One poll tick: refresh proposals, and keep retrying the election fetch
 	// until the committee loads (so a transient failure self-heals).
 	function tick() {
@@ -99,6 +137,7 @@
 
 	$effect(() => {
 		tick();
+		fetchHistory(true); // history is fetched once (not polled); paginated on demand
 		let intervalId: ReturnType<typeof setInterval> | undefined;
 		const start = () => (intervalId ??= setInterval(tick, 2000));
 		const stop = () => {
@@ -153,8 +192,10 @@
 			return;
 		}
 		voteState[p.proposalId] = { busy: false, status: 'Vote broadcasted!', error: '' };
-		// Refetch so the new vote (and any resulting status change) is reflected.
+		// Refetch so the new vote (and any resulting status change) is reflected —
+		// including history, since this vote may have just settled the proposal.
 		fetchProposals();
+		fetchHistory(true);
 	}
 
 	function shortId(id: string): string {
@@ -265,6 +306,68 @@
 			{/each}
 		</ul>
 	{/if}
+
+	<!-- Past proposals — read-only history (settled / expired), visible to all,
+	     paginated on demand. No vote action. -->
+	<div class="history">
+		<h4 class="history-title">Past proposals</h4>
+		{#if historyLoad === 'loading' && pastProposals.length === 0}
+			<p class="empty loading"><WaveLoading />Loading history…</p>
+		{:else if historyLoad === 'error' && pastProposals.length === 0}
+			<p class="empty error">Couldn't load past proposals: {historyError}</p>
+		{:else if pastProposals.length === 0}
+			<p class="empty">No past proposals yet.</p>
+		{:else}
+			<ul class="list">
+				{#each pastProposals as p (p.proposalId)}
+					<li class="row">
+						<div class="row-main">
+							<div class="row-head">
+								<span class="kind kind-{p.type}">{typeLabel(p.type)}</span>
+								<strong class="amount"
+									>{new CoinAmount(p.amount, Coin.hive, true).toPrettyString()}</strong
+								>
+								<span class="outcome outcome-{p.status}"
+									>{p.status === 'applied' ? 'Approved' : 'Expired'}</span
+								>
+							</div>
+							<div class="row-meta">
+								{#if p.type === 'reserve_payout'}
+									<span>to <code>@{p.recipient}</code></span>
+								{:else if p.type === 'slash_restore'}
+									<span>restore <code>@{p.slashedAccount}</code></span>
+								{/if}
+								<span class="dot">·</span>
+								<span>{p.votes.length} vote{p.votes.length === 1 ? '' : 's'}</span>
+								{#if p.appliedBlock}<span class="dot">·</span><span>block {p.appliedBlock}</span
+									>{/if}
+								{#if p.appliedTxId}
+									<span class="dot">·</span>
+									<a
+										class="explorer-link"
+										href={getHiveExplorerTxUrl(p.appliedTxId)}
+										target="_blank"
+										rel="noopener">view tx ↗</a
+									>
+								{/if}
+							</div>
+						</div>
+					</li>
+				{/each}
+			</ul>
+			{#if historyHasMore}
+				<div class="more-button">
+					<PillButton
+						styleType="text-subtle"
+						disabled={historyLoading}
+						onclick={() => fetchHistory()}
+					>
+						<span class="sm-caption">{historyLoading ? 'Loading…' : 'Load more'}</span>
+					</PillButton>
+				</div>
+			{/if}
+		{/if}
+	</div>
 </Card>
 
 <style lang="scss">
@@ -347,6 +450,44 @@
 	.kind.kind-slash_restore {
 		background: rgba(230, 150, 60, 0.22);
 		color: #ffc48a;
+	}
+	/* ── Past proposals (history) ── */
+	.history {
+		margin-top: 1.5rem;
+		padding-top: 1.25rem;
+		border-top: 1px solid rgba(255, 255, 255, 0.08);
+	}
+	.history-title {
+		margin: 0 0 0.75rem;
+		font-size: 0.95rem;
+		font-weight: 600;
+		font-family: 'Nunito Sans', sans-serif;
+		color: var(--dash-text-primary);
+	}
+	.outcome {
+		font-size: 0.66rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		padding: 0.18rem 0.5rem;
+		border-radius: 4px;
+		margin-left: auto;
+	}
+	.outcome-applied {
+		background: rgba(143, 220, 155, 0.18);
+		color: #8fdc9b;
+	}
+	.outcome-expired {
+		background: rgba(255, 255, 255, 0.08);
+		color: var(--dash-text-muted);
+	}
+	.explorer-link {
+		color: var(--dash-accent-purple, #b0acff);
+		text-decoration: none;
+		white-space: nowrap;
+	}
+	.explorer-link:hover {
+		text-decoration: underline;
 	}
 	.row-meta {
 		display: flex;

--- a/src/routes/(authed)/witness-assistant/NodeHead.gql
+++ b/src/routes/(authed)/witness-assistant/NodeHead.gql
@@ -1,0 +1,5 @@
+query NodeHead {
+	localNodeInfo {
+		last_processed_block
+	}
+}

--- a/src/routes/(authed)/witness-assistant/WitnessSchedule.gql
+++ b/src/routes/(authed)/witness-assistant/WitnessSchedule.gql
@@ -1,0 +1,6 @@
+query WitnessSchedule($height: Uint64!) {
+	witnessSchedule(height: $height) {
+		account
+		bn
+	}
+}


### PR DESCRIPTION
## Summary

Two additions to the **Witness Assistant** page, released as **0.3.33**.

### 1. Live block-production feed (new "Block production" card, leads the page)
- Real-time **"Now producing @account · block N"** hero + an **"Up next"** chain, with **validator avatars** for quick identification.
- Built **entirely first-party** on `api.vsc.eco` — no third-party explorer dependency:
  - head from `localNodeInfo.last_processed_block`, mapped against the per-slot producer schedule `witnessSchedule(height)`.
- Full elected committee + epoch (`electionByBlockHeight`) in an **expandable** below.
- **Built to sit open all day:** only the tiny head field is polled (every 10s); the ~120-slot schedule is cached and re-fetched only when exhausted (~hourly); an in-flight guard prevents request pile-up; polling pauses on hidden tab; avatars are direct Hive-CDN images (no API calls).
- Read-only, visible to everyone.
- Required a `schema.graphql` re-pull to pick up the `witnessSchedule` / `localNodeInfo` types.

### 2. Governance proposal history (read-only)
- New **"Past proposals"** section in the governance panel: settled reserve-payout + slash-restoration proposals, paginated.
- Each row: type / amount / recipient, an **Approved / Expired** badge, vote count, applied block, and a **"view tx ↗"** link to hivehub (proposals settle as Hive txs).
- Complements the existing open-proposal voting; visible to Hive witnesses.

## Commits
- `feat(governance)`: read-only Past proposals history section
- `feat(witness)`: current-validators box
- `feat(witness)`: real-time block-production feed with avatars; committee expandable
- `style(witness)`: live hero panel (skeleton, formatted block #, reduced-motion)
- `chore(release)`: 0.3.33

## Verification
- `svelte-check` at baseline (no new errors in the changed files), prettier clean.
- Empirically confirmed `witnessSchedule(height)` + `localNodeInfo.last_processed_block` are first-party on `api.vsc.eco` and fast (~0.45s each).

## Test plan
- Witness Assistant → **Block production** card: hero shows current producer + advances over ~30s; "Up next" chain renders; expand **"Validators this epoch"** for the committee; avatars + hivehub links work; "Live blocks ↗" → explorer.
- Governance panel → **Past proposals**: settled rows render with correct badges + tx links; "Load more" paginates.
- Leave the page open a while → stays responsive (head-only polling, cached schedule).