### PR TITLE
fix(auth): keep BTC/EVM wallet users logged in across refresh (0.3.34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to Altera are documented here.
 > CI / build-banner / release-script use, and so a glance at `package.json`
 > matches reality.
 
+## [0.3.34] — 2026-07-02
+
+### Fixes
+
+- **Refreshing an authed page no longer logs out wallet (BTC/EVM) users.** On a hard reload the in-memory reown (WalletConnect/AppKit) session is gone and `initModal()` is only created on demand, so the `(authed)` route guard saw reown `none` and redirected to `/login` before AppKit could reconnect — bouncing anyone signed in with a Bitcoin or EVM wallet to login on every refresh. AppKit _can_ silently reconnect a cached session (confirmed from a live state-machine trace: `initModal()` → `subscribeAccount` fires `connecting → connected`, no wallet prompt), but it's async, and the guard resolved on the initial `none`. The guard now detects a prior reown session (`last_connection === 'reown'` and reown currently `none`), marks auth `pending`, and starts the reconnect _before_ the auth check — so it waits for the reconnect to settle (`authenticated`, or a real `none`) instead of bouncing, with a 10s timeout so it can't hang. Also: removed the localhost auth-guard bypass (a dev shortcut that had hidden this bug by skipping the guard entirely on `localhost`), treated AppKit's `reconnecting` status as `pending`, and extracted the auth-wait logic into a testable `waitForAuth` helper — fixing a subscription leak in it (a synchronous first emission called `unsubscribe()` on the no-op placeholder, leaking the real `authStore` subscription) with regression tests proven to fail without the fix.
+
 ## [0.3.33] — 2026-06-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.3.33",
+	"version": "0.3.34",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {

--- a/src/lib/auth/reown/index.ts
+++ b/src/lib/auth/reown/index.ts
@@ -16,8 +16,7 @@ import { getAddress } from 'viem';
 // 1. Get a project ID at https://cloud.reown.com
 // APP-16: read from PUBLIC_REOWN_PROJECT_ID when set; fall back to the
 // previous literal so the app still works without the env var configured.
-export const projectId =
-	publicEnv.PUBLIC_REOWN_PROJECT_ID || '55a54e098e74ddb214919fe0da4ac384';
+export const projectId = publicEnv.PUBLIC_REOWN_PROJECT_ID || '55a54e098e74ddb214919fe0da4ac384';
 
 // Mainnet-first for BTC so Xverse (which defaults to Mainnet) doesn't
 // get handed a testnet network it isn't configured for when the
@@ -84,9 +83,7 @@ export function initModal() {
 						provider: 'reown',
 						did: value.caipAddress?.startsWith('bip122:')
 							? `did:pkh:bip122:${
-									isBtcTestnetAddress(value.address!)
-										? BTC_TESTNET_CAIP
-										: BTC_MAINNET_CAIP
+									isBtcTestnetAddress(value.address!) ? BTC_TESTNET_CAIP : BTC_MAINNET_CAIP
 								}:${value.address!}`
 							: `did:pkh:eip155:1:${getAddress(value.address!)}`,
 						openSettings: () => modal!.open()
@@ -95,7 +92,7 @@ export function initModal() {
 				if (get(loginRetry) !== 'logout') {
 					loginRetry.set('retry');
 				}
-			} else if (value.status == 'connecting') {
+			} else if (value.status == 'connecting' || value.status == 'reconnecting') {
 				_reownAuthStore.set({
 					status: 'pending'
 				});
@@ -104,7 +101,9 @@ export function initModal() {
 					status: 'none'
 				});
 			}
-		} catch {}
+		} catch {
+			/* transient AppKit account-callback errors are non-fatal */
+		}
 	});
 }
 

--- a/src/lib/auth/waitForAuth.test.ts
+++ b/src/lib/auth/waitForAuth.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { writable, type Readable, type Subscriber } from 'svelte/store';
+import type { Auth } from './store';
+
+// waitForAuth's `!browser` branch would short-circuit (resolve on the first
+// emission regardless of status) under the node/server env where browser=false.
+// Pin browser=true so the test exercises the real client behaviour.
+vi.mock('$app/environment', () => ({ browser: true }));
+
+import { waitForAuth } from './waitForAuth';
+
+const authed: Auth = {
+	status: 'authenticated',
+	value: {
+		address: '0x1',
+		did: 'did:pkh:eip155:1:0x1',
+		provider: 'reown',
+		logout: async () => {},
+		openSettings: () => {}
+	}
+};
+const none: Auth = { status: 'none' };
+const pending: Auth = { status: 'pending' };
+
+/** A store that tracks its live subscriber count, so we can prove waitForAuth
+ *  always unsubscribes (no leak) — including on a synchronous resolve. */
+function trackedStore(initial: Auth) {
+	const inner = writable<Auth>(initial);
+	let liveSubs = 0;
+	const store: Readable<Auth> & { set: (v: Auth) => void; liveSubs: () => number } = {
+		set: inner.set,
+		liveSubs: () => liveSubs,
+		subscribe(run: Subscriber<Auth>) {
+			liveSubs++;
+			const unsub = inner.subscribe(run);
+			return () => {
+				liveSubs--;
+				unsub();
+			};
+		}
+	};
+	return store;
+}
+
+describe('waitForAuth', () => {
+	it('resolves with the value when already authenticated (synchronous)', async () => {
+		const store = trackedStore(authed);
+		const result = await waitForAuth(store);
+		expect(result).not.toBe(false);
+		expect((result as Auth).status).toBe('authenticated');
+		expect(store.liveSubs()).toBe(0); // no leaked subscription
+	});
+
+	it('resolves false when already none (synchronous) — and does NOT leak', async () => {
+		// This is the regression test for the sync-subscribe leak: without the
+		// `if (settled) unsubscribe()` guard, liveSubs would stay at 1.
+		const store = trackedStore(none);
+		const result = await waitForAuth(store);
+		expect(result).toBe(false);
+		expect(store.liveSubs()).toBe(0);
+	});
+
+	it('waits through pending, then resolves on authenticated', async () => {
+		const store = trackedStore(pending);
+		const p = waitForAuth(store);
+		store.set(authed);
+		const result = await p;
+		expect((result as Auth).status).toBe('authenticated');
+		expect(store.liveSubs()).toBe(0);
+	});
+
+	it('waits through pending, then resolves false on none', async () => {
+		const store = trackedStore(pending);
+		const p = waitForAuth(store);
+		store.set(none);
+		const result = await p;
+		expect(result).toBe(false);
+		expect(store.liveSubs()).toBe(0);
+	});
+
+	it('times out to false when it never settles', async () => {
+		vi.useFakeTimers();
+		try {
+			const store = trackedStore(pending);
+			const p = waitForAuth(store, 5000);
+			await vi.advanceTimersByTimeAsync(5000);
+			const result = await p;
+			expect(result).toBe(false);
+			expect(store.liveSubs()).toBe(0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/src/lib/auth/waitForAuth.ts
+++ b/src/lib/auth/waitForAuth.ts
@@ -1,0 +1,41 @@
+import { browser } from '$app/environment';
+import type { Readable } from 'svelte/store';
+import type { Auth } from './store';
+
+/**
+ * Resolve once the auth store settles: the `Auth` value on `authenticated`, or
+ * `false` on `none`. `pending` keeps waiting — that's what lets the (authed)
+ * route guard sit through an in-flight reown reconnect instead of bouncing on
+ * the initial `none`. Times out to `false` so a reconnect that never settles
+ * can't hang the guard.
+ *
+ * Extracted from the route guard so it's unit-testable in isolation.
+ */
+export function waitForAuth(store: Readable<Auth>, timeoutMs = 10000): Promise<Auth | false> {
+	return new Promise<Auth | false>((resolve) => {
+		let unsubscribe: () => void = () => {};
+		let settled = false;
+		const finish = (v: Auth | false) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			resolve(v);
+			unsubscribe();
+		};
+		const timer = setTimeout(() => finish(false), timeoutMs);
+		const handle = (v: Auth) => {
+			if (v.status === 'authenticated' || !browser) {
+				finish(v);
+			} else if (v.status === 'none') {
+				finish(false);
+			}
+			// 'pending' → keep waiting
+		};
+		unsubscribe = store.subscribe(handle);
+		// Svelte calls `handle` synchronously during subscribe with the current
+		// value. If that already resolved, `unsubscribe` above was still the no-op
+		// placeholder — clean up the now-assigned real subscription here so it
+		// doesn't leak.
+		if (settled) unsubscribe();
+	});
+}

--- a/src/routes/(authed)/+layout.ts
+++ b/src/routes/(authed)/+layout.ts
@@ -1,31 +1,39 @@
 import { browser } from '$app/environment';
-import { authStore, type Auth } from '$lib/auth/store';
+import { get } from 'svelte/store';
+import { authStore, type Auth, _reownAuthStore } from '$lib/auth/store';
 import { redirect } from '@sveltejs/kit';
-import '$lib/auth/reown';
+import { initModal } from '$lib/auth/reown';
 import '$lib/auth/hive';
 
 export const ssr = false;
 export const prerender = false;
 
-function isAuthenticated(): Promise<Auth | false> {
-	const out = new Promise<Auth | false>((resolve) => {
+// Wait for auth to settle: resolve on the first 'authenticated' (→ the value)
+// or 'none' (→ false). 'pending' keeps waiting — that's what lets the guard sit
+// through an in-flight reown reconnect instead of bouncing on the initial none.
+// The timeout guards against a reconnect that never settles so we can't hang.
+function isAuthenticated(timeoutMs = 10000): Promise<Auth | false> {
+	return new Promise<Auth | false>((resolve) => {
 		let unsubscribe: () => void = () => {};
-
-		const handle = (v: Auth | { status: 'none', value: undefined }) => {
-			if (v.status === 'authenticated' || !browser) {
-				// APP-15: removed console.log that leaked authenticated auth value.
-				resolve(v);
-				unsubscribe();
-			} else if (v.status === 'none') {
-				resolve(false);
-				unsubscribe();
-			}
+		let settled = false;
+		const finish = (v: Auth | false) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			resolve(v);
+			unsubscribe();
 		};
-
+		const timer = setTimeout(() => finish(false), timeoutMs);
+		const handle = (v: Auth) => {
+			if (v.status === 'authenticated' || !browser) {
+				finish(v);
+			} else if (v.status === 'none') {
+				finish(false);
+			}
+			// 'pending' → keep waiting
+		};
 		unsubscribe = authStore.subscribe(handle);
-
 	});
-	return out;
 }
 
 export async function load({ url }) {
@@ -33,10 +41,32 @@ export async function load({ url }) {
 		return { auth: { status: 'pending' } as Auth };
 	}
 	// Skip auth check on localhost for development
-	const isLocalhost = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+	const isLocalhost =
+		window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
 	if (isLocalhost) {
 		return { auth: { status: 'none' } as Auth };
 	}
+
+	// A hard reload wipes the in-memory reown (BTC/EVM) session, and initModal()
+	// is otherwise only created on demand — so the guard would see reown 'none'
+	// and bounce the user to /login before AppKit could reconnect. AppKit CAN
+	// silently reconnect a cached session (verified: initModal() → subscribeAccount
+	// fires connecting → connected, no wallet prompt), but it's async. So when the
+	// user last connected a reown wallet, mark reown 'pending' and start the
+	// reconnect BEFORE the auth check — the guard then waits for it to resolve
+	// (authenticated, or a settled none) instead of bouncing on the initial none.
+	// Guard on reown === 'none' so this only fires when there's no in-memory
+	// session (a hard reload) — not on client-side navigation where reown is
+	// already 'authenticated' (setting it 'pending' there would strand it, since
+	// initModal() no-ops when the modal already exists and won't re-fire).
+	if (
+		localStorage.getItem('last_connection') === 'reown' &&
+		get(_reownAuthStore).status === 'none'
+	) {
+		_reownAuthStore.set({ status: 'pending' });
+		initModal();
+	}
+
 	const authed = await isAuthenticated();
 	if (!authed && url.pathname != '/login') {
 		localStorage.setItem('redirect_url', url.toString());

--- a/src/routes/(authed)/+layout.ts
+++ b/src/routes/(authed)/+layout.ts
@@ -4,38 +4,11 @@ import { authStore, type Auth, _reownAuthStore } from '$lib/auth/store';
 import { redirect } from '@sveltejs/kit';
 import type { LayoutLoad } from './$types';
 import { initModal } from '$lib/auth/reown';
+import { waitForAuth } from '$lib/auth/waitForAuth';
 import '$lib/auth/hive';
 
 export const ssr = false;
 export const prerender = false;
-
-// Wait for auth to settle: resolve on the first 'authenticated' (→ the value)
-// or 'none' (→ false). 'pending' keeps waiting — that's what lets the guard sit
-// through an in-flight reown reconnect instead of bouncing on the initial none.
-// The timeout guards against a reconnect that never settles so we can't hang.
-function isAuthenticated(timeoutMs = 10000): Promise<Auth | false> {
-	return new Promise<Auth | false>((resolve) => {
-		let unsubscribe: () => void = () => {};
-		let settled = false;
-		const finish = (v: Auth | false) => {
-			if (settled) return;
-			settled = true;
-			clearTimeout(timer);
-			resolve(v);
-			unsubscribe();
-		};
-		const timer = setTimeout(() => finish(false), timeoutMs);
-		const handle = (v: Auth) => {
-			if (v.status === 'authenticated' || !browser) {
-				finish(v);
-			} else if (v.status === 'none') {
-				finish(false);
-			}
-			// 'pending' → keep waiting
-		};
-		unsubscribe = authStore.subscribe(handle);
-	});
-}
 
 export const load: LayoutLoad = async ({ url }) => {
 	if (!browser) {
@@ -62,7 +35,7 @@ export const load: LayoutLoad = async ({ url }) => {
 		initModal();
 	}
 
-	const authed = await isAuthenticated();
+	const authed = await waitForAuth(authStore);
 	if (!authed && url.pathname !== '/login') {
 		localStorage.setItem('redirect_url', url.toString());
 		throw redirect(307, '/login');

--- a/src/routes/(authed)/+layout.ts
+++ b/src/routes/(authed)/+layout.ts
@@ -2,6 +2,7 @@ import { browser } from '$app/environment';
 import { get } from 'svelte/store';
 import { authStore, type Auth, _reownAuthStore } from '$lib/auth/store';
 import { redirect } from '@sveltejs/kit';
+import type { LayoutLoad } from './$types';
 import { initModal } from '$lib/auth/reown';
 import '$lib/auth/hive';
 
@@ -36,15 +37,9 @@ function isAuthenticated(timeoutMs = 10000): Promise<Auth | false> {
 	});
 }
 
-export async function load({ url }) {
+export const load: LayoutLoad = async ({ url }) => {
 	if (!browser) {
 		return { auth: { status: 'pending' } as Auth };
-	}
-	// Skip auth check on localhost for development
-	const isLocalhost =
-		window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
-	if (isLocalhost) {
-		return { auth: { status: 'none' } as Auth };
 	}
 
 	// A hard reload wipes the in-memory reown (BTC/EVM) session, and initModal()
@@ -68,9 +63,9 @@ export async function load({ url }) {
 	}
 
 	const authed = await isAuthenticated();
-	if (!authed && url.pathname != '/login') {
+	if (!authed && url.pathname !== '/login') {
 		localStorage.setItem('redirect_url', url.toString());
-		redirect(307, '/login');
+		throw redirect(307, '/login');
 	}
 	return { auth: authed };
-}
+};


### PR DESCRIPTION
## Summary

Refreshing any authed page logged out **wallet (BTC/EVM) users** and bounced them to `/login`. This fixes the root cause and hardens the auth guard.

## Root cause

On a hard reload the in-memory reown (WalletConnect/AppKit) session is gone, and `initModal()` is only created on demand — so the `(authed)` route guard saw reown `none` and redirected to `/login` **before** AppKit could reconnect. A live state-machine trace confirmed the race: the guard resolved on the initial `none` ~1s before `subscribeAccount` fired `connecting → connected`.

Crucially, the trace also proved AppKit **silently reconnects** a cached session (`initModal()` → `connecting → connected`, **no wallet prompt**) — so the fix uses the real reconnection, not an optimistic guess.

## The fix

- The guard now detects a prior reown session (`last_connection === 'reown'` **and** reown currently `none` — so it only fires on a reload, never strands an already-authenticated client-side navigation), marks auth `pending`, and starts the reconnect **before** the auth check.
- The auth wait now sits through `pending` and resolves only on `authenticated` / a settled `none`, with a **10s timeout** so it can't hang.
- Treated AppKit's `reconnecting` status as `pending` (was falling through to `none`).
- **Removed the localhost auth-guard bypass** — a dev shortcut that had hidden this bug by skipping the guard entirely on `localhost`.
- Extracted the wait logic into a testable `waitForAuth` helper and **fixed a subscription leak** in it (a synchronous first emission called `unsubscribe()` on the no-op placeholder, leaking the real `authStore` subscription).

## Tests

- New `waitForAuth.test.ts` — 5 cases (sync authenticated / none, pending→authenticated, pending→none, timeout), each asserting **no leaked subscriber**. Proven to fail without the leak fix.
- Full suite green: **358 passed**, 0 failed.

## Test plan (smoke, verified ✅)

- Log in with EVM/Phantom → hard-refresh → stays logged in, no `/login` bounce, no wallet popup.
- Navigate between authed pages → stays logged in.
- Log out → `/login` → refresh → stays logged out.
- Logged out → direct authed URL → redirected to `/login`.
- Post-refresh EVM send signs and completes.