### PR TITLE
feat(dashboard): Magi/Wallet balance toggle on the Balance card

### DIFF
--- a/src/lib/cards/Balance/Balance.svelte
+++ b/src/lib/cards/Balance/Balance.svelte
@@ -8,6 +8,12 @@
 	import { goto } from '$app/navigation';
 	import QuickSend from '$lib/sendswap/QuickSend.svelte';
 	import { getTxSessionId } from '$lib/sendswap/utils/sendUtils';
+	import {
+		fetchConnectedWalletBalances,
+		type WalletBalance
+	} from '$lib/cards/ConnectedWallet/connectedWalletBalances';
+	import { CoinAmount } from '$lib/currency/CoinAmount';
+	import { Coin, Network } from '$lib/sendswap/utils/sendOptions';
 
 	let auth = $derived(getAuth()());
 	let did = $derived(auth.value?.did);
@@ -18,10 +24,28 @@
 			: 0
 	);
 
+	let quickSendOpen = $state(false);
+	let sendSessionId = $state(getTxSessionId());
+	let toggleQuickSend = $state<(open?: boolean) => void>(() => {});
+
+	// Magi vs. connected-wallet balances, toggled in-place (no extra card).
+	type BalTab = 'magi' | 'wallet';
+	let activeTab = $state<BalTab>('magi');
+	let walletBalances = $state<WalletBalance[]>([]);
+	let walletTotalUsd = $state(0);
+	let walletLoading = $state(false);
+	let walletError = $state(false);
+	// Lazily fetch the connected wallet's on-chain (Hive L1 / EVM / BTC) balances
+	// the first time the Wallet tab is opened; refetch if the account changes.
+	let walletFetchedFor = $state<string | undefined>(undefined);
+
+	// The headline $ amount tracks the active tab: Magi total vs. connected-wallet
+	// total (falls back to the Magi figure while the wallet total is still loading).
+	let displayValue = $derived(activeTab === 'wallet' && !walletLoading ? walletTotalUsd : balance);
 	// Derive dollars and cents from the same rounded integer so a cents field
 	// that rounds up to 100 (e.g. balance = 999.999) correctly bumps the dollar
 	// digit instead of displaying "$999.100".
-	let totalCents = $derived(Math.round(balance * 100));
+	let totalCents = $derived(Math.round(displayValue * 100));
 	let dollars = $derived(Math.floor(totalCents / 100));
 	let cents = $derived(
 		new Intl.NumberFormat('en-US', {
@@ -30,9 +54,81 @@
 		}).format(totalCents % 100)
 	);
 
-	let quickSendOpen = $state(false);
-	let sendSessionId = $state(getTxSessionId());
-	let toggleQuickSend = $state<(open?: boolean) => void>(() => {});
+	async function selectTab(tab: BalTab) {
+		activeTab = tab;
+		if (tab !== 'wallet') return;
+		const key = auth.value?.did;
+		if (!key || walletFetchedFor === key) return; // already loaded for this account
+		walletFetchedFor = key;
+		walletLoading = true;
+		walletError = false;
+		try {
+			const bals = await fetchConnectedWalletBalances(auth);
+			walletBalances = bals;
+			walletTotalUsd = await sumWalletUsd(bals);
+		} catch {
+			walletError = true;
+		} finally {
+			walletLoading = false;
+		}
+	}
+
+	// Sum the wallet's balances in USD. HIVE/HBD/BTC price via CoinAmount; native
+	// ETH isn't a Coin, so it's priced separately via CoinGecko (as MarketPrices does).
+	const coinForSymbol = (s: string) =>
+		s === 'HIVE' ? Coin.hive : s === 'HBD' ? Coin.hbd : s === 'BTC' ? Coin.btc : null;
+	async function fetchEthUsd(): Promise<number> {
+		try {
+			const r = await fetch(
+				'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd'
+			);
+			const d = await r.json();
+			return d?.ethereum?.usd ?? 0;
+		} catch {
+			return 0;
+		}
+	}
+	async function sumWalletUsd(bals: WalletBalance[]): Promise<number> {
+		let total = 0;
+		let ethUsd: number | null = null;
+		for (const b of bals) {
+			const coin = coinForSymbol(b.symbol);
+			if (coin) {
+				try {
+					const usd = await new CoinAmount(b.amount, coin).convertTo(Coin.usd, Network.lightning);
+					total += usd.toNumber();
+				} catch {
+					// ignore a single failed conversion
+				}
+			} else if (b.symbol === 'ETH') {
+				if (ethUsd === null) ethUsd = await fetchEthUsd();
+				total += b.amount * ethUsd;
+			}
+		}
+		return total;
+	}
+
+	// Fixed decimals per asset so amounts line up (Hive/HBD 3dp, BTC 8dp, EVM 6dp).
+	const decimalsFor = (symbol: string) => (symbol === 'BTC' ? 8 : symbol === 'ETH' ? 6 : 3);
+	const fmtAmount = (n: number, symbol: string) =>
+		n.toLocaleString(undefined, {
+			minimumFractionDigits: decimalsFor(symbol),
+			maximumFractionDigits: decimalsFor(symbol)
+		});
+	// Match AccBalance's subtitle line under each coin name.
+	const subtitleFor = (symbol: string, sub?: string) => {
+		const base =
+			symbol === 'HIVE'
+				? 'Native Hive Token'
+				: symbol === 'HBD'
+					? 'Hive Backed Dollar'
+					: symbol === 'BTC'
+						? 'Bitcoin'
+						: symbol === 'ETH'
+							? 'Ethereum'
+							: symbol;
+		return sub ? `${base} · ${sub}` : base;
+	};
 
 	function openDeposit() {
 		// eslint-disable-next-line svelte/no-navigation-without-resolve -- static route; resolve() not exported in this kit version
@@ -46,7 +142,30 @@
 
 <Card>
 	<div class="balance-inner">
-		<span class="balance-label">Magi Balance</span>
+		<div class="bal-toggle" role="tablist">
+			<button
+				type="button"
+				class="bal-toggle-item"
+				class:active={activeTab === 'magi'}
+				role="tab"
+				aria-selected={activeTab === 'magi'}
+				onclick={() => selectTab('magi')}
+			>
+				Magi Balance
+			</button>
+			<span class="bal-toggle-divider" aria-hidden="true"></span>
+			<button
+				type="button"
+				class="bal-toggle-item"
+				class:active={activeTab === 'wallet'}
+				role="tab"
+				aria-selected={activeTab === 'wallet'}
+				onclick={() => selectTab('wallet')}
+			>
+				Wallet
+			</button>
+		</div>
+
 		<div class="balance-row">
 			<div class="balance-amount">
 				<span class="dollars">${dollars.toLocaleString()}</span><span class="cents">.{cents}</span>
@@ -69,12 +188,36 @@
 			<button class="action-btn action-btn-outline" onclick={openWithdraw}> Withdraw </button>
 		</div>
 
-		{#if did}
-			<span class="balances-title">Balances</span>
-			<div class="balances-section">
-				<AccBalance {did} />
-			</div>
-		{/if}
+		<div class="balances-section">
+			{#if activeTab === 'magi'}
+				{#if did}
+					<AccBalance {did} />
+				{/if}
+			{:else if walletLoading}
+				<p class="wallet-msg">Loading…</p>
+			{:else if walletError}
+				<p class="wallet-msg">Couldn't load wallet balances.</p>
+			{:else if walletBalances.length === 0}
+				<p class="wallet-msg">No balances in your connected wallet.</p>
+			{:else}
+				<div class="balances-list">
+					{#each walletBalances as b (b.symbol + '/' + (b.sub ?? ''))}
+						<div class="wallet-row">
+							<div class="wrow-icon">
+								{#if b.icon}<img src={b.icon} alt="" loading="lazy" />{/if}
+							</div>
+							<div class="wrow-info">
+								<div class="wname-row">
+									<span class="wcoin-name">{b.symbol}</span>
+									<span class="wrow-amount">{fmtAmount(b.amount, b.symbol)} {b.symbol}</span>
+								</div>
+								<span class="wcoin-sub">{subtitleFor(b.symbol, b.sub)}</span>
+							</div>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</div>
 	</div>
 </Card>
 
@@ -92,14 +235,6 @@
 		min-height: 0;
 		box-sizing: border-box;
 		overflow: hidden;
-	}
-
-	.balance-label {
-		display: block;
-		font-size: 0.85rem;
-		font-weight: 600;
-		color: var(--dash-text-primary);
-		margin-bottom: 0.5rem;
 	}
 
 	.balance-row {
@@ -186,12 +321,102 @@
 		box-shadow: 0 0 16px -4px rgba(111, 106, 248, 0.2);
 	}
 
-	.balances-title {
-		display: block;
+	.bal-toggle {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		margin-bottom: 0.75rem;
+		flex-shrink: 0;
+	}
+	.bal-toggle-item {
+		padding: 0;
+		background: none;
+		border: none;
+		font-family: inherit;
+		font-size: 0.85rem;
+		font-weight: 600;
+		color: var(--dash-text-muted);
+		cursor: pointer;
+		transition: color 0.15s;
+	}
+	.bal-toggle-item:hover {
+		color: var(--dash-text-secondary);
+	}
+	.bal-toggle-item.active {
+		color: var(--dash-text-primary);
+	}
+	.bal-toggle-divider {
+		width: 1px;
+		height: 14px;
+		background: var(--dash-card-border);
+		flex-shrink: 0;
+	}
+
+	.wallet-msg {
+		margin: 0.25rem 0 0;
+		font-size: 0.85rem;
+		color: var(--dash-text-muted);
+		font-style: italic;
+	}
+	/* Wallet rows mirror AccBalance's format for a consistent look. */
+	.balances-list {
+		display: flex;
+		flex-direction: column;
+	}
+	.wallet-row {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		padding: 0.625rem 0;
+		border-bottom: 1px solid var(--dash-divider);
+	}
+	.wallet-row:last-child {
+		border-bottom: none;
+	}
+	.wrow-icon {
+		width: 36px;
+		height: 36px;
+		border-radius: 50%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+	}
+	.wrow-icon img {
+		width: 36px;
+		height: 36px;
+		border-radius: 50%;
+	}
+	.wrow-info {
+		display: flex;
+		flex-direction: column;
+		gap: 0.125rem;
+		flex: 1;
+		min-width: 0;
+	}
+	.wname-row {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		flex-wrap: wrap;
+		gap: 0.125rem 0.5rem;
+		min-width: 0;
+	}
+	.wcoin-name {
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: var(--dash-text-primary);
+	}
+	.wcoin-sub {
+		font-size: 0.75rem;
+		color: var(--dash-text-muted);
+		font-weight: 400;
+	}
+	.wrow-amount {
 		font-size: 0.85rem;
 		font-weight: 600;
 		color: var(--dash-text-primary);
-		margin-bottom: 0.625rem;
+		white-space: nowrap;
 		flex-shrink: 0;
 	}
 

--- a/src/lib/cards/ConnectedWallet/connectedWalletBalances.ts
+++ b/src/lib/cards/ConnectedWallet/connectedWalletBalances.ts
@@ -1,0 +1,108 @@
+import { getHiveAccounts } from '$lib/auth/hive/getHiveAccounts';
+import { isBtcTestnetAddress } from '$lib/stores/currentBalance';
+import type { Account } from '$lib/auth/hive/accountTypes';
+import type { Auth } from '$lib/auth/store';
+
+export type WalletBalance = {
+	symbol: string;
+	amount: number;
+	icon?: string;
+	/** Optional qualifier shown next to the symbol, e.g. "savings". */
+	sub?: string;
+};
+
+/** "1.234 HIVE" → 1.234 */
+function parseHiveAmount(s: string | undefined): number {
+	if (!s) return 0;
+	const n = Number.parseFloat(String(s).split(' ')[0]);
+	return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Hive L1 balances for a Keychain/Hive account — liquid HIVE + HBD and their
+ * savings balances. Deliberately NOT hive-engine tokens (those are a separate
+ * layer the user didn't ask for).
+ */
+export async function fetchHiveL1Balances(username: string): Promise<WalletBalance[]> {
+	const res = (await getHiveAccounts([username])) as { result?: Account[] } | undefined;
+	const acc = res?.result?.[0];
+	if (!acc) return [];
+	const hive = parseHiveAmount(acc.balance);
+	const hbd = parseHiveAmount(acc.hbd_balance);
+	const hiveSavings = parseHiveAmount(acc.savings_balance);
+	const hbdSavings = parseHiveAmount(acc.savings_hbd_balance);
+	const out: WalletBalance[] = [
+		{ symbol: 'HIVE', amount: hive, icon: '/hive/hive.svg' },
+		{ symbol: 'HBD', amount: hbd, icon: '/hive/hbd.svg' }
+	];
+	if (hiveSavings > 0)
+		out.push({ symbol: 'HIVE', amount: hiveSavings, icon: '/hive/hive.svg', sub: 'savings' });
+	if (hbdSavings > 0)
+		out.push({ symbol: 'HBD', amount: hbdSavings, icon: '/hive/hbd.svg', sub: 'savings' });
+	return out;
+}
+
+/**
+ * Native EVM balance of the connected address via the reown/wagmi config,
+ * pinned to `chainId` (the DID's chain — Ethereum L1 mainnet for Altera) so the
+ * figure always matches the eip155 identity, not whatever chain the wallet is
+ * currently switched to. Funds on L2s (Arbitrum, etc.) are out of scope.
+ */
+export async function fetchEvmBalances(address: string, chainId = 1): Promise<WalletBalance[]> {
+	// initModal() ensures wagmiConfig exists (it's created lazily; a reload may
+	// not have re-created it yet). Safe to call repeatedly.
+	const { initModal, wagmiConfig } = await import('$lib/auth/reown');
+	initModal();
+	if (!wagmiConfig) return [];
+	try {
+		const { getBalance } = await import('@wagmi/core');
+		const bal = (await getBalance(wagmiConfig, {
+			address: address as `0x${string}`,
+			chainId
+		})) as {
+			value: bigint;
+			decimals: number;
+			symbol?: string;
+		};
+		const amount = Number(bal.value) / 10 ** bal.decimals;
+		const symbol = bal.symbol || 'ETH';
+		return [{ symbol, amount, icon: symbol === 'ETH' ? '/eth/eth.svg' : undefined }];
+	} catch {
+		return [];
+	}
+}
+
+/** BTC balance of the connected address via mempool.space's public API. */
+export async function fetchBtcBalance(address: string): Promise<WalletBalance[]> {
+	const base = isBtcTestnetAddress(address)
+		? 'https://mempool.space/testnet/api'
+		: 'https://mempool.space/api';
+	try {
+		const res = await fetch(`${base}/address/${address}`);
+		if (!res.ok) return [];
+		const d = await res.json();
+		const sats =
+			(d.chain_stats.funded_txo_sum ?? 0) -
+			(d.chain_stats.spent_txo_sum ?? 0) +
+			((d.mempool_stats?.funded_txo_sum ?? 0) - (d.mempool_stats?.spent_txo_sum ?? 0));
+		return [{ symbol: 'BTC', amount: sats / 1e8, icon: '/btc/btc.svg' }];
+	} catch {
+		return [];
+	}
+}
+
+/** Dispatch to the right chain based on the auth provider / DID. */
+export async function fetchConnectedWalletBalances(auth: Auth): Promise<WalletBalance[]> {
+	const v = auth.value;
+	if (!v) return [];
+	if (v.provider === 'aioha' && v.username) return fetchHiveL1Balances(v.username);
+	if (v.provider === 'reown') {
+		if (v.did?.startsWith('did:pkh:bip122:')) return fetchBtcBalance(v.address);
+		if (v.did?.startsWith('did:pkh:eip155:')) {
+			// did:pkh:eip155:<chainId>:<address> — read the balance on that chain.
+			const chainId = Number(v.did.split(':')[3]) || 1;
+			return fetchEvmBalances(v.address, chainId);
+		}
+	}
+	return [];
+}


### PR DESCRIPTION
## What

Adds a **Magi Balance | Wallet** toggle to the dashboard Balance card so users
can peek at their connected wallet's on-chain balances in place — no extra card.

## Behaviour

- **Magi tab** — existing Magi token balances, unchanged.
- **Wallet tab** — the connected wallet's native on-chain balances, by chain:
  - **Hive (Keychain):** L1 HIVE/HBD + savings
  - **EVM (MetaMask):** native ETH on the `eip155:1` mainnet chain, CoinGecko-priced
  - **BTC:** on-chain balance via mempool.space
- The headline **$ amount recomputes** to the wallet's USD total on the Wallet tab.
- Wallet rows reuse `AccBalance`'s row format for a consistent look.
- Amount + Deposit/Withdraw/Send stay visible in both tabs; only the token list swaps.

## Scope notes

- EVM balance is **pinned to the DID's chain (mainnet L1)** — L2 funds (Arbitrum,
  etc.) are out of scope, matching Altera's L1 settlement model. Native coin only
  (no ERC-20s).

## Testing

- `pnpm test` — 358 pass / 2 skipped (one unrelated flaky render-timeout passes on re-run)
- `pnpm check` — no new type errors (baseline unchanged)
- `pnpm lint` — clean
- Manually verified Hive Keychain (HIVE/HBD + recomputed total); EVM shows mainnet
  ETH (correctly $0 when funds are on L2); BTC path code-complete.