### PR TITLE
 chore(release): 0.3.35 — dashboard wallet balances + Balance trend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to Altera are documented here.
 > CI / build-banner / release-script use, and so a glance at `package.json`
 > matches reality.
 
+## [0.3.35] — 2026-07-06
+
+### Added
+
+- **Dashboard Balance card — Magi / Wallet toggle.** The Balance card now carries a "Magi Balance | Wallet" toggle so you can see your connected wallet's on-chain balances in place, without adding another card to the dashboard. The **Magi** tab shows your Magi token balances as before; the **Wallet** tab shows the connected wallet's native on-chain balances, dispatched by auth provider / DID: Hive (Keychain) → L1 HIVE/HBD + savings, EVM (MetaMask) → native ETH on the `eip155:1` mainnet chain (CoinGecko-priced), BTC → on-chain balance via mempool.space. The headline `$` amount **recomputes to the wallet's USD total** on the Wallet tab (HIVE/HBD/BTC via `CoinAmount`, ETH via CoinGecko), and wallet rows reuse the Magi list's row format for a consistent look. Deposit / Withdraw / Send stay visible in both tabs — only the token list swaps. The EVM balance is **pinned to the DID's chain (mainnet L1)** so it always matches the `eip155:1` identity regardless of the wallet's current network; funds on L2s (Arbitrum, etc.) are intentionally out of scope, and only the native coin is shown.
+
+### Changed
+
+- **Dashboard "Portfolio value" card is now "Balance trend", and its chart is interactive.** The card never actually showed a value — its header rendered the _net change_ over the selected range (a `Diff`), and the balance itself is already the Magi Balance card's headline, so a second value was redundant. Renamed to **"Balance trend"** to match what it shows. The trend now always shows **2 decimals** (it was compact-formatted, so small day-to-day changes collapsed to "$0"). And **hovering the chart now shows the balance value at that point plus its date** — the hover state (`hoveredPoint` / `hoveredIndex`) was declared but never bound to `LineChart`, so moving over the chart did nothing before; it's now wired via `bind:`.
+
 ## [0.3.34] — 2026-07-02
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.3.34",
+	"version": "0.3.35",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {

--- a/src/lib/cards/Balance/Diff.svelte
+++ b/src/lib/cards/Balance/Diff.svelte
@@ -11,6 +11,7 @@
 			style: 'currency',
 			currency: 'USD',
 			notation: props.compact ? 'compact' : undefined,
+			minimumFractionDigits: 2,
 			maximumFractionDigits: 2
 		})
 	);

--- a/src/lib/cards/Balance/PortfolioValue.svelte
+++ b/src/lib/cards/Balance/PortfolioValue.svelte
@@ -111,8 +111,12 @@
 		if (!did || !selectedDateRange) return;
 		loadingBalances = true;
 		fetchAndStoreAccountBalances(did, selectedDateRange.start, selectedDateRange.end, interval)
-			.then(() => { loadingBalances = false; })
-			.catch(() => { loadingBalances = false; });
+			.then(() => {
+				loadingBalances = false;
+			})
+			.catch(() => {
+				loadingBalances = false;
+			});
 	});
 </script>
 
@@ -120,10 +124,20 @@
 	<div class={['root', { hovered: hoveredIndex }]}>
 		<div class="header-row">
 			<div class="title-area">
-				<h5>Portfolio value</h5>
-				{#if !loadingBalances}
+				<h5>Balance trend</h5>
+				{#if hoveredPoint}
+					<span class="hover-value"
+						>${balance.toLocaleString(undefined, {
+							minimumFractionDigits: 2,
+							maximumFractionDigits: 2
+						})}</span
+					>
+					{#if date}
+						<span class="hover-date">{moment(date).format('MMM D · HH:mm')}</span>
+					{/if}
+				{:else if !loadingBalances}
 					<div class="change-pill">
-						<Diff up={priceDiff[0]} down={priceDiff[1]} compact={true} />
+						<Diff up={priceDiff[0]} down={priceDiff[1]} compact={false} />
 					</div>
 				{/if}
 			</div>
@@ -143,6 +157,8 @@
 				height={280}
 				isLoading={loadingBalances}
 				showYAxis={false}
+				bind:hoveredPoint
+				bind:hoveredIndex
 			/>
 		</div>
 	</div>
@@ -179,6 +195,15 @@
 	}
 	.change-pill :global(.diff) {
 		font-size: 0.75rem;
+	}
+	.hover-value {
+		font-size: 1rem;
+		font-weight: 600;
+		color: var(--dash-text-primary);
+	}
+	.hover-date {
+		font-size: 0.7rem;
+		color: var(--dash-text-muted);
 	}
 	.lc-wrapper {
 		margin: 0 -1.25rem -1.25rem;


### PR DESCRIPTION
## 0.3.35

Two dashboard changes, plus the version/changelog the wallet-balances merge missed.

### Balance trend card (this PR's code)
- Renames "Portfolio value" → **"Balance trend"** (it showed the change, not a value).
- Trend always shows **2 decimals** (small changes no longer collapse to `$0`).
- **Hover the chart** to see the balance value + date at each point (`hoveredPoint`/`hoveredIndex` are now bound to `LineChart`).

### Changelog / version
- Adds the **0.3.35** entry and bumps `package.json` `0.3.34 → 0.3.35`.
- The 0.3.35 entry also documents the **Magi/Wallet balance toggle** shipped earlier in `cc4466a`, which never got a version/changelog entry.