### PR TITLE
feat(auth): Hive account switcher behind "Switch user" (0.3.37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to Altera are documented here.
 > CI / build-banner / release-script use, and so a glance at `package.json`
 > matches reality.
 
+## [0.3.37] — 2026-07-14
+
+### Added
+
+- **Hive account switcher.** For Hive (aioha) sessions the sidebar's "Log out" button and the account-menu item become **"Switch user"** and open a switcher panel instead of ending the session: it lists the active account plus every other connected Hive login, switches with one click, connects additional accounts (the full Hive login form — Keychain, HiveAuth, Ledger, PeakVault, MetaMask Snap — embedded), forgets remembered accounts, and keeps a real **Log out** at the bottom. Multi-account persistence is Aioha's own (`getOtherLogins` / `switchUser` / `removeOtherLogin`) — no custom storage. Crucially, switching now **clears account-scoped data** (notifications, pending transactions, balances) exactly like logout does — those live under global localStorage keys, so without this the next account would inherit the previous account's data (the cross-account leak fixed in 0.3.28 would have come back via switching). EVM/BTC wallets keep plain "Log out" (a wallet disconnect). Requested by jux.
+
 ## [0.3.36] — 2026-07-13
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "altera",
 	"private": true,
-	"version": "0.3.36",
+	"version": "0.3.37",
 	"type": "module",
 	"types": "./src/has/hive-auth-wrapper.d.ts",
 	"scripts": {

--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -5,6 +5,7 @@
 	import { fly } from 'svelte/transition';
 	import { paths } from './paths';
 	import { getAuth } from '$lib/auth/store';
+	import { switchUserPanelOpen } from '$lib/auth/switchUserStore';
 	import { browser } from '$app/environment';
 
 	const COLLAPSE_KEY = 'sidebar-collapsed';
@@ -23,9 +24,7 @@
 	let isHiveUser = $derived(auth.value?.username != null);
 	let visiblePaths = $derived(paths.filter((p) => !p.requiresHive || isHiveUser));
 
-	let collapsed = $state(
-		browser ? localStorage.getItem(COLLAPSE_KEY) === 'true' : false
-	);
+	let collapsed = $state(browser ? localStorage.getItem(COLLAPSE_KEY) === 'true' : false);
 
 	function toggleCollapse() {
 		collapsed = !collapsed;
@@ -38,7 +37,18 @@
 		}, 1000);
 	});
 
+	// For Hive (aioha) logins the button becomes "Switch user" and opens the
+	// account-switcher panel (add/switch/remove Hive accounts, with full
+	// logout inside it). EVM wallets keep "Log out" (a plain disconnect).
+	// Requested by jux.
+	const isHiveSession = $derived(auth.value?.provider === 'aioha');
+	const logoutLabel = $derived(isHiveSession ? 'Switch user' : 'Log out');
+
 	async function handleLogout() {
+		if (isHiveSession) {
+			switchUserPanelOpen.set(true);
+			return;
+		}
 		if (auth.value?.logout) {
 			await auth.value.logout();
 		}
@@ -106,7 +116,11 @@
 		</div>
 
 		<div class="sidebar-footer">
-			<button class="footer-btn collapse-btn desktop-only" onclick={toggleCollapse} title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}>
+			<button
+				class="footer-btn collapse-btn desktop-only"
+				onclick={toggleCollapse}
+				title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+			>
 				<span class="nav-icon">
 					{#if collapsed}
 						<PanelLeftOpenIcon size={20} />
@@ -118,10 +132,10 @@
 					<span class="nav-label">Collapse</span>
 				{/if}
 			</button>
-			<button class="footer-btn" onclick={handleLogout} title={collapsed ? 'Log out' : undefined}>
+			<button class="footer-btn" onclick={handleLogout} title={collapsed ? logoutLabel : undefined}>
 				<span class="nav-icon"><LogOut size={20} /></span>
 				{#if !collapsed}
-					<span class="nav-label">Log out</span>
+					<span class="nav-label">{logoutLabel}</span>
 				{/if}
 			</button>
 		</div>
@@ -144,7 +158,11 @@
 		left: 0;
 		display: flex;
 		flex-direction: column;
-		background: linear-gradient(180deg, rgba(255,255,255,0.06) 0%, rgba(255,255,255,0.03) 100%);
+		background: linear-gradient(
+			180deg,
+			rgba(255, 255, 255, 0.06) 0%,
+			rgba(255, 255, 255, 0.03) 100%
+		);
 		-webkit-backdrop-filter: blur(10px);
 		backdrop-filter: blur(10px);
 		will-change: transform;
@@ -154,7 +172,9 @@
 		box-sizing: border-box;
 		padding: calc(1.75rem + 1.5vh) 1rem 1.25rem 1rem;
 		z-index: 10;
-		transition: width 0.2s ease, padding 0.2s ease;
+		transition:
+			width 0.2s ease,
+			padding 0.2s ease;
 		font-weight: 500;
 	}
 	nav.collapsed {
@@ -231,7 +251,9 @@
 		text-decoration: none;
 		font-size: 0.9rem;
 		font-weight: 500;
-		transition: background-color 0.15s, color 0.15s;
+		transition:
+			background-color 0.15s,
+			color 0.15s;
 		white-space: nowrap;
 		overflow: hidden;
 	}
@@ -245,8 +267,8 @@
 	}
 	.nav-button.current,
 	.nav-button.current:hover {
-		background: linear-gradient(135deg, #7B74FF 0%, #6F6AF8 50%, #5B54E0 100%);
-		color: #FFFFFF;
+		background: linear-gradient(135deg, #7b74ff 0%, #6f6af8 50%, #5b54e0 100%);
+		color: #ffffff;
 		font-weight: 600;
 		border-radius: 1.25rem;
 		box-shadow: 0 2px 12px rgba(111, 106, 248, 0.3);
@@ -288,7 +310,9 @@
 		width: 100%;
 		text-align: left;
 		font-family: inherit;
-		transition: background-color 0.15s, color 0.15s;
+		transition:
+			background-color 0.15s,
+			color 0.15s;
 		white-space: nowrap;
 		overflow: hidden;
 	}

--- a/src/lib/Topbar/Topbar.svelte
+++ b/src/lib/Topbar/Topbar.svelte
@@ -6,6 +6,7 @@
 	import CommandPalette from './CommandPalette.svelte';
 	import { Component, MenuIcon, Search, Bell } from '@lucide/svelte';
 	import { getAuth } from '../auth/store';
+	import { switchUserPanelOpen } from '$lib/auth/switchUserStore';
 	import { accountBalance } from '$lib/stores/currentBalance';
 	import { onMount } from 'svelte';
 	let { onMenuToggle } = $props();
@@ -96,12 +97,28 @@
 					snippet: option,
 					snippetData: { label: 'App Preferences', icon: Component }
 				},
-				{ label: 'logout', snippet: option, snippetData: { label: 'Logout', icon: Component } }
+				{
+					label: 'logout',
+					snippet: option,
+					// For Hive (aioha) logins "logging out" is really account switching:
+					// Keychain re-login is just picking another username. EVM wallets
+					// keep "Logout" (disconnect). Requested by jux.
+					snippetData: {
+						label: auth.value?.provider === 'aioha' ? 'Switch User' : 'Logout',
+						icon: Component
+					}
+				}
 			]}
 			onSelect={async (e) => {
 				switch (e.value) {
 					case 'logout':
-						await logout();
+						// Hive sessions get the account-switcher panel (switch/add/
+						// remove accounts, with full logout inside); EVM disconnects.
+						if (auth.value?.provider === 'aioha') {
+							switchUserPanelOpen.set(true);
+						} else {
+							await logout();
+						}
 						break;
 					case 'acc-prefs':
 						openSettings();

--- a/src/lib/auth/SwitchUserPanel.svelte
+++ b/src/lib/auth/SwitchUserPanel.svelte
@@ -1,0 +1,240 @@
+<!--
+	Hive account switcher — the panel behind "Switch user".
+
+	Lists the active Hive account plus every other connected login that Aioha
+	keeps in its persistent multi-login storage (getOtherLogins), switches with
+	aioha.switchUser (the auth store follows via the existing account_changed
+	handler, which also clears account-scoped data), lets the user connect
+	another account (embedded HiveLogin) and remove remembered ones. Full
+	logout lives at the bottom. Requested by jux.
+-->
+<script lang="ts">
+	import Dialog from '$lib/zag/Dialog.svelte';
+	import Avatar from '$lib/zag/Avatar.svelte';
+	import PillButton from '$lib/PillButton.svelte';
+	import HiveLogin from './HiveLogin.svelte';
+	import { getAuth } from './store';
+	import { switchUserPanelOpen } from './switchUserStore';
+	import { Check, LogOut, X } from '@lucide/svelte';
+
+	const auth = $derived(getAuth()());
+	const username = $derived(auth.value?.username);
+	const aioha = $derived(auth.value?.aioha);
+
+	let open = $state(false);
+	let toggle = $state<(o?: boolean) => void>(() => {});
+
+	// Store → dialog (open requests from sidebar/topbar) and dialog → store
+	// (user dismissed with Esc/X/backdrop). The dialog→store direction must
+	// only react to a CLOSE TRANSITION (previous-value tracker, same pattern
+	// as ReviewSwap): a level check like `!open && $store` fires in the gap
+	// between the store going true and the dialog actually opening, and
+	// cancels the open before it happens.
+	$effect(() => {
+		const want = $switchUserPanelOpen;
+		if (want !== open) toggle(want);
+	});
+	let lastOpen = false;
+	$effect(() => {
+		if (open === lastOpen) return;
+		lastOpen = open;
+		if (!open) switchUserPanelOpen.set(false);
+	});
+
+	// Other connected accounts. Re-read when the panel opens or the active
+	// user changes (post-switch / post-add); `bump` covers removals.
+	let bump = $state(0);
+	const others = $derived.by(() => {
+		void bump;
+		void username;
+		if (!open || !aioha) return [];
+		return Object.entries(aioha.getOtherLogins()).map(([name, provider]) => ({
+			name,
+			provider: String(provider)
+		}));
+	});
+
+	let switchError = $state('');
+	function switchTo(name: string) {
+		switchError = '';
+		if (!aioha) return;
+		// account_changed updates the auth store and clears account-scoped data.
+		const ok = aioha.switchUser(name);
+		if (!ok) {
+			switchError = `Couldn't switch to @${name} — its session may have expired. Remove it and connect again.`;
+			return;
+		}
+		switchUserPanelOpen.set(false);
+	}
+
+	function remove(name: string) {
+		switchError = '';
+		aioha?.removeOtherLogin(name);
+		bump++;
+	}
+
+	async function logoutAll() {
+		switchUserPanelOpen.set(false);
+		await auth.value?.logout?.();
+	}
+</script>
+
+<Dialog bind:open bind:toggle>
+	{#snippet title()}Switch user{/snippet}
+	{#snippet content()}
+		<div class="switch-panel">
+			<ul class="accounts">
+				{#if username}
+					<li class="account current">
+						<Avatar did={`hive:${username}`} fallback="" size="small" />
+						<span class="name">@{username}</span>
+						<span class="current-badge"><Check size={12} /> Current</span>
+					</li>
+				{/if}
+				{#each others as other (other.name)}
+					<li class="account">
+						<button type="button" class="switch-btn" onclick={() => switchTo(other.name)}>
+							<Avatar did={`hive:${other.name}`} fallback="" size="small" />
+							<span class="name">@{other.name}</span>
+							<span class="provider">{other.provider}</span>
+						</button>
+						<button
+							type="button"
+							class="remove-btn"
+							title="Forget this account"
+							aria-label="Forget @{other.name}"
+							onclick={() => remove(other.name)}
+						>
+							<X size={14} />
+						</button>
+					</li>
+				{/each}
+			</ul>
+
+			{#if others.length === 0}
+				<p class="empty">No other accounts connected yet.</p>
+			{/if}
+
+			{#if switchError}
+				<p class="error">{switchError}</p>
+			{/if}
+
+			<!-- HiveLogin brings its own trigger + dialog; a successful login makes
+			     the new account active and Aioha keeps the previous one connected. -->
+			<div class="add-account">
+				<HiveLogin />
+			</div>
+
+			<div class="panel-footer">
+				<PillButton onclick={logoutAll} styleType="outline" theme="secondary">
+					<LogOut size={14} />
+					Log out
+				</PillButton>
+			</div>
+		</div>
+	{/snippet}
+</Dialog>
+
+<style lang="scss">
+	.switch-panel {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		min-width: min(22rem, 85vw);
+	}
+	.accounts {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+	}
+	.account {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		border: 1px solid var(--dash-card-border);
+		border-radius: 12px;
+	}
+	.account.current {
+		padding: 0.6rem 0.75rem;
+		background: rgba(111, 106, 248, 0.1);
+		border-color: rgba(111, 106, 248, 0.5);
+	}
+	.switch-btn {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.6rem 0.75rem;
+		background: none;
+		border: none;
+		font: inherit;
+		color: var(--dash-text-primary);
+		cursor: pointer;
+		text-align: left;
+		border-radius: 12px;
+		min-width: 0;
+	}
+	.switch-btn:hover {
+		background: rgba(255, 255, 255, 0.05);
+	}
+	.name {
+		font-weight: 600;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	.provider {
+		margin-left: auto;
+		font-size: 0.7rem;
+		color: var(--dash-text-muted);
+		text-transform: capitalize;
+	}
+	.current-badge {
+		margin-left: auto;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		font-size: 0.72rem;
+		font-weight: 600;
+		color: var(--dash-accent-green);
+	}
+	.remove-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.75rem;
+		height: 1.75rem;
+		margin-right: 0.5rem;
+		border: none;
+		background: none;
+		color: var(--dash-text-muted);
+		cursor: pointer;
+		border-radius: 50%;
+		flex-shrink: 0;
+	}
+	.remove-btn:hover {
+		color: var(--dash-text-primary);
+		background: rgba(255, 255, 255, 0.08);
+	}
+	.empty {
+		margin: 0;
+		font-size: 0.85rem;
+		color: var(--dash-text-muted);
+	}
+	.error {
+		margin: 0;
+		font-size: 0.85rem;
+		color: var(--dash-accent-red, #dc2626);
+	}
+	.add-account :global([data-part='trigger']) {
+		width: 100%;
+	}
+	.panel-footer {
+		display: flex;
+		justify-content: flex-end;
+		padding-top: 0.75rem;
+		border-top: 1px solid var(--dash-card-border);
+	}
+</style>

--- a/src/lib/auth/hive/index.ts
+++ b/src/lib/auth/hive/index.ts
@@ -1,7 +1,7 @@
 import { Aioha, KeyTypes, Providers } from '@aioha/aioha';
 import { DOMAIN } from '../url';
 import { browser } from '$app/environment';
-import { _hiveAuthStore, cleanUpLogout, loginRetry } from '../store';
+import { _hiveAuthStore, cleanUpAccountData, cleanUpLogout, loginRetry } from '../store';
 import { goto } from '$app/navigation';
 import { getAccounts } from '@aioha/aioha/build/rpc';
 import { postingMetadataFromString, type Account } from './accountTypes';
@@ -11,10 +11,8 @@ import { resolveNodeUrl } from '$lib/nodeSelection/select';
 // Hive L1 chain IDs. Mainnet has the well-known default; testnet uses a
 // different chain ID and MetaMask Snap refuses to sign anything unless the
 // right one is set via `aioha.setChainId()`.
-const HIVE_MAINNET_CHAIN_ID =
-	'beeab0de00000000000000000000000000000000000000000000000000000000';
-const HIVE_TESTNET_CHAIN_ID =
-	'18dcf0a285365fc58b71f18b3d3fec954aa0c141c44e4e5cb4cf777b9eab274e';
+const HIVE_MAINNET_CHAIN_ID = 'beeab0de00000000000000000000000000000000000000000000000000000000';
+const HIVE_TESTNET_CHAIN_ID = '18dcf0a285365fc58b71f18b3d3fec954aa0c141c44e4e5cb4cf777b9eab274e';
 
 // Hive L1 RPC endpoints. Testnet must NOT fall through to api.hive.blog or
 // broadcasts get rejected ("missing active authority") because the mainnet
@@ -68,9 +66,7 @@ if (browser) {
 		});
 		// Tell Aioha which VSC network we're on so ops go to the right net.
 		try {
-			(aioha as unknown as { vscSetNetId?: (id: string) => void }).vscSetNetId?.(
-				vscNetworkId
-			);
+			(aioha as unknown as { vscSetNetId?: (id: string) => void }).vscSetNetId?.(vscNetworkId);
 		} catch (err) {
 			console.warn('aioha.vscSetNetId failed', err);
 		}
@@ -99,8 +95,16 @@ if (browser) {
 		} else {
 			_hiveAuthStore.set({ status: 'none' });
 		}
+		let lastUser = aioha.isLoggedIn() ? aioha.getCurrentUser() : undefined;
 		aioha.on('account_changed', () => {
 			const user = aioha.getCurrentUser();
+			// Switching to a DIFFERENT account (switchUser / adding a login) must
+			// clear account-scoped data (notifications, pending txs, balances) —
+			// they live under global keys and would otherwise leak across accounts.
+			if (user && lastUser && user !== lastUser) {
+				cleanUpAccountData();
+			}
+			lastUser = user;
 			let authStore;
 			if (user != undefined) {
 				authStore = {

--- a/src/lib/auth/store.ts
+++ b/src/lib/auth/store.ts
@@ -22,7 +22,14 @@ export type Auth = {
 	};
 };
 
-export function cleanUpLogout() {
+/**
+ * Clear everything scoped to the signed-in ACCOUNT (notifications, pending
+ * txs, balances). Called on logout AND on account switching — notifications
+ * and pending transactions live under global localStorage keys, so without
+ * this the next account inherits the previous account's data (the
+ * cross-account leak fixed in 0.3.x would come back via switching).
+ */
+export function cleanUpAccountData() {
 	clearAllStores();
 	clearNotifications();
 	clearLocalTransactions();
@@ -32,6 +39,10 @@ export function cleanUpLogout() {
 		connectedBal: undefined
 	});
 	accountBalanceHistory.set([]);
+}
+
+export function cleanUpLogout() {
+	cleanUpAccountData();
 	goto('/login');
 }
 

--- a/src/lib/auth/switchUserStore.ts
+++ b/src/lib/auth/switchUserStore.ts
@@ -1,0 +1,9 @@
+import { writable } from 'svelte/store';
+
+/**
+ * Open-state for the Hive account-switcher panel (SwitchUserPanel, mounted
+ * once in the (authed) layout). Both the sidebar's "Switch user" button and
+ * the topbar account menu set this — a shared store instead of prop-drilling
+ * through two unrelated component trees.
+ */
+export const switchUserPanelOpen = writable(false);

--- a/src/routes/(authed)/+layout.svelte
+++ b/src/routes/(authed)/+layout.svelte
@@ -13,6 +13,7 @@
 	import { page } from '$app/state';
 	import { getAccountNameFromAuth } from '$lib/getAccountName';
 	import UpdateToast from '$lib/components/UpdateToast.svelte';
+	import SwitchUserPanel from '$lib/auth/SwitchUserPanel.svelte';
 
 	let { children } = $props();
 	let showSidebar = $state(false);
@@ -42,11 +43,7 @@
 			goto('/login');
 			return;
 		}
-		if (
-			!browser ||
-			auth.value ||
-			localStorage.getItem('last_connection') !== 'reown'
-		) {
+		if (!browser || auth.value || localStorage.getItem('last_connection') !== 'reown') {
 			return;
 		}
 		(async () => {
@@ -85,6 +82,7 @@
 </div>
 
 <UpdateToast />
+<SwitchUserPanel />
 
 <style lang="scss">
 	.app-shell {


### PR DESCRIPTION
## What
For Hive (aioha) sessions, "Log out" (sidebar) and "Logout" (account menu)
become **"Switch user"** and open an account-switcher panel: the active
account plus every other connected Hive login, one-click switching, an
embedded Hive login (Keychain / HiveAuth / Ledger / PeakVault / MetaMask
Snap) to connect more accounts, per-account forget, and a real **Log out**
at the bottom. EVM/BTC wallets keep plain "Log out". Requested by jux.

## How
- Multi-account persistence is **Aioha's own** (`getOtherLogins` /
  `switchUser` / `removeOtherLogin`) — no custom storage.
- Switching rides the existing `account_changed` handler, which updates the
  auth store — and now also **clears account-scoped data** (notifications,
  pending txs, balances) via `cleanUpAccountData()`, shared with logout.
  Without this, the next account inherits the previous account's data — the
  cross-account leak fixed in 0.3.28 would have returned via switching.

## Testing
- Keychain: panel opens from both triggers; added a second account; switched
  back and forth (notifications cleared, balances reloaded); forget works;
  Log out works.
- MetaMask: unchanged ("Logout" disconnects).
- Lint/type-check: no new issues (only pre-existing `goto` false-positives
  in touched files).