### PR TITLE
feat(market): add NFT Market page with the Magi market widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
 		"@types/qrcode": "^1.5.6",
 		"@vercel/analytics": "^1.6.1",
 		"@vsc.eco/client": "^0.0.7",
+		"@vsc.eco/market-widget": "^0.0.2",
 		"@vsc.eco/token-widget": "^0.0.2",
 		"@wagmi/core": "^3.3.1",
 		"@zag-js/avatar": "^1.33.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@vsc.eco/client':
         specifier: ^0.0.7
         version: 0.0.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@vsc.eco/market-widget':
+        specifier: ^0.0.2
+        version: 0.0.2(@aioha/aioha@1.8.2(webextension-polyfill@0.10.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@vsc.eco/token-widget':
         specifier: ^0.0.2
         version: 0.0.2(@aioha/aioha@1.8.2(webextension-polyfill@0.10.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1299,7 +1302,7 @@ packages:
 
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
-    deprecated: 'The package is now available as "qr": npm install qr'
+    deprecated: 'Switch to "qr" (new package name) for security updates: npm install qr'
 
   '@phosphor-icons/webcomponents@2.1.5':
     resolution: {integrity: sha512-JcvQkZxvcX2jK+QCclm8+e8HXqtdFW9xV4/kk2aL9Y3dJA2oQVt+pzbv1orkumz3rfx4K9mn9fDoMr1He1yr7Q==}
@@ -2567,6 +2570,22 @@ packages:
 
   '@vsc.eco/client@0.0.7':
     resolution: {integrity: sha512-ZubSSl8TMljkdUyHApJGfB7xVrXfqsTh1pHsYImvHcmznh1DV/gswe8EnhaVG6eDkAOJEIFsSfaKele1aFt0/Q==}
+
+  '@vsc.eco/market-core@0.0.1':
+    resolution: {integrity: sha512-FJ83GXjYRmSdXA5KRd6DCrZu9v6EPzLf32r5gkPRvcD9/Ua0ig/gxDOvMa6EqrLFOonqkR5pk/Xhw3mrxleVdQ==}
+
+  '@vsc.eco/market-sdk@0.0.1':
+    resolution: {integrity: sha512-bhc9kpB98el1i2NReOF+MqgH+zKGEioFGl5JvK8OT1sKNEBEb8SaVAbFXDf36hLsIQfP6MU0TYFBLXhjG6geog==}
+
+  '@vsc.eco/market-widget@0.0.2':
+    resolution: {integrity: sha512-E/RE6Q1ypc0dMo+DgcrBzNJUGEUgFawROH2lKT/bQ+kmfCnLB8VNa0aotKyfXe7eVCDd3EOKhEFxevwsZ4XMZw==}
+    peerDependencies:
+      '@aioha/aioha': ^1.8.0
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+    peerDependenciesMeta:
+      '@aioha/aioha':
+        optional: true
 
   '@vsc.eco/token-core@0.0.2':
     resolution: {integrity: sha512-5JBi2aLyfrsNcK/8ff/Fi8E8cLP+oAfJIn4FBwIjderVqlFb53a3m9R5lDZaxBVmGrq1sTuaMrwgcfX3CEvBag==}
@@ -9437,6 +9456,24 @@ snapshots:
       - typescript
       - utf-8-validate
       - zod
+
+  '@vsc.eco/market-core@0.0.1': {}
+
+  '@vsc.eco/market-sdk@0.0.1':
+    dependencies:
+      '@vsc.eco/market-core': 0.0.1
+
+  '@vsc.eco/market-widget@0.0.2(@aioha/aioha@1.8.2(webextension-polyfill@0.10.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@r2wc/react-to-web-component': 2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@vsc.eco/market-core': 0.0.1
+      '@vsc.eco/market-sdk': 0.0.1
+      '@vsc.eco/token-core': 0.0.2
+      '@vsc.eco/token-sdk': 0.0.2
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@aioha/aioha': 1.8.2(webextension-polyfill@0.10.0)
 
   '@vsc.eco/token-core@0.0.2': {}
 

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,4 +1,4 @@
-import { ArrowRightLeft, Coins, Droplets, Eye, LayoutDashboard, ScrollText, Send } from '@lucide/svelte';
+import { ArrowRightLeft, Coins, Droplets, Eye, LayoutDashboard, ScrollText, Send, Store } from '@lucide/svelte';
 
 export type SidebarPath = {
 	name: string;
@@ -38,6 +38,12 @@ export const paths: SidebarPath[] = [
 		name: 'Magi Tokens / NFTs',
 		icon: Coins,
 		href: '/custom-tokens',
+		requiresHive: true
+	},
+	{
+		name: 'NFT Market',
+		icon: Store,
+		href: '/market',
 		requiresHive: true
 	}
 ];

--- a/src/routes/(authed)/market/+page.svelte
+++ b/src/routes/(authed)/market/+page.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { KeyTypes } from '@aioha/aioha';
+	import { getAuth } from '$lib/auth/store';
+	import { getMagiIndexerBaseUrl, vscNetworkId } from '../../../client';
+	import '@vsc.eco/market-widget/styles.css';
+
+	let auth = $derived(getAuth()());
+	let username = $derived(auth.value?.username);
+	let aioha = $derived(auth.value?.aioha);
+
+	// The deployed magi-market contract, per network. Mainnet is the contract
+	// milo deployed 2026-07-22; testnet is the long-standing instance. The
+	// SDK's own MAINNET_CONFIG still ships the testnet id as a placeholder, so
+	// we must set marketContractId explicitly — this is what "connects the page
+	// to the new contract".
+	const isTestnet = vscNetworkId === 'vsc-testnet';
+	const marketContractId = isTestnet
+		? 'vsc1BnMAaeUzhzVcfKMDG5vphthhymk6irjLNq'
+		: 'vsc1BdZFXb8HdLptKUamNG4nL74hSb6UUBEiQA';
+
+	// Read side (listings/auctions/mint-spots) is served by an indexer that
+	// projects the magi_market_* fold views. The okinoko indexer is the one we
+	// keep configured for this contract, so it is primary; the app's own
+	// configured Magi indexer is the failover. Ordering matters: failover fires
+	// only on error, NOT on an empty result — so the indexer that actually
+	// tracks this contract must come first, or a stale/generic indexer would
+	// return "no listings" without ever failing over.
+	const okinokoHasura = isTestnet
+		? 'https://api-testnet.okinoko.io/hasura/v1/graphql'
+		: 'https://api.okinoko.io/hasura/v1/graphql';
+	const indexerHasuraUrls = [okinokoHasura, `${getMagiIndexerBaseUrl()}/v1/graphql`];
+
+	// VSC node GraphQL — used by the SDK for getStateByKeys / findContractOutput
+	// (write verification). Known-good mainnet/testnet node endpoints.
+	const gqlUrls = isTestnet
+		? ['https://magi-test.techcoderx.com/api/v1/graphql']
+		: [
+				'https://api.vsc.eco/api/v1/graphql',
+				'https://vsc.techcoderx.com/api/v1/graphql',
+				'https://api.okinoko.io/api/v1/graphql'
+			];
+
+	const marketConfig = {
+		network: (isTestnet ? 'vsc-testnet' : 'vsc-mainnet') as 'vsc-testnet' | 'vsc-mainnet',
+		marketContractId,
+		indexerHasuraUrls,
+		gqlUrls
+	};
+
+	let host: HTMLDivElement | undefined = $state();
+	let ready = $state(false);
+	// React root + MagiMarketPanel are loaded dynamically so the SSR bundle
+	// stays react-free and the import only runs once we're in the browser.
+	type ReactRoot = { render: (node: unknown) => void; unmount: () => void };
+	let root: ReactRoot | undefined;
+	let createElement: ((type: unknown, props: Record<string, unknown>) => unknown) | undefined;
+	let MagiMarketPanel: unknown;
+
+	onMount(async () => {
+		const [react, reactDom, widget] = await Promise.all([
+			import('react'),
+			import('react-dom/client'),
+			import('@vsc.eco/market-widget')
+		]);
+		if (!host) return;
+		createElement = react.createElement as unknown as typeof createElement;
+		MagiMarketPanel = widget.MagiMarketPanel;
+		root = reactDom.createRoot(host) as unknown as ReactRoot;
+		ready = true;
+	});
+
+	onDestroy(() => {
+		root?.unmount();
+		root = undefined;
+	});
+
+	$effect(() => {
+		if (!ready || !root || !createElement || !MagiMarketPanel || !username) return;
+		root.render(
+			createElement(MagiMarketPanel, {
+				aioha,
+				keyType: KeyTypes.Active,
+				username,
+				config: marketConfig,
+				enableRefresh: true
+			})
+		);
+	});
+</script>
+
+<svelte:head>
+	<title>NFT Market</title>
+</svelte:head>
+
+<h1>NFT Market</h1>
+
+{#if !username}
+	<p class="error">
+		The NFT marketplace requires a Hive account. Please
+		<a href="/logout">logout</a> and sign in with Hive.
+	</p>
+{:else if !ready}
+	<p class="muted">Loading widget…</p>
+{/if}
+
+<div bind:this={host} class="widget-host"></div>
+
+<style>
+	:global(h1) {
+		color: var(--dash-text-primary);
+		font-family: 'Nunito Sans', sans-serif;
+	}
+	.error {
+		color: var(--dash-text-secondary, #b66);
+	}
+	.muted {
+		color: var(--dash-text-secondary);
+	}
+	.widget-host {
+		width: 100%;
+	}
+	/* Override the widget's internal max-width cap so it fills the main area. */
+	.widget-host :global(.magi-token),
+	.widget-host :global(.magi-market) {
+		max-width: none;
+		width: 100%;
+	}
+</style>


### PR DESCRIPTION
Adds a sidebar "NFT Market" page that embeds @vsc.eco/market-widget's MagiMarketPanel, connected to the magi-market contract milo deployed to mainnet (vsc1BdZFXb8HdLptKUamNG4nL74hSb6UUBEiQA).

- New route src/routes/(authed)/market/+page.svelte. Mirrors the existing custom-tokens token-widget integration: React + react-dom loaded dynamically on mount so the SSR bundle stays react-free, MagiMarketPanel rendered into a Svelte-owned host div, unmounted on destroy. Hive login required (write actions sign via aioha, KeyTypes.Active).
- Passes an explicit MagiConfig. The SDK's own MAINNET_CONFIG still ships the testnet contract id as a placeholder, so marketContractId is set here per network — this is what points the page at the new contract. SDK will follow independently.
- Read side: indexerHasuraUrls put the okinoko indexer (which tracks this contract's magi_market_* views) first, then the app's configured Magi indexer as failover. Ordering is deliberate — SDK failover fires on error, not on an empty result, so the indexer that actually tracks the contract must be primary or listings would silently read empty.
- Network-aware: mainnet vs testnet swap the contract id, indexer, and VSC node gql endpoints, following the app's vscNetworkId.
- Sidebar: "NFT Market" entry (Store icon, requiresHive) in paths.ts, next to "Magi Tokens / NFTs".

Verified: pnpm build green, market-widget chunk bundled into the route, svelte-check clean for the new files.